### PR TITLE
Add stubbed out methods for new entrypoints in arm platform bootmgr

### DIFF
--- a/ArmPkg/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/ArmPkg/Library/PlatformBootManagerLib/PlatformBm.c
@@ -768,6 +768,18 @@ PlatformBootManagerWaitCallback (
 }
 
 /**
+BDS Entry  - DXE phase complete, BDS Entered.
+*/
+VOID
+EFIAPI
+PlatformBootManagerBdsEntry (
+  VOID
+)
+{
+  return;
+}
+
+/**
   The function is called when no boot option could be launched,
   including platform recovery options and options pointing to applications
   built into firmware volumes.
@@ -779,6 +791,31 @@ EFIAPI
 PlatformBootManagerUnableToBoot (
   VOID
   )
+{
+  return;
+}
+
+/**
+ HardKeyBoot
+*/
+VOID
+EFIAPI
+PlatformBootManagerPriorityBoot (
+  UINT16 **BootNext
+  )
+{
+  return;
+}
+
+/**
+ This is called from BDS right before going into front page 
+ when no bootable devices/options found
+*/
+VOID
+EFIAPI
+PlatformBootManagerProcessBootCompletion (
+  IN EFI_BOOT_MANAGER_LOAD_OPTION *BootOption
+)
 {
   return;
 }


### PR DESCRIPTION
Project MU has changed library contract for PlatformBootManagerLib.  Add missing entry points as stubs.