### PR TITLE
[CHERRY-PICK] Fix up the MmuLib logic as we move to use generic interface (#191)

### DIFF
--- a/ArmPkg/Library/MmuLib/MmuLib.c
+++ b/ArmPkg/Library/MmuLib/MmuLib.c
@@ -59,7 +59,7 @@ MmuSetAttributes (
     Attributes &= ~EFI_MEMORY_RO;
   }
 
-  ASSERT (Attributes == 0);
+  // MU_CHANGE - END
   ASSERT_EFI_ERROR (Status);
   return Status;
 }


### PR DESCRIPTION
Please ensure you have read the [contribution
docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior to submitting the pull request. In particular,
[pull request
guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

Upstream change removed declaration of specific individual interfaces and moved to use the common interface `ArmSetMemoryAttributes`. This change accommodates the MU_CHANGE with needed functions inside MmuLib.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- **Functionality** - Does the change ultimately impact how firmware functions?
- Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
- **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter validation improvement, ...
- [ ] Breaking change?
- **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
- Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
- **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
- Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

Tested bootable on QEMU SBSA.

N/A

(cherry picked from commit 62905b3c70f66e927a003195068ea0b10cea7360)
