### PR TITLE
Workaround assembler issues in the Microsoft toolchain, pickup new assembly file changes

### DIFF
--- a/ArmPkg/Library/ArmLib/AArch64/ArmLibSupport.masm
+++ b/ArmPkg/Library/ArmLib/AArch64/ArmLibSupport.masm
@@ -193,13 +193,13 @@ ArmSetMAIR ENDP
 //  IN VOID  *MVA                    // X1
 //  );
 ArmUpdateTranslationTableEntry PROC
-   dc      civac, x0             // Clean and invalidate data line
-   dsb     sy
+   dsb     nshst
+   lsr     x1, x1, #12
    EL1_OR_EL2_OR_EL3(x0)
 1
    // tlbi    vaae1, x1             // TLB Invalidate VA , EL1
-   // TODO-cho: Use the alternate encoding of tlbi due to the assembler not
-   // generating the correct code when tlbi is used.
+   // TODO-cho-19475344: Use the alternate encoding of tlbi due to the assembler not
+   // generating the correct code when tlbi vaae1 is used.
    sys #0, C8, C7, #3, x1
    b       %f4
 2
@@ -208,7 +208,7 @@ ArmUpdateTranslationTableEntry PROC
 3
    tlbi    vae3, x1              // TLB Invalidate VA , EL3
 4
-   dsb     sy
+   dsb     nsh
    isb sy
    ret
 ArmUpdateTranslationTableEntry ENDP
@@ -217,10 +217,10 @@ ArmInvalidateTlb PROC
    EL1_OR_EL2_OR_EL3(x0)
 1
    // MS_CHANGE
-   // TODO-cho-19475344: Promote the tlbi to vmalle1is due to the assembler not
-   // generating the right code when vmalle1 is used.
+   // TODO-cho-19475344: Use the alternate encoding of tlbi due to the assembler not
+   // generating the right code when tlbi vmalle1 is used.
    // tlbi vmalle1
-   tlbi  vmalle1is
+   sys #0, C8, C7, #0
    b     %f4
 2
    tlbi  alle2

--- a/ArmPkg/Library/ArmLib/AArch64/ArmLibSupport.masm
+++ b/ArmPkg/Library/ArmLib/AArch64/ArmLibSupport.masm
@@ -198,7 +198,7 @@ ArmUpdateTranslationTableEntry PROC
    EL1_OR_EL2_OR_EL3(x0)
 1
    // tlbi    vaae1, x1             // TLB Invalidate VA , EL1
-   // TODO-cho-19475344: Use the alternate encoding of tlbi due to the assembler not
+   // MU_CHANGE : Use the alternate encoding of tlbi due to the assembler not
    // generating the correct code when tlbi vaae1 is used.
    sys #0, C8, C7, #3, x1
    b       %f4
@@ -216,8 +216,7 @@ ArmUpdateTranslationTableEntry ENDP
 ArmInvalidateTlb PROC
    EL1_OR_EL2_OR_EL3(x0)
 1
-   // MS_CHANGE
-   // TODO-cho-19475344: Use the alternate encoding of tlbi due to the assembler not
+   // MU_CHANGE : Use the alternate encoding of tlbi due to the assembler not
    // generating the right code when tlbi vmalle1 is used.
    // tlbi vmalle1
    sys #0, C8, C7, #0

--- a/ArmPkg/Library/ArmLib/AArch64/ArmLibSupport.masm
+++ b/ArmPkg/Library/ArmLib/AArch64/ArmLibSupport.masm
@@ -197,7 +197,10 @@ ArmUpdateTranslationTableEntry PROC
    dsb     sy
    EL1_OR_EL2_OR_EL3(x0)
 1
-   tlbi    vaae1, x1             // TLB Invalidate VA , EL1
+   // tlbi    vaae1, x1             // TLB Invalidate VA , EL1
+   // TODO-cho: Use the alternate encoding of tlbi due to the assembler not
+   // generating the correct code when tlbi is used.
+   sys #0, C8, C7, #3, x1
    b       %f4
 2
    tlbi    vae2, x1              // TLB Invalidate VA , EL2
@@ -214,13 +217,9 @@ ArmInvalidateTlb PROC
    EL1_OR_EL2_OR_EL3(x0)
 1
    // MS_CHANGE
-   // TODO-cho-19475344: Without doing a tlbi vmalle1is we see a write data
-   // abort with KdDxe enabled patching instructions even though that page should
-   // be marked read/write. Its possible the hypervisor is not invalidating the
-   // TLB correctly when moved across physical processors, or some other issue is present.
-   //
-   // This should be swapped back to tlbi vmalle1 when the hypervisor issue
-   // is root caused, and fixed.
+   // TODO-cho-19475344: Promote the tlbi to vmalle1is due to the assembler not
+   // generating the right code when vmalle1 is used.
+   // tlbi vmalle1
    tlbi  vmalle1is
    b     %f4
 2

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibReplaceEntry.masm
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibReplaceEntry.masm
@@ -24,19 +24,20 @@
 //VOID
 //ArmReplaceLiveTranslationEntry (
 //  IN  UINT64  *Entry,
-//  IN  UINT64  Value
+//  IN  UINT64  Value,
+//  IN  UINT64  Address
 //  )
 ArmReplaceLiveTranslationEntry PROC
 
   // disable interrupts
-  mrs   x2, daif
+  mrs   x4, daif
   msr   daifset, #0xf
   isb sy
 
   // clean and invalidate first so that we don't clobber
   // adjacent entries that are dirty in the caches
   dc    civac, x0
-  dsb   ish
+  dsb   nsh
 
   EL1_OR_EL2_OR_EL3(x3)
 1
@@ -54,8 +55,11 @@ ArmReplaceLiveTranslationEntry PROC
   dmb   sy
   dc    ivac, x0
 
-  // flush the TLBs
-    tlbi    vmalle1      // error A2503: SP register cannot be used in this context
+  // flush translations for the target address from the TLBs
+  // tlbi    vaae1, x2
+  // TODO-cho-19475344: Use the alternate encoding of tlbi due to the assembler not
+  // generating the correct code when tlbi is used.
+  sys #0, C8, C7, #3, x2
   dsb   sy
 
   // re-enable the MMU
@@ -80,7 +84,7 @@ ArmReplaceLiveTranslationEntry PROC
   dc    ivac, x0
 
   // flush the TLBs
-  tlbi  alle2
+  tlbi  vae2, x2
   dsb   sy
 
   // re-enable the MMU
@@ -105,7 +109,7 @@ ArmReplaceLiveTranslationEntry PROC
   dc    ivac, x0
 
   // flush the TLBs
-  tlbi  alle3
+  tlbi  vae3, x2
   dsb   sy
 
   // re-enable the MMU
@@ -113,7 +117,7 @@ ArmReplaceLiveTranslationEntry PROC
   isb sy
 
 4
-  msr   daif, x2
+  msr   daif, x4
   ret
 ArmReplaceLiveTranslationEntry ENDP
 

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibReplaceEntry.masm
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibReplaceEntry.masm
@@ -57,7 +57,7 @@ ArmReplaceLiveTranslationEntry PROC
 
   // flush translations for the target address from the TLBs
   // tlbi    vaae1, x2
-  // TODO-cho-19475344: Use the alternate encoding of tlbi due to the assembler not
+  // MU_CHANGE : Use the alternate encoding of tlbi due to the assembler not
   // generating the correct code when tlbi is used.
   sys #0, C8, C7, #3, x2
   dsb   sy

--- a/ArmPkg/Library/ArmSmcPsciResetSystemLib/AArch64/Reset.asm
+++ b/ArmPkg/Library/ArmSmcPsciResetSystemLib/AArch64/Reset.asm
@@ -25,8 +25,7 @@ DisableMmuAndReenterPei
   bl    ArmDisableMmu
 
   ; no memory accesses after MMU and caches have been disabled
-  ; MU_CHANGE
-  ; TODO-cho: The Microsoft assembler does not support the movl pseudo-instruction.
+  ; MU_CHANGE : The Microsoft assembler does not support the movl pseudo-instruction.
   ; No platforms using the Microsoft toolchain support S3 and Capsule update anyways,
   ; so comment it out to still use this library.
   ;

--- a/ArmPkg/Library/ArmSmcPsciResetSystemLib/AArch64/Reset.asm
+++ b/ArmPkg/Library/ArmSmcPsciResetSystemLib/AArch64/Reset.asm
@@ -25,8 +25,13 @@ DisableMmuAndReenterPei
   bl    ArmDisableMmu
 
   ; no memory accesses after MMU and caches have been disabled
-
-  movl  x0, FixedPcdGet64 (PcdFvBaseAddress)
+  ; TODO-cho: The Microsoft assembler does not support the movl pseudo-instruction.
+  ; No platforms using the Microsoft toolchain support S3 and Capsule update anyways,
+  ; so comment it out to still use this library.
+  ;
+  ; NOTE: This obviously means the function that uses this (EnterS3WithImmediateWake) WILL NOT WORK.
+  ;
+  ; movl  x0, FixedPcdGet64 (PcdFvBaseAddress)
   blr   x0
 
   ; never returns

--- a/ArmPkg/Library/ArmSmcPsciResetSystemLib/AArch64/Reset.asm
+++ b/ArmPkg/Library/ArmSmcPsciResetSystemLib/AArch64/Reset.asm
@@ -25,6 +25,7 @@ DisableMmuAndReenterPei
   bl    ArmDisableMmu
 
   ; no memory accesses after MMU and caches have been disabled
+  ; MU_CHANGE
   ; TODO-cho: The Microsoft assembler does not support the movl pseudo-instruction.
   ; No platforms using the Microsoft toolchain support S3 and Capsule update anyways,
   ; so comment it out to still use this library.


### PR DESCRIPTION
The assembler still assembles TLBI instructions incorrectly so workaround the issue using the SYS instruction alias. 

Comment out the MOVL pseduo instruction used in reset as that isn't supported either. 

Update MASM files to pickup new changes in other assembly files.
