### PR TITLE
Improve Arm Memory Attribute Protocol Logging

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
+++ b/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
@@ -84,6 +84,11 @@ GetMemoryAttributes (
   EFI_STATUS  Status;
 
   if ((Length == 0) || (Attributes == NULL)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a invalid length is 0 or attributes are null\n",
+      __func__
+      )); // MU_CHANGE: Better memory attributes protocol logging
     return EFI_INVALID_PARAMETER;
   }
 
@@ -201,6 +206,13 @@ SetMemoryAttributes (
   if ((Length == 0) ||
       ((Attributes & ~(EFI_MEMORY_RO | EFI_MEMORY_RP | EFI_MEMORY_XP)) != 0))
   {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a invalid length: 0x%llx or attributes 0x%llx\n",
+      __func__,
+      Length,
+      Attributes
+      )); // MU_CHANGE: Better memory attributes protocol logging
     return EFI_INVALID_PARAMETER;
   }
 
@@ -213,6 +225,13 @@ SetMemoryAttributes (
   if ((Attributes & EFI_MEMORY_RP) != 0) {
     Status = ArmSetMemoryRegionNoAccess (BaseAddress, Length);
     if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a failed to set EFI_MEMORY_RP on BaseAddress 0x%llx of length 0x%llx!\n",
+        __func__,
+        BaseAddress,
+        Length
+        )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
   }
@@ -220,6 +239,13 @@ SetMemoryAttributes (
   if ((Attributes & EFI_MEMORY_RO) != 0) {
     Status = ArmSetMemoryRegionReadOnly (BaseAddress, Length);
     if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a failed to set EFI_MEMORY_RO on BaseAddress 0x%llx of length 0x%llx!\n",
+        __func__,
+        BaseAddress,
+        Length
+        )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
   }
@@ -227,6 +253,13 @@ SetMemoryAttributes (
   if ((Attributes & EFI_MEMORY_XP) != 0) {
     Status = ArmSetMemoryRegionNoExec (BaseAddress, Length);
     if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a failed to set EFI_MEMORY_XP on BaseAddress 0x%llx of length 0x%llx!\n",
+        __func__,
+        BaseAddress,
+        Length
+        )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
   }
@@ -287,6 +320,13 @@ ClearMemoryAttributes (
   if ((Length == 0) ||
       ((Attributes & ~(EFI_MEMORY_RO | EFI_MEMORY_RP | EFI_MEMORY_XP)) != 0))
   {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a invalid length: 0x%llx or attributes 0x%llx\n",
+      __func__,
+      Length,
+      Attributes
+      )); // MU_CHANGE: Better memory attributes protocol logging
     return EFI_INVALID_PARAMETER;
   }
 
@@ -299,6 +339,13 @@ ClearMemoryAttributes (
   if ((Attributes & EFI_MEMORY_RP) != 0) {
     Status = ArmClearMemoryRegionNoAccess (BaseAddress, Length);
     if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a failed to clear EFI_MEMORY_RP from BaseAddress 0x%llx of length 0x%llx!\n",
+        __func__,
+        BaseAddress,
+        Length
+        )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
   }
@@ -306,6 +353,13 @@ ClearMemoryAttributes (
   if ((Attributes & EFI_MEMORY_RO) != 0) {
     Status = ArmClearMemoryRegionReadOnly (BaseAddress, Length);
     if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a failed to clear EFI_MEMORY_RO from BaseAddress 0x%llx of length 0x%llx!\n",
+        __func__,
+        BaseAddress,
+        Length
+        )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
   }
@@ -313,6 +367,13 @@ ClearMemoryAttributes (
   if ((Attributes & EFI_MEMORY_XP) != 0) {
     Status = ArmClearMemoryRegionNoExec (BaseAddress, Length);
     if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a failed to clear EFI_MEMORY_XP from BaseAddress 0x%llx of length 0x%llx!\n",
+        __func__,
+        BaseAddress,
+        Length
+        )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
   }

--- a/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
+++ b/ArmPkg/Drivers/CpuDxe/MemoryAttribute.c
@@ -86,8 +86,10 @@ GetMemoryAttributes (
   if ((Length == 0) || (Attributes == NULL)) {
     DEBUG ((
       DEBUG_ERROR,
-      "%a invalid length is 0 or attributes are null\n",
-      __func__
+      "%a invalid length 0x%llx or attributes %p are null\n",
+      __func__,
+      (UINT64)RegionLength,
+      Attributes
       )); // MU_CHANGE: Better memory attributes protocol logging
     return EFI_INVALID_PARAMETER;
   }
@@ -227,10 +229,11 @@ SetMemoryAttributes (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "%a failed to set EFI_MEMORY_RP on BaseAddress 0x%llx of length 0x%llx!\n",
+        "%a failed to set EFI_MEMORY_RP on BaseAddress 0x%llx of length 0x%llx with status %r!\n",
         __func__,
         BaseAddress,
-        Length
+        Length,
+        Status
         )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
@@ -241,10 +244,11 @@ SetMemoryAttributes (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "%a failed to set EFI_MEMORY_RO on BaseAddress 0x%llx of length 0x%llx!\n",
+        "%a failed to set EFI_MEMORY_RO on BaseAddress 0x%llx of length 0x%llx with status %r!\n",
         __func__,
         BaseAddress,
-        Length
+        Length,
+        Status
         )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
@@ -255,10 +259,11 @@ SetMemoryAttributes (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "%a failed to set EFI_MEMORY_XP on BaseAddress 0x%llx of length 0x%llx!\n",
+        "%a failed to set EFI_MEMORY_XP on BaseAddress 0x%llx of length 0x%llx with status %r!\n",
         __func__,
         BaseAddress,
-        Length
+        Length,
+        Status
         )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
@@ -341,10 +346,11 @@ ClearMemoryAttributes (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "%a failed to clear EFI_MEMORY_RP from BaseAddress 0x%llx of length 0x%llx!\n",
+        "%a failed to clear EFI_MEMORY_RP from BaseAddress 0x%llx of length 0x%llx with status %r!\n",
         __func__,
         BaseAddress,
-        Length
+        Length,
+        Status
         )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
@@ -355,10 +361,11 @@ ClearMemoryAttributes (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "%a failed to clear EFI_MEMORY_RO from BaseAddress 0x%llx of length 0x%llx!\n",
+        "%a failed to clear EFI_MEMORY_RO from BaseAddress 0x%llx of length 0x%llx with status %r!\n",
         __func__,
         BaseAddress,
-        Length
+        Length,
+        Status
         )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }
@@ -369,10 +376,11 @@ ClearMemoryAttributes (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "%a failed to clear EFI_MEMORY_XP from BaseAddress 0x%llx of length 0x%llx!\n",
+        "%a failed to clear EFI_MEMORY_XP from BaseAddress 0x%llx of length 0x%llx with status %r!\n",
         __func__,
         BaseAddress,
-        Length
+        Length,
+        Status
         )); // MU_CHANGE: Better memory attribute protocol logging
       return EFI_UNSUPPORTED;
     }

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -380,7 +380,7 @@ UpdateRegionMapping (
       "%a RegionStart: 0x%llx or RegionLength: 0x%llx are not page aligned!\n",
       __func__,
       RegionStart,
-      RegionLength 
+      RegionLength
       )); // MU_CHANGE: Better memory attribute protocol logging
     return EFI_INVALID_PARAMETER;
   }

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -375,6 +375,13 @@ UpdateRegionMapping (
   UINTN  T0SZ;
 
   if (((RegionStart | RegionLength) & EFI_PAGE_MASK) != 0) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a RegionStart: 0x%llx or RegionLength: 0x%llx are not page aligned!\n",
+      __func__,
+      RegionStart,
+      RegionLength 
+      )); // MU_CHANGE: Better memory attribute protocol logging
     return EFI_INVALID_PARAMETER;
   }
 

--- a/ArmPkg/Library/ArmMmuLib/Arm/ArmMmuLibUpdate.c
+++ b/ArmPkg/Library/ArmMmuLib/Arm/ArmMmuLibUpdate.c
@@ -376,6 +376,13 @@ SetMemoryAttributes (
   BOOLEAN     FlushTlbs;
 
   if (BaseAddress > (UINT64)MAX_ADDRESS) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a BaseAddress: 0x%llx is greater than MAX_ADDRESS: 0x%llx, fail to apply attributes!\n",
+      __func__,
+      BaseAddress,
+      (UINT64)MAX_ADDRESS
+      )); // MU_CHANGE: Better memory attribute protocol logging
     return EFI_UNSUPPORTED;
   }
 
@@ -436,6 +443,14 @@ SetMemoryAttributes (
     }
 
     if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a failed to update attributes with status %r for BaseAddress 0x%llx of length 0x%llx\n",
+        __func__,
+        Status,
+        BaseAddress,
+        ChunkLength
+        )); // MU_CHANGE: Better memory attribute protocol logging
       break;
     }
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The Arm Memory Attribute Protocol logging is lacking, as evidenced by issue #124. This PR simply adds additional logging to make future debugging work easier and to help identify issue #124 in the wild, as it is likely to come up again with non-patched versions of the Linux shim.

The x86 Memory Attribute Protocol code already has good logging in the error cases.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Only logging update, no testing.

## Integration Instructions

N/A.
