### PR TITLE
matched parameters for LcdInitialize

### DIFF
--- a/ArmPlatformPkg/Include/Library/LcdHwLib.h
+++ b/ArmPlatformPkg/Include/Library/LcdHwLib.h
@@ -41,7 +41,7 @@ LcdIdentify (
 **/
 EFI_STATUS
 LcdInitialize (
-  EFI_PHYSICAL_ADDRESS  FrameBaseAddress
+  IN CONST EFI_PHYSICAL_ADDRESS  FrameBaseAddress
   );
 
 /**

--- a/ArmPlatformPkg/Library/ArmMaliDp/ArmMaliDp.c
+++ b/ArmPlatformPkg/Library/ArmMaliDp/ArmMaliDp.c
@@ -345,7 +345,7 @@ SetConfigValid (VOID)
 **/
 EFI_STATUS
 LcdSetMode (
-  IN CONST UINT32  ModeNumber
+  IN UINT32  ModeNumber
   )
 {
   EFI_STATUS    Status;

--- a/ArmPlatformPkg/Library/HdLcd/HdLcd.c
+++ b/ArmPlatformPkg/Library/HdLcd/HdLcd.c
@@ -32,7 +32,7 @@
 **/
 EFI_STATUS
 LcdInitialize (
-  IN EFI_PHYSICAL_ADDRESS   VramBaseAddress
+  IN CONST EFI_PHYSICAL_ADDRESS   VramBaseAddress
   )
 {
   // Disable the controller

--- a/ArmPlatformPkg/Library/LcdHwNullLib/LcdHwNullLib.c
+++ b/ArmPlatformPkg/Library/LcdHwNullLib/LcdHwNullLib.c
@@ -42,7 +42,7 @@ LcdIdentify (
 **/
 EFI_STATUS
 LcdInitialize (
-  EFI_PHYSICAL_ADDRESS  FrameBaseAddress
+  IN CONST EFI_PHYSICAL_ADDRESS  FrameBaseAddress
   )
 {
   return EFI_SUCCESS;

--- a/ArmPlatformPkg/Library/PL111Lcd/PL111Lcd.c
+++ b/ArmPlatformPkg/Library/PL111Lcd/PL111Lcd.c
@@ -57,7 +57,7 @@ LcdIdentify (
 **/
 EFI_STATUS
 LcdInitialize (
-  IN EFI_PHYSICAL_ADDRESS   VramBaseAddress
+  IN CONST EFI_PHYSICAL_ADDRESS   VramBaseAddress
   )
 {
   // Define start of the VRAM. This never changes for any graphics mode


### PR DESCRIPTION
It was causing ArmMaliDp to fail to get built, which threw the build process off track