### PR TITLE
ArmGicLib/ArmGicV3: Update ICC_SG1R register

### DIFF
--- a/ArmPkg/Drivers/ArmGic/GicV3/AArch64/ArmGicV3.masm
+++ b/ArmPkg/Drivers/ArmGic/GicV3/AArch64/ArmGicV3.masm
@@ -71,7 +71,7 @@ ArmGicV3SetControlSystemRegisterEnable ENDP
 //  );
 ArmGicV3SendNsG1Sgi PROC
         dsb     ishst
-        msr     ICC_SGI1R, x0
+        msr     ICC_SGI1R_EL1, x0
         isb
         ret
 ArmGicV3SendNsG1Sgi ENDP


### PR DESCRIPTION
## Description

The current register `ICC_SGI1R` builds on `ARM` but fails on `AARCH64`:

```
ArmPkg\Drivers\ArmGic\ArmGicLib\OUTPUT\GicV3\AArch64\ArmGicV3.iii(86):
  illegal flag(s) ICC_SGI1R
```

AARCH64 resgister `ICC_SG1R_EL1` performs the same function and compiles on both architectures.

https://developer.arm.com/documentation/ddi0601/2021-03/AArch64-Registers/ICC-SGI1R-EL1--Interrupt-Controller-Software-Generated-Interrupt-Group-1-Register?lang=en
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified `ARM` and `AARCH64` builds.

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>