### PR TITLE
Backport Visual Studio Fixes to Release/202102 [Rebase & FF] 

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -11,6 +11,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 --*/
 
 #include <Library/MemoryAllocationLib.h>
+#include <Library/SafeIntLib.h>         // MU_CHANGE: Convert integers safely
+#include <Chipset/AArch64Mmu.h>         // MU_CHANGE: Include header used in file
 #include "CpuDxe.h"
 
 #define INVALID_ENTRY   ((UINT32)~0)
@@ -123,8 +125,16 @@ GetNextEntryAttribute (
 
   // Get the memory space map from GCD
   MemorySpaceMap = NULL;
-  Status = gDS->GetMemorySpaceMap (&NumberOfDescriptors, &MemorySpaceMap);
-  ASSERT_EFI_ERROR (Status);
+  Status         = gDS->GetMemorySpaceMap (&NumberOfDescriptors, &MemorySpaceMap);
+  // MU_CHANGE [BEGIN]: Check if the memory space map is valid
+  if (EFI_ERROR (Status)) {
+    // This function needs to define what is returned when an error occurs.
+    // Callers need to actually check the return value and add error handling.
+    ASSERT_EFI_ERROR (Status);
+    return 0;
+  }
+
+  // MU_CHANGE [END]: Check if the memory space map is valid
 
   // We cannot get more than 3-level page table
   ASSERT (TableLevel <= 3);
@@ -133,8 +143,17 @@ GetNextEntryAttribute (
   // the subsequent ones should be filled up
   for (Index = 0; Index < EntryCount; Index++) {
     Entry = TableAddress[Index];
-    EntryType = Entry & TT_TYPE_MASK;
-    EntryAttribute = Entry  & TT_ATTR_INDX_MASK;
+
+    // MU_CHANGE [BEGIN]: Convert integers safely
+    Status = SafeUint64ToUint32 (Entry, &EntryType);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "[%a] - Table address entry exceeds 32-bit.\n", __func__));
+      return 0;
+    }
+
+    EntryAttribute = EntryType & TT_ATTRIBUTES_MASK;  // MU_CHANGE: Return all attributes from page table
+    EntryType     &= TT_TYPE_MASK;
+    // MU_CHANGE [END]: Convert integers safely
 
     // If Entry is a Table Descriptor type entry then go through the sub-level table
     if ((EntryType == TT_TYPE_BLOCK_ENTRY) ||

--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -11,7 +11,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 --*/
 
 #include <Library/MemoryAllocationLib.h>
-#include <Library/SafeIntLib.h>         // MU_CHANGE: Convert integers safely
 #include <Chipset/AArch64Mmu.h>         // MU_CHANGE: Include header used in file
 #include "CpuDxe.h"
 
@@ -144,16 +143,10 @@ GetNextEntryAttribute (
   for (Index = 0; Index < EntryCount; Index++) {
     Entry = TableAddress[Index];
 
-    // MU_CHANGE [BEGIN]: Convert integers safely
-    Status = SafeUint64ToUint32 (Entry, &EntryType);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "[%a] - Table address entry exceeds 32-bit.\n", __func__));
-      return 0;
-    }
-
-    EntryAttribute = EntryType & TT_ATTRIBUTES_MASK;  // MU_CHANGE: Return all attributes from page table
-    EntryType     &= TT_TYPE_MASK;
-    // MU_CHANGE [END]: Convert integers safely
+    // MU_CHANGE [BEGIN]: Add UINT32 cast
+    EntryType      = (UINT32)(Entry & TT_TYPE_MASK);
+    EntryAttribute = (UINT32)(Entry & TT_ATTRIBUTES_MASK);  // MU_CHANGE: Return all attributes from page table
+    // MU_CHANGE [END]: Add UINT32 cast
 
     // If Entry is a Table Descriptor type entry then go through the sub-level table
     if ((EntryType == TT_TYPE_BLOCK_ENTRY) ||

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
@@ -49,7 +49,6 @@
   DxeServicesTableLib
   HobLib
   PeCoffGetEntryPointLib
-  SafeIntLib                # MU_CHANGE: Convert integers safely
   UefiDriverEntryPoint
   UefiLib
 

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
@@ -49,6 +49,7 @@
   DxeServicesTableLib
   HobLib
   PeCoffGetEntryPointLib
+  SafeIntLib                # MU_CHANGE: Convert integers safely
   UefiDriverEntryPoint
   UefiLib
 

--- a/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuPeiLibConstructor.c
+++ b/ArmPkg/Library/ArmMmuLib/AArch64/ArmMmuPeiLibConstructor.c
@@ -12,6 +12,8 @@
 #include <Library/ArmMmuLib.h>
 #include <Library/CacheMaintenanceLib.h>
 #include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include "ArmMmuLibInternal.h"  // MU_CHANGE: Add function pointer type
 
 EFI_STATUS
 EFIAPI
@@ -20,12 +22,21 @@ ArmMmuPeiLibConstructor (
   IN CONST EFI_PEI_SERVICES          **PeiServices
   )
 {
-  extern UINT32             ArmReplaceLiveTranslationEntrySize;
+  // MU_CHANGE [BEGIN]: Add function pointer type
+  extern UINT32                       ArmReplaceLiveTranslationEntrySize;
+  ARM_REPLACE_LIVE_TRANSLATION_ENTRY  ArmReplaceLiveTranslationEntryFunc;
+  VOID                                *Hob;
+  // MU_CHANGE [END]: Add function pointer type
 
   EFI_FV_FILE_INFO          FileInfo;
   EFI_STATUS                Status;
 
-  ASSERT (FileHandle != NULL);
+  // MU_CHANGE [BEGIN]: Add basic function parameter validation
+  if ((FileHandle == NULL) || (PeiServices == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // MU_CHANGE [END]: Add basic function parameter validation
 
   Status = (*PeiServices)->FfsGetFileInfo (FileHandle, &FileInfo);
   ASSERT_EFI_ERROR (Status);

--- a/ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
+++ b/ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
@@ -19,11 +19,13 @@
   CONSTRUCTOR                    = ArmMmuBaseLibConstructor
 
 [Sources.AARCH64]
+  ArmMmuLibInternal.h                 # MU_CHANGE: Add function pointer type
   AArch64/ArmMmuLibCore.c
   AArch64/ArmMmuLibReplaceEntry.S    | GCC
   AArch64/ArmMmuLibReplaceEntry.masm | MSFT
 
 [Sources.ARM]
+  ArmMmuLibInternal.h                 # MU_CHANGE: Add function pointer type
   Arm/ArmMmuLibConvert.c
   Arm/ArmMmuLibCore.c
   Arm/ArmMmuLibUpdate.c

--- a/ArmPkg/Library/ArmMmuLib/ArmMmuLibInternal.h
+++ b/ArmPkg/Library/ArmMmuLib/ArmMmuLibInternal.h
@@ -1,0 +1,23 @@
+/** @file
+  Arm MMU library instance internal header file.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  MU_CHANGE [WHOLE FILE]: Add function pointer type
+**/
+
+#ifndef ARM_MMU_LIB_INTERNAL_H_
+#define ARM_MMU_LIB_INTERNAL_H_
+
+typedef
+VOID(
+ EFIAPI  *ARM_REPLACE_LIVE_TRANSLATION_ENTRY
+ )(
+  IN  UINT64  *Entry,
+  IN  UINT64  Value,
+  IN  UINT64  RegionStart,
+  IN  BOOLEAN DisableMmu
+  );
+
+#endif

--- a/ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
+++ b/ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
@@ -17,6 +17,7 @@
   CONSTRUCTOR                    = ArmMmuPeiLibConstructor
 
 [Sources.AARCH64]
+  ArmMmuLibInternal.h                 # MU_CHANGE: Add function pointer type
   AArch64/ArmMmuLibCore.c
   AArch64/ArmMmuPeiLibConstructor.c
   AArch64/ArmMmuLibReplaceEntry.S       | GCC


### PR DESCRIPTION
## Description

Two fixes to improve overall code and Visual Studio compatibility:

---

**ArmPkg: Fix pointer type errors**

The code tries to use a data pointer type for a function pointer and
Visual Studio doesn't like it.

Fixes this warning:
  `nonstandard extension, function/data pointer conversion in expression`

This change represents the function pointer with the appropriate type
(instead of `VOID*`) and defines the type with a typedef for code
clarity.

A minor change is added to also validate function pointer parameters
in an already modified function to generally improve its robustness.

Some practices like adding a function description are not added
because the function prototype is from `ArmMmuLib` which doesn't
currently have function descriptions and adding them is outside the
scope of the compiler fix being added in this change.

---

**ArmPkg/Drivers/CpuDxe: Check integer before conversion**

`GetNextEntryAttribute()` assigns a 64-bit integer to 32-bit integers.
This change checks that the value fits in a 32-bit integer and
fixes the following Visual Studio compiler warning:

`'=': conversion from 'UINT64' to 'UINT32', possible loss of data`

---

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Visual Studio 2019/2022 build using `stuart_ci_build -c .pytool/CISettings.py TOOL_CHAIN_TAG=<VS2019 | VS2022>`

Had to make the following changes which are not included in this PR

Update the ArmPkg.ci.yaml with the following:
```inf
   "CompilerPlugin": {
        "DscPath": "ArmPkg.dsc"
   },
```

Trim down CiSettings.py to only build AARCH64
```diff
-        return (
-                "IA32",
-                "X64",
-                "ARM",
-                "AARCH64")
+        return ("AARCH64")
```

Init the ArmSoftFloatLib submodule
```bash
git submodule init
git submodule update
```

Add the ArmSoftFloatLib to the ArmPkg.dsc
```diff
 [LibraryClasses.common]
+  ArmSoftFloatLib|ArmPkg/Library/ArmSoftFloatLib/ArmSoftFloatLib.inf
```
## Integration Instructions

No special work other than picking up the changes.