### PR TITLE
ArmPlatformPkg: Update LcdHwNullLib to prevent init

### DIFF
--- a/ArmPlatformPkg/Library/LcdHwNullLib/LcdHwNullLib.c
+++ b/ArmPlatformPkg/Library/LcdHwNullLib/LcdHwNullLib.c
@@ -23,7 +23,7 @@ LcdIdentify (
   VOID
   )
 {
-  return EFI_SUCCESS;
+  return EFI_NOT_FOUND;   // MU_CHANGE TCBZ3351 - Prevent further LCD init.
 }
 
 /**


### PR DESCRIPTION
## Description

Library previously returned EFI_SUCCESS which causes the platform to continue initializing LCD HW. Should return EFI_NOT_FOUND.

Fixes TCBZ3351.

Cherry-picked from: 1c2b9430af.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.
