### PR TITLE
Implement Memory Attribute Protocol Installation Policy Option

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
@@ -327,14 +327,26 @@ CpuDxeInitialize (
   //
   RemapUnusedMemoryNx ();
 
+  // MU_CHANGE [START]: Only install Memory Attribute Protocol if policy is enabled
   Status = gBS->InstallMultipleProtocolInterfaces (
                   &mCpuHandle,
                   &gEfiCpuArchProtocolGuid,
                   &mCpu,
-                  &gEfiMemoryAttributeProtocolGuid,
-                  &mMemoryAttribute,
+                  // &gEfiMemoryAttributeProtocolGuid,
+                  // &mMemoryAttribute,
                   NULL
                   );
+
+  if (gDxeMps.InstallMemoryAttributeProtocol) {
+    Status = gBS->InstallMultipleProtocolInterfaces (
+                    &mCpuHandle,
+                    &gEfiMemoryAttributeProtocolGuid,
+                    &mMemoryAttribute,
+                    NULL
+                    );
+  }
+
+  // MU_CHANGE [END]
 
   //
   // Make sure GCD and MMU settings match. This API calls gDS->SetMemorySpaceAttributes ()

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
@@ -336,6 +336,7 @@ CpuDxeInitialize (
                   // &mMemoryAttribute,
                   NULL
                   );
+  ASSERT_EFI_ERROR (Status);
 
   if (gDxeMps.InstallMemoryAttributeProtocol) {
     Status = gBS->InstallMultipleProtocolInterfaces (
@@ -344,6 +345,9 @@ CpuDxeInitialize (
                     &mMemoryAttribute,
                     NULL
                     );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Failed to install Memory Attribute Protocol!\n"));
+    }
   }
 
   // MU_CHANGE [END]


### PR DESCRIPTION
## Description

Linux shim currently incorrectly uses the UEFI memory attribute protocol
causing a fault. The broken shim does not have the NXCOMPAT
flag, so compatibility mode can be used to uninstall the protocol
when it is loaded. For flexibility, this patch implements the policy
configuration option to allow ARM platforms to choose not to install the
protocol.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on SBSA by running the DxePagingAuditTestApp with the protocol policy set to TRUE and FALSE

## Integration Instructions

N/A
