### PR TITLE
Remove define ID_AA64MMFR2_EL1 in AArch64Support.masm, because it is now present in VS2019 toolchain

### DIFF
--- a/ArmPkg/Library/ArmLib/AArch64/AArch64Support.masm
+++ b/ArmPkg/Library/ArmLib/AArch64/AArch64Support.masm
@@ -72,8 +72,6 @@
 #define CTRL_V_BIT       (1 << 12)
 #define CPACR_VFP_BITS   (3 << 20)
 
-ID_AA64MMFR2_EL1 EQU 0x403A    // MS_CHANGE
-
 ArmInvalidateDataCacheEntryByMVA PROC
   dc      ivac, x0    // Invalidate single data cache line
   ret


### PR DESCRIPTION
Remove define for ID_AA64MMFR2_EL1