### PR TITLE
Install Empty GCD Sync Protocol After SyncCacheConfig()

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
@@ -375,6 +375,15 @@ CpuDxeInitialize (
   SyncCacheConfig (&mCpu);
   mIsFlushingGCD = FALSE;
 
+  // MU_CHANGE START: Install blank protocol to signal the end of the GCD sync
+  gBS->InstallMultipleProtocolInterfaces (
+         &ImageHandle,
+         &gEdkiiGcdSyncCompleteProtocolGuid,
+         NULL,
+         NULL
+         );
+  // MU_CHANGE END
+
   //
   // Setup a callback for idle events
   //

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
@@ -60,6 +60,7 @@
   gEfiCpuArchProtocolGuid
   gEfiMemoryAttributeProtocolGuid
   gArmPageTableMemoryAllocationProtocolGuid ## MU_CHANGE: PRODUCES
+  gEdkiiGcdSyncCompleteProtocolGuid         ## MU_CHANGE: PRODUCES
 
 [Guids]
   gEfiDebugImageInfoTableGuid


### PR DESCRIPTION
## Description

With the addition of the following commit in MU_BASECORE, the ordering of memory protection initialization and the GCD sync has been flipped so the GCD sync occurs first: https://github.com/microsoft/mu_basecore/commit/144e3fe63244e0dfb14a6442dd969dd2757e844e

This reverse ordering was done to support RP on free memory because if the initialization was done first then the allocate memory calls during GCD sync would cause page faults because the attributes cannot be changed during the syncing process.

This PR installs the GCD sync complete protocol so the memory protection initialization routine is signaled.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by booting SBSA to shell with RP on free memory active

## Integration Instructions

N/A