### PR TITLE
Introduce MM communicate and variable service into MU_TIANO_ARM

### DIFF
--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -176,6 +176,7 @@
   ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
   ArmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf
   ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
+  ArmPkg/Drivers/SmmVariablePei/SmmVariablePei.inf
   # MU_CHANGE [END]
 
 [Components.AARCH64]

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -175,6 +175,7 @@
   # MU_CHANGE [BEGIN]
   ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
   ArmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf
+  ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
   # MU_CHANGE [END]
 
 [Components.AARCH64]

--- a/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
+++ b/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
@@ -1,0 +1,179 @@
+/** @file -- MmCommunicationPei.c
+  Provides an interface to send MM request in PEI
+
+  Copyright (c) 2016-2021, Arm Limited. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "MmCommunicationPei.h"
+
+//
+// Module globals
+//
+EFI_PEI_MM_COMMUNICATION_PPI  mPeiMmCommunication = {
+  MmCommunicationPeim
+};
+
+EFI_PEI_PPI_DESCRIPTOR  mPeiMmCommunicationPpi = {
+  (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+  &gEfiPeiMmCommunicationPpiGuid,
+  &mPeiMmCommunication
+};
+
+/**
+ * Entry point of PEI MM Communication driver
+ *
+ * @param  FileHandle   Handle of the file being invoked.
+ *                      Type EFI_PEI_FILE_HANDLE is defined in FfsFindNextFile().
+ * @param  PeiServices  General purpose services available to every PEIM.
+ *
+ * @retval EFI_SUCCESS  If the interface could be successfully installed
+ * @retval Others       Returned from PeiServicesInstallPpi()
+ *
+**/
+EFI_STATUS
+EFIAPI
+MmCommunicationPeiInitialize (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  )
+{
+  return PeiServicesInstallPpi (&mPeiMmCommunicationPpi);
+}
+
+/**
+  MmCommunicationPeim
+  Communicates with a registered handler.
+  This function provides a service to send and receive messages from a registered UEFI service during PEI.
+
+  @param[in] This                 The EFI_PEI_MM_COMMUNICATION_PPI instance.
+  @param[in] CommBuffer           Pointer to the data buffer
+  @param[in] CommSize             The size of the data buffer being passed in. On exit, the
+                                  size of data being returned. Zero if the handler does not
+                                  wish to reply with any data.
+
+  @retval EFI_SUCCESS             The message was successfully posted.
+  @retval EFI_INVALID_PARAMETER   CommBuffer was NULL or *CommSize does not match
+                                  MessageLength + sizeof (EFI_MM_COMMUNICATE_HEADER).
+  @retval EFI_BAD_BUFFER_SIZE     The buffer is too large for the MM implementation.
+                                  If this error is returned, the MessageLength field
+                                  in the CommBuffer header or the integer pointed by
+                                  CommSize, are updated to reflect the maximum payload
+                                  size the implementation can accommodate.
+  @retval EFI_ACCESS_DENIED       The CommunicateBuffer parameter or CommSize parameter,
+                                  if not omitted, are in address range that cannot be
+                                  accessed by the MM environment.
+**/
+EFI_STATUS
+EFIAPI
+MmCommunicationPeim (
+  IN CONST EFI_PEI_MM_COMMUNICATION_PPI  *This,
+  IN OUT VOID                            *CommBuffer,
+  IN OUT UINTN                           *CommSize
+  )
+{
+  EFI_MM_COMMUNICATE_HEADER  *CommunicateHeader;
+  ARM_SMC_ARGS               CommunicateSmcArgs;
+  EFI_STATUS                 Status;
+  UINTN                      BufferSize;
+
+  Status     = EFI_ACCESS_DENIED;
+  BufferSize = 0;
+
+  ZeroMem (&CommunicateSmcArgs, sizeof (ARM_SMC_ARGS));
+
+  // Check that our static buffer is looking good.
+  // We are using PcdMmBufferBase to transfer variable data.
+  // We are not using the full size of the buffer since there is a cost
+  // of copying data between Normal and Secure World.
+  ASSERT (PcdGet64 (PcdMmBufferSize) > 0 && PcdGet64 (PcdMmBufferBase) != 0);
+
+  //
+  // Check parameters
+  //
+  if (CommBuffer == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // If the length of the CommBuffer is 0 then return the expected length.
+  // This case can be used by the consumer of this driver to find out the
+  // max size that can be used for allocating CommBuffer.
+  if ((CommSize != NULL) && \
+      ((*CommSize == 0) || (*CommSize > (UINTN)PcdGet64 (PcdMmBufferSize))))
+  {
+    *CommSize = (UINTN)PcdGet64 (PcdMmBufferSize);
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER *)(UINTN)(PcdGet64 (PcdMmBufferBase));
+
+  CopyMem ((VOID *)CommunicateHeader, CommBuffer, *CommSize);
+
+  // CommBuffer is a mandatory parameter. Hence, Rely on
+  // MessageLength + Header to ascertain the
+  // total size of the communication payload rather than
+  // rely on optional CommSize parameter
+  BufferSize = CommunicateHeader->MessageLength +
+               sizeof (CommunicateHeader->HeaderGuid) +
+               sizeof (CommunicateHeader->MessageLength);
+
+  //
+  // If CommSize is supplied it must match MessageLength + sizeof (EFI_MM_COMMUNICATE_HEADER);
+  //
+  if ((CommSize != NULL) && (*CommSize != BufferSize)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // SMC Function ID
+  CommunicateSmcArgs.Arg0 = ARM_SMC_ID_MM_COMMUNICATE_AARCH64;
+
+  // Cookie
+  CommunicateSmcArgs.Arg1 = 0;
+
+  // comm_buffer_address (64-bit physical address)
+  CommunicateSmcArgs.Arg2 = (UINTN)CommunicateHeader;
+
+  // comm_size_address (not used, indicated by setting to zero)
+  CommunicateSmcArgs.Arg3 = 0;
+
+  // Call the Standalone MM environment.
+  ArmCallSmc (&CommunicateSmcArgs);
+
+  switch (CommunicateSmcArgs.Arg0) {
+    case ARM_SMC_MM_RET_SUCCESS:
+      // On successful return, the size of data being returned is inferred from
+      // MessageLength + Header.
+      BufferSize = CommunicateHeader->MessageLength +
+                   sizeof (CommunicateHeader->HeaderGuid) +
+                   sizeof (CommunicateHeader->MessageLength);
+      CopyMem (CommBuffer, (VOID *)CommunicateHeader, BufferSize);
+      if (CommSize != NULL) {
+        *CommSize = BufferSize;
+      }
+
+      Status = EFI_SUCCESS;
+      break;
+
+    case ARM_SMC_MM_RET_INVALID_PARAMS:
+      Status = EFI_INVALID_PARAMETER;
+      break;
+
+    case ARM_SMC_MM_RET_DENIED:
+      Status = EFI_ACCESS_DENIED;
+      break;
+
+    case ARM_SMC_MM_RET_NO_MEMORY:
+      // Unexpected error since the CommSize was checked for zero length
+      // prior to issuing the SMC
+      Status = EFI_OUT_OF_RESOURCES;
+      ASSERT (0);
+      break;
+
+    default:
+      Status = EFI_ACCESS_DENIED;
+      ASSERT (0);
+  }
+
+  return Status;
+}

--- a/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.h
+++ b/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.h
@@ -1,0 +1,78 @@
+/** @file -- MmCommunicationPei.h
+  Provides an interface to send MM request in PEI
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _MM_COMMUNICATION_PEI_H_
+#define _MM_COMMUNICATION_PEI_H_
+
+#include <PiPei.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/ArmSmcLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/PeimEntryPoint.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/HobLib.h>
+
+#include <Protocol/MmCommunication.h>
+
+#include <IndustryStandard/ArmStdSmc.h>
+
+#include <Ppi/MmCommunication.h>
+
+/**
+ * Entry point of PEI MM Communication driver
+ *
+ * @param  FileHandle   Handle of the file being invoked.
+ *                      Type EFI_PEI_FILE_HANDLE is defined in FfsFindNextFile().
+ * @param  PeiServices  General purpose services available to every PEIM.
+ *
+ * @retval EFI_SUCCESS  If the interface could be successfully installed
+ * @retval Others       Returned from PeiServicesInstallPpi()
+ *
+**/
+EFI_STATUS
+EFIAPI
+MmCommunicationPeiInitialize (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  );
+
+/**
+  MmCommunicationPeim
+  Communicates with a registered handler.
+  This function provides a service to send and receive messages from a registered UEFI service during PEI.
+
+  @param[in] This                 The EFI_PEI_MM_COMMUNICATION_PPI instance.
+  @param[in] CommBuffer           Pointer to the buffer
+  @param[in] CommSize             The size of the data buffer being passed in. On exit, the
+                                  size of data being returned. Zero if the handler does not
+                                  wish to reply with any data.
+
+  @retval EFI_SUCCESS             The message was successfully posted.
+  @retval EFI_INVALID_PARAMETER   CommBuffer was NULL or *CommSize does not match
+                                  MessageLength + sizeof (EFI_MM_COMMUNICATE_HEADER).
+  @retval EFI_BAD_BUFFER_SIZE     The buffer is too large for the MM implementation.
+                                  If this error is returned, the MessageLength field
+                                  in the CommBuffer header or the integer pointed by
+                                  CommSize, are updated to reflect the maximum payload
+                                  size the implementation can accommodate.
+  @retval EFI_ACCESS_DENIED       The CommunicateBuffer parameter or CommSize parameter,
+                                  if not omitted, are in address range that cannot be
+                                  accessed by the MM environment.
+
+**/
+EFI_STATUS
+EFIAPI
+MmCommunicationPeim (
+  IN CONST EFI_PEI_MM_COMMUNICATION_PPI  *This,
+  IN OUT VOID                            *CommBuffer,
+  IN OUT UINTN                           *CommSize
+  );
+
+#endif /* _MM_COMMUNICATION_PEI_H_ */

--- a/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
+++ b/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
@@ -1,0 +1,41 @@
+#/** @file -- MmCommunicationPei.inf
+#
+#  Copyright (c) 2016 - 2021, Arm Limited. All rights reserved.<BR>
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MmCommunicationPei
+  FILE_GUID                      = 58FFB346-1B75-42C7-AD69-37C652423C1A
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = MmCommunicationPeiInitialize
+
+[Sources]
+  MmCommunicationPei.c
+  MmCommunicationPei.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  ArmPkg/ArmPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  ArmSmcLib
+  PeimEntryPoint
+  PeiServicesLib
+  HobLib
+
+[Pcd]
+  gArmTokenSpaceGuid.PcdMmBufferBase
+  gArmTokenSpaceGuid.PcdMmBufferSize
+
+[Ppis]
+  gEfiPeiMmCommunicationPpiGuid     ## PRODUCES
+
+[Depex]
+  TRUE

--- a/ArmPkg/Drivers/SmmVariablePei/SmmVariablePei.c
+++ b/ArmPkg/Drivers/SmmVariablePei/SmmVariablePei.c
@@ -1,0 +1,231 @@
+/** @file -- SmmVariablePei.c
+  Provides interface for reading Secure System Variables during PEI.
+
+  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "SmmVariablePei.h"
+
+//
+// Module globals
+//
+EFI_PEI_READ_ONLY_VARIABLE2_PPI  mPeiSecureVariableRead = {
+  PeiSmmGetVariable,
+  PeiSmmGetNextVariableName
+};
+
+EFI_PEI_PPI_DESCRIPTOR  mPeiSmmVariablePpi = {
+  (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+  &gEfiPeiReadOnlyVariable2PpiGuid,
+  &mPeiSecureVariableRead
+};
+
+/**
+ * Entry point of PEI Secure Variable read driver
+ *
+ * @param  FileHandle   Handle of the file being invoked.
+ *                      Type EFI_PEI_FILE_HANDLE is defined in FfsFindNextFile().
+ * @param  PeiServices  General purpose services available to every PEIM.
+ *
+ * @retval EFI_SUCCESS  If the interface could be successfully installed
+ * @retval Others       Returned from PeiServicesInstallPpi()
+ *
+**/
+EFI_STATUS
+EFIAPI
+PeiSmmVariableInitialize (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  )
+{
+  return PeiServicesInstallPpi (&mPeiSmmVariablePpi);
+}
+
+/**
+  This service retrieves a variable's value using its name and GUID.
+
+  This function is using the Secure Variable Store. If the Data
+  buffer is too small to hold the contents of the variable, the error
+  EFI_BUFFER_TOO_SMALL is returned and DataSize is set to the required buffer
+  size to obtain the data.
+
+  @param  This                  A pointer to this instance of the EFI_PEI_READ_ONLY_VARIABLE2_PPI.
+  @param  VariableName          A pointer to a null-terminated string that is the variable's name.
+  @param  VariableGuid          A pointer to an EFI_GUID that is the variable's GUID. The combination of
+                                VariableGuid and VariableName must be unique.
+  @param  Attributes            If non-NULL, on return, points to the variable's attributes.
+  @param  DataSize              On entry, points to the size in bytes of the Data buffer.
+                                On return, points to the size of the data returned in Data.
+  @param  Data                  Points to the buffer which will hold the returned variable value.
+                                May be NULL with a zero DataSize in order to determine the size of the buffer needed.
+
+  @retval EFI_SUCCESS           The variable was read successfully.
+  @retval EFI_NOT_FOUND         The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL  The DataSize is too small for the resulting data.
+                                DataSize is updated with the size required for
+                                the specified variable.
+  @retval EFI_INVALID_PARAMETER VariableName, VariableGuid, DataSize or Data is NULL.
+  @retval EFI_DEVICE_ERROR      The variable could not be retrieved because of a device error.
+
+**/
+EFI_STATUS
+EFIAPI
+PeiSmmGetVariable (
+  IN CONST  EFI_PEI_READ_ONLY_VARIABLE2_PPI *This,
+  IN CONST  CHAR16 *VariableName,
+  IN CONST  EFI_GUID *VariableGuid,
+  OUT       UINT32 *Attributes, OPTIONAL
+  IN OUT    UINTN                            *DataSize,
+  OUT       VOID                             *Data OPTIONAL
+  )
+{
+  EFI_STATUS                                Status;
+  UINTN                                     MessageSize;
+  EFI_MM_COMMUNICATE_HEADER                 *CommunicateHeader;
+  SMM_VARIABLE_COMMUNICATE_HEADER           *SmmVarCommsHeader;
+  SMM_VARIABLE_COMMUNICATE_ACCESS_VARIABLE  *SmmVarAccessHeader;
+  UINT8                                     *MmCommunicateBuffer;
+  UINT8                                     RequiredPages;
+  EFI_PEI_MM_COMMUNICATION_PPI              *MmCommunicationPpi;
+
+  // Check input parameters
+  if ((VariableName == NULL) || (VariableGuid == NULL) || (DataSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (VariableName[0] == 0) {
+    return EFI_NOT_FOUND;
+  }
+
+  if ((*DataSize > 0) && (Data == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = PeiServicesLocatePpi (&gEfiPeiMmCommunicationPpiGuid, 0, NULL, (VOID **)&MmCommunicationPpi);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to locate PEI MM Communication PPI: %r\n", __FUNCTION__, Status));
+    return Status;
+  }
+
+  // Allocate required pages to send MM request
+  RequiredPages = EFI_SIZE_TO_PAGES (
+                    sizeof (EFI_MM_COMMUNICATE_HEADER) + \
+                    sizeof (SMM_VARIABLE_COMMUNICATE_HEADER) + \
+                    sizeof (SMM_VARIABLE_COMMUNICATE_ACCESS_VARIABLE) + \
+                    StrSize (VariableName) + *DataSize
+                    );
+  MmCommunicateBuffer = (UINT8 *)AllocatePages (RequiredPages);
+
+  if (MmCommunicateBuffer == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate memory: %r\n", __FUNCTION__, Status));
+    return Status;
+  }
+
+  // Zero the entire Communication Buffer
+  ZeroMem (MmCommunicateBuffer, (RequiredPages * EFI_PAGE_SIZE));
+
+  CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER *)MmCommunicateBuffer;
+
+  SmmVarCommsHeader = (SMM_VARIABLE_COMMUNICATE_HEADER *)CommunicateHeader->Data;
+
+  SmmVarAccessHeader = (SMM_VARIABLE_COMMUNICATE_ACCESS_VARIABLE *)SmmVarCommsHeader->Data;
+
+  // Use gEfiSmmVariableProtocolGuid to request the SMM variable service in S-EL0
+  CopyMem ((VOID *)&CommunicateHeader->HeaderGuid, &gEfiSmmVariableProtocolGuid, sizeof (GUID));
+
+  // We are only supporting GetVariable
+  SmmVarCommsHeader->Function = SMM_VARIABLE_FUNCTION_GET_VARIABLE;
+
+  // Variable GUID
+  CopyMem ((VOID *)&SmmVarAccessHeader->Guid, VariableGuid, sizeof (GUID));
+
+  // Program the max amount of data we accept.
+  SmmVarAccessHeader->DataSize = *DataSize;
+
+  // Get size of the variable name
+  SmmVarAccessHeader->NameSize = StrSize (VariableName);
+
+  //
+  // Program all data structure sizes
+  //
+
+  // Program the MM header size
+  CommunicateHeader->MessageLength = sizeof (SMM_VARIABLE_COMMUNICATE_HEADER) - 1 + \
+                                     sizeof (SMM_VARIABLE_COMMUNICATE_ACCESS_VARIABLE) - 1 + \
+                                     SmmVarAccessHeader->NameSize + SmmVarAccessHeader->DataSize;
+
+  // Size of the entire message sent to the secure world.
+  MessageSize = CommunicateHeader->MessageLength + \
+                sizeof (CommunicateHeader->HeaderGuid) + \
+                sizeof (CommunicateHeader->MessageLength);
+
+  CopyMem ((VOID *)&SmmVarAccessHeader->Name, VariableName, SmmVarAccessHeader->NameSize);
+
+  // Send the MM request using MmCommunicationPeiLib
+  Status = MmCommunicationPpi->Communicate (MmCommunicationPpi, CommunicateHeader, &MessageSize);
+
+  if (EFI_ERROR (Status)) {
+    // Received an error from MM interface.
+    DEBUG ((DEBUG_ERROR, "%a - MM Interface Error: %r\n", __FUNCTION__, Status));
+    goto Exit;
+  }
+
+  // MM request was successfully handled by the framework.
+  // Set status to the Variable Service Status Code
+  Status = SmmVarCommsHeader->ReturnStatus;
+  if (EFI_ERROR (Status)) {
+    // We received an error from Variable Service.
+    // We cant do anymore so return Status
+    if (Status != EFI_BUFFER_TOO_SMALL) {
+      DEBUG ((DEBUG_ERROR, "%a - Variable Service Error: %r\n", __FUNCTION__, Status));
+    }
+
+    goto Exit;
+  }
+
+  Status = EFI_SUCCESS;
+
+  // User provided buffer is too small
+  if (*DataSize < SmmVarAccessHeader->DataSize) {
+    Status = EFI_BUFFER_TOO_SMALL;
+  }
+
+Exit:
+  // Check if we need to set Attributes
+  if (Attributes != NULL) {
+    *Attributes = SmmVarAccessHeader->Attributes;
+  }
+
+  *DataSize = SmmVarAccessHeader->DataSize;
+
+  if (Status == EFI_SUCCESS) {
+    CopyMem ((VOID *)Data, (UINT8 *)SmmVarAccessHeader->Name + SmmVarAccessHeader->NameSize, *DataSize);
+  }
+
+  // Free the Communication Buffer
+  if (MmCommunicateBuffer != NULL) {
+    FreePages (MmCommunicateBuffer, RequiredPages);
+  }
+
+  return Status;
+}
+
+/**
+ * This function is not supported
+ * @retval EFI_UNSUPPORTED
+ *
+**/
+EFI_STATUS
+EFIAPI
+PeiSmmGetNextVariableName (
+  IN CONST  EFI_PEI_READ_ONLY_VARIABLE2_PPI  *This,
+  IN OUT UINTN                               *VariableNameSize,
+  IN OUT CHAR16                              *VariableName,
+  IN OUT EFI_GUID                            *VariableGuid
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/ArmPkg/Drivers/SmmVariablePei/SmmVariablePei.h
+++ b/ArmPkg/Drivers/SmmVariablePei/SmmVariablePei.h
@@ -1,0 +1,110 @@
+/** @file -- SmmVariablePei.h
+  Provides interface for reading Secure System Variables during PEI.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _PEI_SMM_VARIABLE_LIB_H_
+#define _PEI_SMM_VARIABLE_LIB_H_
+
+#include <PiPei.h>
+#include <Uefi/UefiSpec.h>
+
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PeimEntryPoint.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/HobLib.h>
+
+#include <Guid/SmmVariableCommon.h>
+
+#include <Ppi/ReadOnlyVariable2.h>
+#include <Ppi/MmCommunication.h>
+
+#include <Protocol/MmCommunication.h>
+
+/**
+ * Entry point of PEI Secure Variable read driver
+ *
+ * @param  FileHandle   Handle of the file being invoked.
+ *                      Type EFI_PEI_FILE_HANDLE is defined in FfsFindNextFile().
+ * @param  PeiServices  General purpose services available to every PEIM.
+ *
+ * @retval EFI_SUCCESS  If the interface could be successfully installed
+ * @retval Others       Returned from PeiServicesInstallPpi()
+ *
+**/
+EFI_STATUS
+EFIAPI
+PeiSmmVariableInitialize (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  );
+
+/**
+
+  This function enables the read of Secure Variables during PEI.
+
+  This function is using the Secure Variable Store.If the Data
+  buffer is too small to hold the contents of the variable, the error
+  EFI_BUFFER_TOO_SMALL is returned and DataSize is set to the required buffer
+  size to obtain the data.
+
+  The function performs the following:
+
+  1) Creates an MM request
+  2) Fills out the following data structures for the Secure Variable Service
+      SMM_VARIABLE_COMMUNICATE_HEADER/SMM_VARIABLE_COMMUNICATE_ACCESS_VARIABLE
+  3) Adds the SMM data structures to the MM request.
+  4) Sends the MM request to EL3 using MmCommunicationPeiLib.
+  5) The MM request is sent to S-EL0.
+  6) The MM request is then handled by the registered handler with GUID: gEfiSmmVariableProtocolGuid
+
+  @param  This                  A pointer to this instance of the EFI_PEI_READ_ONLY_VARIABLE2_PPI.
+  @param  VariableName          A pointer to a null-terminated string that is the variable's name.
+  @param  VariableGuid          A pointer to an EFI_GUID that is the variable's GUID. The combination of
+                                VariableGuid and VariableName must be unique.
+  @param  Attributes            If non-NULL, on return, points to the variable's attributes.
+  @param  DataSize              On entry, points to the size in bytes of the Data buffer.
+                                On return, points to the size of the data returned in Data.
+  @param  Data                  Points to the buffer which will hold the returned variable value.
+                                May be NULL with a zero DataSize in order to determine the size of the buffer needed.
+
+  @retval EFI_SUCCESS           The variable was read successfully.
+  @retval EFI_NOT_FOUND         The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL  The DataSize is too small for the resulting data.
+                                DataSize is updated with the size required for
+                                the specified variable.
+  @retval EFI_INVALID_PARAMETER VariableName, VariableGuid, DataSize or Data is NULL.
+  @retval EFI_DEVICE_ERROR      The variable could not be retrieved because of a device error.
+
+**/
+EFI_STATUS
+EFIAPI
+PeiSmmGetVariable (
+  IN CONST  EFI_PEI_READ_ONLY_VARIABLE2_PPI  *This,
+  IN CONST  CHAR16                           *VariableName,
+  IN CONST  EFI_GUID                         *VariableGuid,
+  OUT       UINT32                           *Attributes,
+  IN OUT    UINTN                            *DataSize,
+  OUT       VOID                             *Data OPTIONAL
+  );
+
+/**
+ * This function is not supported
+ * @retval EFI_UNSUPPORTED
+ *
+**/
+EFI_STATUS
+EFIAPI
+PeiSmmGetNextVariableName (
+  IN CONST  EFI_PEI_READ_ONLY_VARIABLE2_PPI  *This,
+  IN OUT UINTN                               *VariableNameSize,
+  IN OUT CHAR16                              *VariableName,
+  IN OUT EFI_GUID                            *VariableGuid
+  );
+
+#endif /* _PEI_SMM_VARIABLE_LIB_H_ */

--- a/ArmPkg/Drivers/SmmVariablePei/SmmVariablePei.inf
+++ b/ArmPkg/Drivers/SmmVariablePei/SmmVariablePei.inf
@@ -1,0 +1,46 @@
+## @file -- SmmVariablePei.inf
+# Provides interface for reading Secure System Variables during PEI.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmmVariablePei
+  FILE_GUID                      = CD660A87-454B-4346-A35C-3D89BF8ECFAF
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = PeiSmmVariableInitialize
+
+[Sources]
+  SmmVariablePei.c
+  SmmVariablePei.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  ArmPkg/ArmPkg.dec
+
+[LibraryClasses]
+  PcdLib
+  PeiServicesLib
+  PeimEntryPoint
+  MemoryAllocationLib
+  HobLib
+
+[Pcd]
+  gArmTokenSpaceGuid.PcdMmBufferBase
+  gArmTokenSpaceGuid.PcdMmBufferSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize
+
+[Protocols]
+  gEfiSmmVariableProtocolGuid             ## CONSUMES
+
+[Ppis]
+  gEfiPeiReadOnlyVariable2PpiGuid         ## PRODUCES
+  gEfiPeiMmCommunicationPpiGuid           ## CONSUMES
+
+[Depex]
+  gEfiPeiMmCommunicationPpiGuid


### PR DESCRIPTION
This change introduces 2 new modules into MU_TIANO_ARM repo, to support the MM communication and variable read service in PEI phase on ARM based platforms.