### PR TITLE
[CHERRY-PICK] StandaloneMmCpu: Support MM Communication call from EL3

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -234,6 +234,10 @@
   #
   gArmTokenSpaceGuid.PcdUefiShellDefaultBootEnable|FALSE|BOOLEAN|0x0000052
 
+
+  # MU_CHANGE ARM_CP_997351F8E3
+  gArmTokenSpaceGuid.PcdArmMmCommunicateFromEl3Workaround|FALSE|BOOLEAN|0x1000045
+
 [PcdsFixedAtBuild.common, PcdsPatchableInModule.common]
   gArmTokenSpaceGuid.PcdFdBaseAddress|0|UINT64|0x0000002B
   gArmTokenSpaceGuid.PcdFvBaseAddress|0|UINT64|0x0000002D

--- a/ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
+++ b/ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
@@ -47,5 +47,10 @@
   gEfiStandaloneMmNonSecureBufferGuid
   gEfiMmCpuDriverEpDescriptorGuid
 
+# MU_CHANGE ARM_CP_997351F8E3 [BEGIN]
+[Pcd]
+  gArmTokenSpaceGuid.PcdArmMmCommunicateFromEl3Workaround
+# MU_CHANGE ARM_CP_997351F8E3 [END]
+
 [Depex]
   TRUE


### PR DESCRIPTION
## Description

The MM Communication call from Normal world (EL2) to the StandaloneMM secure partition uses to PLAT_SP_IMAGE_NS_BUF_BASE buffer. This buffer is shared memory between Normal world and S-EL0. The MM communication call from EL3 to S-EL0 uses PLAT_SPM_BUF_BASE buffer.

So checking the base address to that of the base address of the shared memory between normal world and S-EL0 is not correct and not of much use either. So remove this check.

Signed-off-by: Omkar Anand Kulkarni <omkar.kulkarni@arm.com>
Change-Id: I8b697c03528e21223c177a07fc642f01473c3e8b (cherry picked from commit 997351f8e30ec5e352750908e113a2b50cdc18bd)

This is from a public ARM branch of edk2, but cherry-picked from release/202311 commit eb95bb43d6.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.
