### PR TITLE
Add the ability to configure the memory type used for the FD region

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -202,6 +202,9 @@
   #
   gArmTokenSpaceGuid.PcdFdSize|0|UINT32|0x0000002C
   gArmTokenSpaceGuid.PcdFvSize|0|UINT32|0x0000002E
+
+
+  # MU_CHANGE: PCD To configure memory type used for FD region allocation. Defaults to EfiBootServicesData
   gArmTokenSpaceGuid.PcdFdMemoryType|4|UINT32|0x1000046 # MU_CHANGE
 
   #

--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -202,6 +202,7 @@
   #
   gArmTokenSpaceGuid.PcdFdSize|0|UINT32|0x0000002C
   gArmTokenSpaceGuid.PcdFvSize|0|UINT32|0x0000002E
+  gArmTokenSpaceGuid.PcdFdMemoryType|4|UINT32|0x1000046 # MU_CHANGE
 
   #
   # Value to add to a host address to obtain a device address, using

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -181,7 +181,7 @@ MemoryPeim (
         BuildMemoryAllocationHob (
           PcdGet64 (PcdFdBaseAddress),
           PcdGet32 (PcdFdSize),
-          EfiBootServicesData
+          PcdGet32 (PcdFdMemoryType) // MU_CHANGE
           );
 
         Found = TRUE;

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
@@ -39,6 +39,7 @@
 [FixedPcd]
   gArmTokenSpaceGuid.PcdFdBaseAddress
   gArmTokenSpaceGuid.PcdFdSize
+  gArmTokenSpaceGuid.PcdFdMemoryType # MU_CHANGE
 
   gArmPlatformTokenSpaceGuid.PcdSystemMemoryUefiRegionSize
 


### PR DESCRIPTION
## Description

Add the ability to configure the memory type used for the FD region on the non-secure UEFI side. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on internal platform build.

## Integration Instructions

N/A
