### PR TITLE
[Rebase & FF] [Cherry-pick] Get all the missing commits from 202302 into 202311

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
@@ -329,14 +329,30 @@ CpuDxeInitialize (
   //
   RemapUnusedMemoryNx ();
 
+  // MU_CHANGE [START]: Only install Memory Attribute Protocol if policy is enabled
   Status = gBS->InstallMultipleProtocolInterfaces (
                   &mCpuHandle,
                   &gEfiCpuArchProtocolGuid,
                   &mCpu,
-                  &gEfiMemoryAttributeProtocolGuid,
-                  &mMemoryAttribute,
+                  // &gEfiMemoryAttributeProtocolGuid,
+                  // &mMemoryAttribute,
                   NULL
                   );
+  ASSERT_EFI_ERROR (Status);
+
+  if (gDxeMps.InstallMemoryAttributeProtocol) {
+    Status = gBS->InstallMultipleProtocolInterfaces (
+                    &mCpuHandle,
+                    &gEfiMemoryAttributeProtocolGuid,
+                    &mMemoryAttribute,
+                    NULL
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Failed to install Memory Attribute Protocol!\n"));
+    }
+  }
+
+  // MU_CHANGE [END]
 
   //
   // Make sure GCD and MMU settings match. This API calls gDS->SetMemorySpaceAttributes ()

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,8 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.19.8
-edk2-pytool-extensions~=0.26.4
+edk2-pytool-library~=0.20.0
+edk2-pytool-extensions~=0.27.0
 edk2-basetools==0.1.49
 antlr4-python3-runtime==4.13.1
 lcov-cobertura==2.0.2


### PR DESCRIPTION
## Description

Cherry-pick the commits from 202302 that are missing from 202311 since the creation of the release branch.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

N/A
