### PR TITLE
Set RTC and Runtime Flash MMIO as XP by Default

### DIFF
--- a/ArmPlatformPkg/Drivers/NorFlashDxe/NorFlashDxe.c
+++ b/ArmPlatformPkg/Drivers/NorFlashDxe/NorFlashDxe.c
@@ -427,14 +427,14 @@ NorFlashFvbInitialize (
                   EfiGcdMemoryTypeMemoryMappedIo,
                   Instance->DeviceBaseAddress,
                   RuntimeMmioRegionSize,
-                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
+                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP // MU_CHANGE: Set Runtime flash MMIO as XP by default
                   );
   ASSERT_EFI_ERROR (Status);
 
   Status = gDS->SetMemorySpaceAttributes (
                   Instance->DeviceBaseAddress,
                   RuntimeMmioRegionSize,
-                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
+                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP // MU_CHANGE: Set Runtime flash MMIO as XP by default
                   );
   ASSERT_EFI_ERROR (Status);
 

--- a/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
+++ b/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.c
@@ -319,13 +319,13 @@ LibRtcInitialize (
                   EfiGcdMemoryTypeMemoryMappedIo,
                   mPL031RtcBase,
                   SIZE_4KB,
-                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
+                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP // MU_CHANGE: Allocate RTC memory XP by default
                   );
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
-  Status = gDS->SetMemorySpaceAttributes (mPL031RtcBase, SIZE_4KB, EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
+  Status = gDS->SetMemorySpaceAttributes (mPL031RtcBase, SIZE_4KB, EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP); // MU_CHANGE: Allocate RTC memory XP by default
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/ArmVirtPkg/Library/KvmtoolRtcFdtClientLib/KvmtoolRtcFdtClientLib.c
+++ b/ArmVirtPkg/Library/KvmtoolRtcFdtClientLib/KvmtoolRtcFdtClientLib.c
@@ -44,7 +44,7 @@ KvmtoolRtcMapMemory (
                   EfiGcdMemoryTypeMemoryMappedIo,
                   RtcPageBase,
                   EFI_PAGE_SIZE,
-                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
+                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP // MU_CHANGE: Set RTC memory XP by default
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((
@@ -80,7 +80,7 @@ KvmtoolRtcMapMemory (
   Status = gDS->SetMemorySpaceAttributes (
                   RtcPageBase,
                   EFI_PAGE_SIZE,
-                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME
+                  EFI_MEMORY_UC | EFI_MEMORY_RUNTIME | EFI_MEMORY_XP // MU_CHANGE: Set RTC memory XP by default
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

When `SetMemorySpaceAttributes()` is called with CPU arch attributes set, it will unset any attributes not explicitly set. In the RTC and runtime flash MMIO code, this is the `EFI_MEMORY_XP` bit that gets unset, which is a potential security and safety issue.

This PR fixes up callers to `SetMemorySpaceAttributes()` that are clearing the `EFI_MEMORY_XP` bit to explicitly set it.

The NorFlashDxe driver is a runtime driver to map flash to MMIO, this should be mapped XP at such a time as during runtime we will not be executing from the flash region.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested to build and on QEMU, though I do not have hardware that uses these RTCs.

## Integration Instructions

N/A.
