### PR TITLE
ArmPkg/Drivers/CpuDxe: Cast table entry

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -11,7 +11,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 --*/
 
 #include <Library/MemoryAllocationLib.h>
-#include <Library/SafeIntLib.h>         // MU_CHANGE: Convert integers safely
 #include <Chipset/AArch64Mmu.h>         // MU_CHANGE: Include header used in file
 #include "CpuDxe.h"
 
@@ -168,16 +167,10 @@ GetNextEntryAttribute (
   for (Index = 0; Index < EntryCount; Index++) {
     Entry = TableAddress[Index];
 
-    // MU_CHANGE [BEGIN]: Convert integers safely
-    Status = SafeUint64ToUint32 (Entry, &EntryType);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "[%a] - Table address entry exceeds 32-bit.\n", __func__));
-      return 0;
-    }
-
-    EntryAttribute = EntryType & TT_ATTRIBUTES_MASK;  // MU_CHANGE: Return all attributes from page table
-    EntryType     &= TT_TYPE_MASK;
-    // MU_CHANGE [END]: Convert integers safely
+    // MU_CHANGE [BEGIN]: Add UINT32 cast
+    EntryType      = (UINT32)(Entry & TT_TYPE_MASK);
+    EntryAttribute = (UINT32)(Entry & TT_ATTRIBUTES_MASK);  // MU_CHANGE: Return all attributes from page table
+    // MU_CHANGE [END]: Add UINT32 cast
 
     // If Entry is a Table Descriptor type entry then go through the sub-level table
     if ((EntryType == TT_TYPE_BLOCK_ENTRY) ||

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
@@ -50,7 +50,6 @@
   HobLib
   MemoryAllocationLib
   PeCoffGetEntryPointLib
-  SafeIntLib                # MU_CHANGE: Convert integers safely
   UefiDriverEntryPoint
   UefiLib
   DxeMemoryProtectionHobLib # MU_CHANGE


### PR DESCRIPTION
## Description

Casts the table entry as a 32-bit integer since the value may be
larger than 32-bit. A cast is needed to prevent a compiler warning.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- ArmPkg build
- Virtual platform boot

## Integration Instructions

N/A