### PR TITLE
MemoryInitPei: Remove Non-RT Types from Mem Type Info HOB

### DIFF
--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
@@ -48,10 +48,6 @@
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiReservedMemoryType
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesData
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesCode
-  gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiBootServicesCode
-  gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiBootServicesData
-  gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderCode
-  gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderData
 
 [Pcd]
   gArmTokenSpaceGuid.PcdSystemMemoryBase

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
@@ -48,6 +48,12 @@
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiReservedMemoryType
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesData
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesCode
+  # MU_CHANGE [BEGIN] - Remove non-RT types from Mem Type Info Settings
+  # gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiBootServicesCode
+  # gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiBootServicesData
+  # gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderCode
+  # gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderData
+  # MU_CHANGE [END] - Remove non-RT types from Mem Type Info Settings
 
 [Pcd]
   gArmTokenSpaceGuid.PcdSystemMemoryBase

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.c
@@ -37,7 +37,7 @@ BuildMemoryTypeInformationHob (
   VOID
   )
 {
-  EFI_MEMORY_TYPE_INFORMATION  Info[10];
+  EFI_MEMORY_TYPE_INFORMATION  Info[6];
 
   Info[0].Type          = EfiACPIReclaimMemory;
   Info[0].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiACPIReclaimMemory);
@@ -49,18 +49,9 @@ BuildMemoryTypeInformationHob (
   Info[3].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiRuntimeServicesData);
   Info[4].Type          = EfiRuntimeServicesCode;
   Info[4].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiRuntimeServicesCode);
-  Info[5].Type          = EfiBootServicesCode;
-  Info[5].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiBootServicesCode);
-  Info[6].Type          = EfiBootServicesData;
-  Info[6].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiBootServicesData);
-  Info[7].Type          = EfiLoaderCode;
-  Info[7].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiLoaderCode);
-  Info[8].Type          = EfiLoaderData;
-  Info[8].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiLoaderData);
-
   // Terminator for the list
-  Info[9].Type          = EfiMaxMemoryType;
-  Info[9].NumberOfPages = 0;
+  Info[5].Type          = EfiMaxMemoryType;
+  Info[5].NumberOfPages = 0;
 
   BuildGuidDataHob (&gEfiMemoryTypeInformationGuid, &Info, sizeof (Info));
 }

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.c
@@ -37,6 +37,8 @@ BuildMemoryTypeInformationHob (
   VOID
   )
 {
+  // MU_CHANGE [BEGIN] - Remove non-RT types from Mem Type Info Settings
+
   EFI_MEMORY_TYPE_INFORMATION  Info[6];
 
   Info[0].Type          = EfiACPIReclaimMemory;
@@ -52,6 +54,8 @@ BuildMemoryTypeInformationHob (
   // Terminator for the list
   Info[5].Type          = EfiMaxMemoryType;
   Info[5].NumberOfPages = 0;
+
+  // MU_CHANGE [END] - Remove non-RT types from Mem Type Info Settings
 
   BuildGuidDataHob (&gEfiMemoryTypeInformationGuid, &Info, sizeof (Info));
 }

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.inf
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.inf
@@ -56,10 +56,6 @@
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiReservedMemoryType
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesData
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesCode
-  gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiBootServicesCode
-  gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiBootServicesData
-  gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderCode
-  gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderData
 
 [Pcd]
   gArmTokenSpaceGuid.PcdSystemMemoryBase

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.inf
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.inf
@@ -56,6 +56,12 @@
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiReservedMemoryType
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesData
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesCode
+  # MU_CHANGE [BEGIN] - Remove non-RT types from Mem Type Info Settings
+  # gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiBootServicesCode
+  # gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiBootServicesData
+  # gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderCode
+  # gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiLoaderData
+  # MU_CHANGE [END] - Remove non-RT types from Mem Type Info Settings
 
 [Pcd]
   gArmTokenSpaceGuid.PcdSystemMemoryBase

--- a/ArmVirtPkg/MemoryInitPei/MemoryInitPeim.c
+++ b/ArmVirtPkg/MemoryInitPei/MemoryInitPeim.c
@@ -33,6 +33,8 @@ BuildMemoryTypeInformationHob (
   VOID
   )
 {
+  // MU_CHANGE [BEGIN] - Remove non-RT types from Mem Type Info Settings
+
   EFI_MEMORY_TYPE_INFORMATION  Info[6];
 
   Info[0].Type          = EfiACPIReclaimMemory;
@@ -48,6 +50,8 @@ BuildMemoryTypeInformationHob (
   // Terminator for the list
   Info[5].Type          = EfiMaxMemoryType;
   Info[5].NumberOfPages = 0;
+
+  // MU_CHANGE [END] - Remove non-RT types from Mem Type Info Settings
 
   BuildGuidDataHob (&gEfiMemoryTypeInformationGuid, &Info, sizeof (Info));
 }

--- a/ArmVirtPkg/MemoryInitPei/MemoryInitPeim.c
+++ b/ArmVirtPkg/MemoryInitPei/MemoryInitPeim.c
@@ -33,30 +33,21 @@ BuildMemoryTypeInformationHob (
   VOID
   )
 {
-  EFI_MEMORY_TYPE_INFORMATION  Info[10];
+  EFI_MEMORY_TYPE_INFORMATION  Info[6];
 
   Info[0].Type          = EfiACPIReclaimMemory;
-  Info[0].NumberOfPages = FixedPcdGet32 (PcdMemoryTypeEfiACPIReclaimMemory);
+  Info[0].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiACPIReclaimMemory);
   Info[1].Type          = EfiACPIMemoryNVS;
-  Info[1].NumberOfPages = FixedPcdGet32 (PcdMemoryTypeEfiACPIMemoryNVS);
+  Info[1].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiACPIMemoryNVS);
   Info[2].Type          = EfiReservedMemoryType;
-  Info[2].NumberOfPages = FixedPcdGet32 (PcdMemoryTypeEfiReservedMemoryType);
+  Info[2].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiReservedMemoryType);
   Info[3].Type          = EfiRuntimeServicesData;
-  Info[3].NumberOfPages = FixedPcdGet32 (PcdMemoryTypeEfiRuntimeServicesData);
+  Info[3].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiRuntimeServicesData);
   Info[4].Type          = EfiRuntimeServicesCode;
-  Info[4].NumberOfPages = FixedPcdGet32 (PcdMemoryTypeEfiRuntimeServicesCode);
-  Info[5].Type          = EfiBootServicesCode;
-  Info[5].NumberOfPages = FixedPcdGet32 (PcdMemoryTypeEfiBootServicesCode);
-  Info[6].Type          = EfiBootServicesData;
-  Info[6].NumberOfPages = FixedPcdGet32 (PcdMemoryTypeEfiBootServicesData);
-  Info[7].Type          = EfiLoaderCode;
-  Info[7].NumberOfPages = FixedPcdGet32 (PcdMemoryTypeEfiLoaderCode);
-  Info[8].Type          = EfiLoaderData;
-  Info[8].NumberOfPages = FixedPcdGet32 (PcdMemoryTypeEfiLoaderData);
-
+  Info[4].NumberOfPages = PcdGet32 (PcdMemoryTypeEfiRuntimeServicesCode);
   // Terminator for the list
-  Info[9].Type          = EfiMaxMemoryType;
-  Info[9].NumberOfPages = 0;
+  Info[5].Type          = EfiMaxMemoryType;
+  Info[5].NumberOfPages = 0;
 
   BuildGuidDataHob (&gEfiMemoryTypeInformationGuid, &Info, sizeof (Info));
 }


### PR DESCRIPTION
## Description

MemoryInitPei: Remove Non-RT Types from Mem Type Info HOB

Removes the following types from the memory type information HOBs
produced in the MemoryInitPei modules in ArmPlatformPkg and ArmVirtPkg.

- `EfiBootServicesCode`
- `EfiBootServicesData`
- `EfiLoaderCode`
- `EfiLoaderData`

When the memory type information UEFI variable is updated in BDS,
it goes through the common variable check code attached to the UEFI
variable driver which explicitly checks the size of the variable data
to determine if the variable update is valid.

MemoryTypeInfoVarCheckHandler () in
MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.c.

The size here is `0x50` instead of the expected size of `0x30`. It
is not common to place non-runtime memory types in the memory type
information HOB so the types are removed from the HOB published
here to align with typical code expectations.

UEFI variable update error:

```
  ERROR: MemoryTypeInfoVarCheckHandler() - DataSize = 0x50 Expected = 0x30
  Variable Check handler fail Security Violation -
    4C19049F-4137-4DD3-9C10-8B97A83FFDFA:MemoryTypeInformation
  Memory Type Information settings cannot be saved. OS S4 may fail!
```

Some Arm platforms may use a different UEFI variable driver that does
not perform this check. If the types are truly needed, the variable
check code should be updated to compensate for them.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- ArmPlatformPkg build and CI
- ArmVirtPkg build and CI
- QemuSbsaPkg build and boot to EFI shell with test apps

## Integration Instructions

Review code to determine if either of these PEIMs (`MemoryInitPeim`).
If so, whether code was dependent on the memory types in the memory
type information HOB that were removed to determine if further changes
are needed.