### PR TITLE
[2405] ArmPlatformPkg: PL011UartLib: Do Not Block Waiting for RX Traffic

### DIFF
--- a/ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.c
+++ b/ArmPlatformPkg/Library/PL011UartLib/PL011UartLib.c
@@ -435,6 +435,24 @@ PL011UartWrite (
   return NumberOfBytes;
 }
 
+// MU_CHANGE Starts: Do not wait indefinitely for the receive buffer to get filled.
+
+/**
+  Check to see if any data is available to be read from the debug device.
+
+  @retval TRUE       At least one byte of data is available to be read
+  @retval FALSE      No data is available to be read
+
+**/
+BOOLEAN
+EFIAPI
+PL011UartPoll (
+  IN  UINTN  UartBase
+  )
+{
+  return ((MmioRead32 (UartBase + UARTFR) & UART_RX_EMPTY_FLAG_MASK) == 0);
+}
+
 /**
   Read data from serial device and save the data in buffer.
 
@@ -455,28 +473,15 @@ PL011UartRead (
 {
   UINTN  Count;
 
-  for (Count = 0; Count < NumberOfBytes; Count++, Buffer++) {
-    while ((MmioRead32 (UartBase + UARTFR) & UART_RX_EMPTY_FLAG_MASK) != 0) {
-    }
+  // for (Count = 0; Count < NumberOfBytes; Count++, Buffer++) {
+  //   while ((MmioRead32 (UartBase + UARTFR) & UART_RX_EMPTY_FLAG_MASK) != 0) {
+  //   }
 
+  for (Count = 0; (Count < NumberOfBytes) && PL011UartPoll (UartBase); Count++, Buffer++) {
     *Buffer = MmioRead8 (UartBase + UARTDR);
   }
 
-  return NumberOfBytes;
-}
+  return Count;
 
-/**
-  Check to see if any data is available to be read from the debug device.
-
-  @retval TRUE       At least one byte of data is available to be read
-  @retval FALSE      No data is available to be read
-
-**/
-BOOLEAN
-EFIAPI
-PL011UartPoll (
-  IN  UINTN  UartBase
-  )
-{
-  return ((MmioRead32 (UartBase + UARTFR) & UART_RX_EMPTY_FLAG_MASK) == 0);
+  // MU_CHANGE Ends
 }


### PR DESCRIPTION
## Description

This patch updates PL011UartLib.c to not wait until the RX buffer has data in it, but return if the buffer is empty.

Cherry-picked from: e87e4bf715

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.