### PR TITLE
[Rebase & FF] Adding support to build with CLANGPDB

### DIFF
--- a/ArmPkg/Include/AsmMacroIoLib.h
+++ b/ArmPkg/Include/AsmMacroIoLib.h
@@ -12,12 +12,22 @@
 #ifndef ASM_MACRO_IO_LIB_H_
 #define ASM_MACRO_IO_LIB_H_
 
+#ifndef __clang__ // MU_CHANGE
 #define _ASM_FUNC(Name, Section)    \
   .global   Name                  ; \
   .section  #Section, "ax"        ; \
   .type     Name, %function       ; \
   .p2align  2                     ; \
   Name:
+// MU_CHANGE Starts: CLANGPDB support
+#else
+#define _ASM_FUNC(Name, Section)    \
+  .global   Name                  ; \
+  .section  #Section, "ax"        ; \
+  .p2align  2                     ; \
+  Name:
+#endif
+// MU_CHANGE Ends
 
 #define ASM_FUNC(Name)  _ASM_FUNC(ASM_PFX(Name), .text. ## Name)
 

--- a/ArmPkg/Include/AsmMacroIoLibV8.h
+++ b/ArmPkg/Include/AsmMacroIoLibV8.h
@@ -103,13 +103,24 @@ bgt    %b6                  __CR__ \
 
 #if !defined (_MSC_VER)
 
+#ifndef __clang__ // MU_CHANGE
 #define _ASM_FUNC(Name, Section)    \
   .global   Name                  ; \
   .section  #Section, "ax"        ; \
   .type     Name, %function       ; \
   Name:                           ; \
   AARCH64_BTI(c)
+// MU_CHANGE Starts: CLANGPDB support
+#else
+#define _ASM_FUNC(Name, Section)    \
+  .global   Name                  ; \
+  .section  #Section, "ax"        ; \
+  Name:                           ; \
+  AARCH64_BTI(c)
+#endif
+// MU_CHANGE Ends
 
+#ifndef __clang__ // MU_CHANGE
 #define _ASM_FUNC_ALIGN(Name, Section, Align)       \
   .global   Name                                  ; \
   .section  #Section, "ax"                        ; \
@@ -117,6 +128,16 @@ bgt    %b6                  __CR__ \
   .balign   Align                                 ; \
   Name:                                           ; \
   AARCH64_BTI(c)
+// MU_CHANGE Starts: CLANGPDB support
+#else
+#define _ASM_FUNC_ALIGN(Name, Section, Align)       \
+  .global   Name                                  ; \
+  .section  #Section, "ax"                        ; \
+  .balign   Align                                 ; \
+  Name:                                           ; \
+  AARCH64_BTI(c)
+#endif
+// MU_CHANGE Ends
 
 #define ASM_FUNC(Name)  _ASM_FUNC(ASM_PFX(Name), .text. ## Name)
 

--- a/ArmPkg/Include/Chipset/AArch64.h
+++ b/ArmPkg/Include/Chipset/AArch64.h
@@ -139,9 +139,18 @@
 #define VECTOR_ENTRY(tbl, off)    \
   .org off
 
+#ifndef __clang__ // MU_CHANGE
 #define VECTOR_END(tbl)           \
   .org 0x800;                     \
   .previous
+// MU_CHANGE Starts: CLANGPDB support
+#else
+#define VECTOR_END(tbl)           \
+  .org 0x800;                     \
+  .section .text.##tbl##,"ax";    \
+  .align 3
+#endif
+// MU_CHANGE Ends
 
 #else
 

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/TableHelperLib.inf
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/TableHelperLib.inf
@@ -25,3 +25,7 @@
 
 [LibraryClasses]
   BaseLib
+# MU_CHANGE Starts
+  AmlLib
+  MemoryAllocationLib
+# MU_CHANGE Ends


### PR DESCRIPTION
## Description

The CLANGPDB does not support directives such as `.type` and `.size`. This change removes them from the macro definitions when building with CLANGPDB.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on QEMU SBSA and booted to UEFI Shell.

## Integration Instructions

N/A