### PR TITLE
Remove `MDEPKG_NDEBUG` from DynamicTables.dsc.inc

### DIFF
--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -10,7 +10,8 @@
 [Defines]
 
 [BuildOptions]
-  RELEASE_*_*_CC_FLAGS     = -DMDEPKG_NDEBUG
+  # MU_CHANGE: should not enforce all consumers to disable debug prints in release builds
+  # RELEASE_*_*_CC_FLAGS     = -DMDEPKG_NDEBUG
 
 [LibraryClasses.common]
   AcpiHelperLib|DynamicTablesPkg/Library/Common/AcpiHelperLib/AcpiHelperLib.inf


### PR DESCRIPTION
## Description

The current build option inserted from `DynamicTables.dsc.inc` making the release build debug prints to be completely muted. This is undesirable when platforms would like to keep logging capabilities, i.e. advanced logger.

This change removes the build option that inserted the macro definition and leave the option to platform consumers.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on proprietary platforms that includes this file and confirmed release builds can print strings to serial port.

## Integration Instructions

N/A
