### PR TITLE
Fixing _PRT methods for PCI Legacy INT

### DIFF
--- a/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
@@ -1055,6 +1055,8 @@ typedef struct CmArmPciInterruptMapInfo {
 
   // MU_CHANGE [BEGIN] Allow user to specify Legacy INT object 
   /// Pci Int Link Name
+  // ACPI 6.4 6.2.13 _PRT (PCI Routing Table) 
+  // "Field: Source : "NamePath"
   CHAR8   *PciIntLinkName;
   // MU_CHANGE [END]
 

--- a/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
@@ -1053,6 +1053,11 @@ typedef struct CmArmPciInterruptMapInfo {
   */
   UINT8                       PciInterrupt;
 
+  // MU_CHANGE [BEGIN] Allow user to specify Legacy INT object 
+  /// Pci Int Link Name
+  CHAR8   *PciIntLinkName;
+  // MU_CHANGE [END]
+
   /** Interrupt controller interrupt.
 
   Cf Devicetree Specification - Release v0.3

--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
@@ -399,7 +399,7 @@ GeneratePrt (
     Status = AmlAddPrtEntry (
                (IrqMapInfo->PciDevice << 16) | 0xFFFF,
                IrqMapInfo->PciInterrupt,
-               &(IrqMapInfo->PciIntLinkName[0]),
+               &(IrqMapInfo->PciIntLinkName[0]),  //MU_CHANGE
                IrqMapInfo->IntcInterrupt.Interrupt,
                PrtNode
                );

--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
@@ -397,9 +397,9 @@ GeneratePrt (
        use a function number of FFFF).
     */
     Status = AmlAddPrtEntry (
-               (IrqMapInfo->PciDevice << 16) | IrqMapInfo->PciFunction, // MU_CHANGE
+               (IrqMapInfo->PciDevice << 16) | 0xFFFF,
                IrqMapInfo->PciInterrupt,
-               NULL,
+               &(IrqMapInfo->PciIntLinkName[0]),
                IrqMapInfo->IntcInterrupt.Interrupt,
                PrtNode
                );


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The existing code for _PRT methods had some issues. 
1. The ADDR parameter for PRT methods must be 0xFFFF ( according to Spec ) 
2. The Exisitng code did not pass the LINK NAME to the PRT method

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  For devices that use legacy INTs
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
The code will be tested using  PCI Analyzer with Legacy INT enabled. 

## Integration Instructions

N/A
