### PR TITLE
.git-blame-ignore-revs: Ignore Line Ending and Uncrustify only commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,29 @@
+###################################################
+# Line Ending Only Changes                        #
+###################################################
+# Convert line endings from LF to CRLF
+bb0004b35a10882e355889df37e2ecdcc8b5fcc7
+# ArmPlatformPkg: convert LFs to CRLF, expand hard TABs
+e63d54db952634c2a3a6a24b6c2a4c6ff66f22bd
+# ArmVirtPkg: convert LFs to CRLF
+a5c2ce7cd136ee959951c5f220ff5d3018d4ac3b
+# ArmPkg: convert LFs to CRLF, expand hard TABs
+11ceb258f36fa5669badbac44ae4755d9885796a
+# ArmPlatformPkg: CRLF fixups for Juno ACPI
+ae52e921c493666014166682e24654e9df5b1457
+# ArmPlatformPkg/ArmVExpressPkg: Fixed line endings to be CRLF
+f66eab9b9c9ef78e74658e087fe9f711a62fd401
+# ARM Packages: CRLF fixup
+e6f3ed43400bc9d02ff3e2728579cc9f35f71405
+
+###################################################
+# Code Formatting (Uncrustify) Only Changes       #
+###################################################
+# DynamicTablesPkg: Apply uncrustify changes
+731c67e1d77b7741a91762d17659fc9fbcb9e305
+# ArmVirtPkg: Apply uncrustify changes
+2b16a4fb91b9b31c0d152588f5ac51080c6c0763
+# ArmPlatformPkg: Apply uncrustify changes
+40b0b23ed34f48c26d711d3e4613a4bb35eeadff
+# ArmPkg: Apply uncrustify changes
+429309e0c6b74792d679681a8edd0d5ae0ff850c


### PR DESCRIPTION
## Description


Adds commits that only applied Uncrustify formatting or converted
line endings to a .git-blame-ignore-revs file so they are ignored
by git blame. This is supported by GitHub:
https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/

This helps clean up git blame by filtering out these changes.

Note: This file needs to be updated on rebase branches. Processes
      like filter-branch can automatically update relevant SHAs.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- `git blame`

## Integration Instructions

N/A