### PR TITLE
Fixing a missing macro definition for CLANG builds

### DIFF
--- a/ArmPkg/Drivers/ArmGic/GicV3/AArch64/ArmGicV3.S
+++ b/ArmPkg/Drivers/ArmGic/GicV3/AArch64/ArmGicV3.S
@@ -23,7 +23,7 @@
 #define ICC_IAR1_EL1            S3_0_C12_C12_0
 #define ICC_PMR_EL1             S3_0_C4_C6_0
 #define ICC_BPR1_EL1            S3_0_C12_C12_3
-#define ICC_SGI1R               S3_0_C12_C11_5  // MU_CHANGE
+#define ICC_SGI1R_EL1           S3_0_C12_C11_5  // MU_CHANGE
 
 #endif
 
@@ -63,7 +63,7 @@ ASM_FUNC(ArmGicV3SetControlSystemRegisterEnable)
 //  );
 ASM_FUNC(ArmGicV3SendNsG1Sgi)
         dsb     ishst
-        msr     ICC_SGI1R, x0
+        msr     ICC_SGI1R_EL1, x0
         isb
         ret
 // MU_CHANGE Ends

--- a/ArmPkg/Drivers/ArmGic/GicV3/Arm/ArmGicV3.S
+++ b/ArmPkg/Drivers/ArmGic/GicV3/Arm/ArmGicV3.S
@@ -36,7 +36,7 @@ ASM_FUNC(ArmGicV3SetControlSystemRegisterEnable)
 //  );
 ASM_FUNC(ArmGicV3SendNsG1Sgi)
         dsb     ishst
-        mcrr    p15, 0, r0, r1, c12 // ICC_SGI1R
+        mcrr    p15, 0, r0, r1, c12 // ICC_SGI1R_EL1
         isb
         bx      lr
 // MU_CHANGE Ends


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This change is created to resolve this issue: https://github.com/microsoft/mu_silicon_arm_tiano/issues/39. The defined macro does not exist in CLANG compiler. On the other hand, this macro is indeed for generating SGI to EL1 environment, which makes the macro definition consistent with [ARM documentation](https://developer.arm.com/documentation/ddi0601/2022-12/AArch64-Registers/ICC-SGI1R-EL1--Interrupt-Controller-Software-Generated-Interrupt-Group-1-Register?lang=en).

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is verified for CLANG compiler manually and GCC through pipeline.

## Integration Instructions

N/A
