### PR TITLE
[CHERRY-PICK] Add the ability to configure the memory type used for the FD region

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -215,6 +215,10 @@
   gArmTokenSpaceGuid.PcdFdSize|0|UINT32|0x0000002C
   gArmTokenSpaceGuid.PcdFvSize|0|UINT32|0x0000002E
 
+
+  # MU_CHANGE: PCD To configure memory type used for FD region allocation. Defaults to EfiBootServicesData
+  gArmTokenSpaceGuid.PcdFdMemoryType|4|UINT32|0x1000046 # MU_CHANGE
+
   #
   # Value to add to a host address to obtain a device address, using
   # unsigned 64-bit integer arithmetic on both ARM and AArch64. This

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -181,7 +181,7 @@ MemoryPeim (
         BuildMemoryAllocationHob (
           PcdGet64 (PcdFdBaseAddress),
           PcdGet32 (PcdFdSize),
-          EfiBootServicesData
+          PcdGet32 (PcdFdMemoryType) // MU_CHANGE
           );
 
         Found = TRUE;

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
@@ -39,6 +39,7 @@
 [FixedPcd]
   gArmTokenSpaceGuid.PcdFdBaseAddress
   gArmTokenSpaceGuid.PcdFdSize
+  gArmTokenSpaceGuid.PcdFdMemoryType # MU_CHANGE
 
   gArmPlatformTokenSpaceGuid.PcdSystemMemoryUefiRegionSize
 


### PR DESCRIPTION
## Description

Add the ability to configure the memory type used for the FD region on the non-secure UEFI side.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on internal platform build.

## Integration Instructions

N/A

Cherry pick of https://github.com/microsoft/mu_silicon_arm_tiano/pull/140
