### PR TITLE
[CHERRY-PICK] [REBASE & FF] Fix CodeQL Issues in AmlLib and PL061GPIO

### DIFF
--- a/ArmPlatformPkg/Drivers/PL061GpioDxe/PL061Gpio.c
+++ b/ArmPlatformPkg/Drivers/PL061GpioDxe/PL061Gpio.c
@@ -34,7 +34,7 @@ PL061Locate (
   OUT UINTN              *RegisterBase
   )
 {
-  UINT32  Index;
+  UINTN  Index; // MU_CHANGE CodeQL
 
   for (Index = 0; Index < mPL061PlatformGpio->GpioControllerCount; Index++) {
     if (  (Gpio >= mPL061PlatformGpio->GpioController[Index].GpioIndex)

--- a/DynamicTablesPkg/Library/Common/AmlLib/AmlEncoding/Aml.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/AmlEncoding/Aml.c
@@ -774,7 +774,7 @@ AmlSetPkgLength (
   // Write to the Buffer.
   *Buffer       = LeadByte;
   CurrentOffset = 1;
-  while (CurrentOffset < (Offset + 1)) {
+  while (CurrentOffset < (Offset + (UINT8)1)) { // MU_CHANGE CodeQL
     CurrentShift              = (UINT8)((CurrentOffset - 1) * 8);
     ComputedLength            = Length & (UINT32)(0x00000FF0 << CurrentShift);
     ComputedLength            = (ComputedLength) >> (4 + CurrentShift);


### PR DESCRIPTION
## Description

Both of these components failed a CodeQL check for comparing non-equal width types in a loop. This fixes the issue.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Confirmed CI passed.

## Integration Instructions

N/A.
