### PR TITLE
Remove print in AdvLogger path causing infinite recursion.

### DIFF
--- a/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
+++ b/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
@@ -420,16 +420,6 @@ ArmSetMemoryAttributes (
   EFI_STATUS  Status;
   UINT64      NeededAttributes;
 
-  DEBUG ((
-    DEBUG_INFO,
-    "%a: BaseAddress == 0x%llx, Length == 0x%llx, Attributes == 0x%llx, Mask == 0x%llx\n",
-    __FUNCTION__,
-    BaseAddress,
-    Length,
-    Attributes,
-    AttributeMask
-    ));
-
   NeededAttributes = Attributes & AttributeMask;
 
   if ((Length == 0) ||


### PR DESCRIPTION
## Description

Removes a print that is in the AdvLogger initialization path that is causing infinite recursion as the print will reenter the AdvLogger initialization code. This code unfortunately cannot be made reentrant safe as at the time of calling the data sections are not guaranteed to be writable without first calling this routine, so the only clean solution is to remove this print.

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested boot manually.

## Integration Instructions

N/A
