### PR TITLE
Fixing the target list to support GIC v3 and above

### DIFF
--- a/ArmPkg/Drivers/ArmGic/ArmGicLib.c
+++ b/ArmPkg/Drivers/ArmGic/ArmGicLib.c
@@ -150,7 +150,7 @@ EFIAPI
 ArmGicSendSgiTo (
   IN  UINTN  GicDistributorBase,
   IN  UINT8  TargetListFilter,
-  IN  UINT8  CPUTargetList,
+  IN  UINTN  CPUTargetList, // MU_CHANGE: Changed from UINT8 to UINTN to support GIC v3+
   IN  UINT8  SgiId
   )
 {

--- a/ArmPkg/Include/Library/ArmGicLib.h
+++ b/ArmPkg/Include/Library/ArmGicLib.h
@@ -225,7 +225,7 @@ EFIAPI
 ArmGicSendSgiTo (
   IN  UINTN  GicDistributorBase,
   IN  UINT8  TargetListFilter,
-  IN  UINT8  CPUTargetList,
+  IN  UINTN  CPUTargetList, // MU_CHANGE: Changed from UINT8 to UINTN to support GIC v3+
   IN  UINT8  SgiId
   );
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The edk2 change recently updated the CPU target list to be UINT8 only. However, when it comes to GIC v3 and above, we need to prepare the register value from the MPIDR value of the target core, which is a UINTN.

This change update the edk2 change to remain the expectation of GIC v3+ usage.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on QEMU SBSA and proprietary physical platforms.

## Integration Instructions

N/A
