### PR TITLE
[2405] ArmPkg: GICv3: Fix ARM_GICD_IROUTER incorrect writes for SPIs

### DIFF
--- a/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
+++ b/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
@@ -457,7 +457,10 @@ GicV3DxeInitialize (
     }
 
     // Route the SPIs to the primary CPU. SPIs start at the INTID 32
-    for (Index = 0; Index < (mGicNumInterrupts - 32); Index++) {
+    // MU_CHANGE - SPIs per the GICv3 spec start at line 32, but the previous code
+    // relied on ARM_GICD_IROUTER to be a value different than the spec that
+    // skipped those first 32 lines.
+    for (Index = 32; Index < mGicNumInterrupts; Index++) {
       MmioWrite64 (
         mGicDistributorBase + ARM_GICD_IROUTER + (Index * 8),
         (UINT32)CpuTarget   // MU_CHANGE - ARM64 VS change

--- a/ArmPkg/Include/Library/ArmGicLib.h
+++ b/ArmPkg/Include/Library/ArmGicLib.h
@@ -37,7 +37,11 @@
 #define ARM_GIC_ICDSGIR  0xF00        // Software Generated Interrupt Register
 
 // GICv3 specific registers
-#define ARM_GICD_IROUTER  0x6100       // Interrupt Routing Registers
+// MU_CHANGE - This was 0x6100 before, which skips past the reserved lines but
+// requires subtracting 32 from every single usage programming this register as
+// the GICv3 spec defines it as 0x6000. Change it back to the specification
+// value.
+#define ARM_GICD_IROUTER  0x6000       // Interrupt Routing Registers
 
 // GICD_CTLR bits
 #define ARM_GIC_ICDDCR_ARE  (1 << 4)     // Affinity Routing Enable (ARE)


### PR DESCRIPTION
## Description

Fix ARM_GICD_IROUTER incorrect writes, SPIs start at 32, not that the highest 32 lines aren't available.
Fix ARM_GICD_IROUTER define to match GICv3 spec.

Cherry-picked from 575f1ce052.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.
