### PR TITLE
Report All Page Table Entry Attributes From Arm MMU

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -120,7 +120,7 @@ GetFirstPageAttribute (
   } else if (((FirstEntry & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY) ||
              ((TableLevel == 3) && ((FirstEntry & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY_LEVEL3)))
   {
-    return FirstEntry & TT_ATTR_INDX_MASK;
+    return FirstEntry & TT_ATTRIBUTES_MASK;
   } else {
     return INVALID_ENTRY;
   }
@@ -158,7 +158,7 @@ GetNextEntryAttribute (
   for (Index = 0; Index < EntryCount; Index++) {
     Entry          = TableAddress[Index];
     EntryType      = Entry & TT_TYPE_MASK;
-    EntryAttribute = Entry  & TT_ATTR_INDX_MASK;
+    EntryAttribute = Entry & TT_ATTRIBUTES_MASK;
 
     // If Entry is a Table Descriptor type entry then go through the sub-level table
     if ((EntryType == TT_TYPE_BLOCK_ENTRY) ||

--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -120,7 +120,7 @@ GetFirstPageAttribute (
   } else if (((FirstEntry & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY) ||
              ((TableLevel == 3) && ((FirstEntry & TT_TYPE_MASK) == TT_TYPE_BLOCK_ENTRY_LEVEL3)))
   {
-    return FirstEntry & TT_ATTRIBUTES_MASK;
+    return FirstEntry & TT_ATTRIBUTES_MASK; // MU_CHANGE: Return all attributes from page table
   } else {
     return INVALID_ENTRY;
   }
@@ -158,7 +158,7 @@ GetNextEntryAttribute (
   for (Index = 0; Index < EntryCount; Index++) {
     Entry          = TableAddress[Index];
     EntryType      = Entry & TT_TYPE_MASK;
-    EntryAttribute = Entry & TT_ATTRIBUTES_MASK;
+    EntryAttribute = Entry & TT_ATTRIBUTES_MASK;  // MU_CHANGE: Return all attributes from page table
 
     // If Entry is a Table Descriptor type entry then go through the sub-level table
     if ((EntryType == TT_TYPE_BLOCK_ENTRY) ||


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Currently, only cacheability attributes are reported from Arm's MMU mgmt code to sync the GCD, which leads to an incorrect initial sync and can cause access flag exceptions (see microsoft/mu_basecore#409 for full context) because TT_AF (the access flag) is not getting reported, so the GCD gets filled in with every range set to EFI_MEMORY_RP (cannot access any page).

This PR returns all page table entry attributes (importantly adding read only and non-executable permissions in addition to the access flag) so that the upper layer code can properly sync the GCD and decide the mapping of page table bits to GCD bits.

```c
TT_ATTR_INDX_MASK = 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0001 1100

TT_ATTRIBUTE_MASK = 1111 1111 1111 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 1111 1111 1100

TT_AF             = 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0100 0000 0000
```

See [AArch64Mmu.h](https://github.com/microsoft/mu_silicon_arm_tiano/blob/f3fc377e2c7c21e1530803d91a5e712a0968abd2/ArmPkg/Include/Chipset/AArch64Mmu.h#LL56C1-L80C65) for the other bit definitions.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a physical ARM platform that was experiencing the runtime break described in microsoft/mu_basecore#409 and saw that it resolved the issue.

## Integration Instructions

N/A.
