### PR TITLE
Fix ARM_GICD_IROUTER constant to match the ARM specification

### DIFF
--- a/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
+++ b/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
@@ -466,6 +466,9 @@ GicV3DxeInitialize (
     }
 
     // Route the SPIs to the primary CPU. SPIs start at the INTID 32
+    // MuChange - SPIs per the GICv3 spec start at line 32, but the previous code
+    // relied on ARM_GICD_IROUTER to be a value different than the spec that
+    // skipped those first 32 lines.
     for (Index = 32; Index < mGicNumInterrupts; Index++) {
       MmioWrite32 (
         mGicDistributorBase + ARM_GICD_IROUTER + (Index * 8),

--- a/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
+++ b/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
@@ -466,7 +466,7 @@ GicV3DxeInitialize (
     }
 
     // Route the SPIs to the primary CPU. SPIs start at the INTID 32
-    for (Index = 0; Index < (mGicNumInterrupts - 32); Index++) {
+    for (Index = 32; Index < mGicNumInterrupts; Index++) {
       MmioWrite32 (
         mGicDistributorBase + ARM_GICD_IROUTER + (Index * 8),
         (UINT32)(CpuTarget | ARM_GICD_IROUTER_IRM)     // MS_CHANGE

--- a/ArmPkg/Include/Library/ArmGicLib.h
+++ b/ArmPkg/Include/Library/ArmGicLib.h
@@ -43,7 +43,11 @@
 #define ARM_GIC_ICDSGIR         0xF00 // Software Generated Interrupt Register
 
 // GICv3 specific registers
-#define ARM_GICD_IROUTER        0x6100 // Interrupt Routing Registers
+// MuChange - This was 0x6100 before, which skips past the reserved lines but
+// requires subtracting 32 from every single usage programming this register as
+// the GICv3 spec defines it as 0x6000. Change it back to the specification
+// value.
+#define ARM_GICD_IROUTER        0x6000 // Interrupt Routing Registers
 
 // GICD_CTLR bits
 #define ARM_GIC_ICDDCR_ARE      (1 << 4) // Affinity Routing Enable (ARE)


### PR DESCRIPTION
SPIs start at 32, but the constant ARM_GICD_ROUTER skips this by defining the start as 0x6100 vs what the specification says, 0x6000. This is unintuitive and could lead to bugs due to needing to subtract by 32 whenever programming SPI IROUTERs. 