### PR TITLE
ArmVirtPkg: QemuVirtMemInfoPeiLib: Allow PcdSystemMemorySize to be non-fixed

### DIFF
--- a/ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoPeiLib.inf
+++ b/ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoPeiLib.inf
@@ -38,11 +38,16 @@
 [Guids]
   gArmVirtSystemMemorySizeGuid
 
+# MU_CHANGE [BEGIN] - Allow PcdSystemMemorySize to be referenced per allowed (i.e. DEC declaration) PCD types
+[Pcd]
+  gArmTokenSpaceGuid.PcdSystemMemorySize
+# MU_CHANGE [END] -  Allow PcdSystemMemorySize to be referenced per allowed (i.e. DEC declaration) PCD types
+
 [FixedPcd]
   gArmTokenSpaceGuid.PcdFdBaseAddress
   gArmTokenSpaceGuid.PcdFvBaseAddress
   gArmTokenSpaceGuid.PcdSystemMemoryBase
-  gArmTokenSpaceGuid.PcdSystemMemorySize
+  # gArmTokenSpaceGuid.PcdSystemMemorySize  # MU_CHANGE - Allow the PCD to be referenced per allowed PCD types
   gArmTokenSpaceGuid.PcdFdSize
   gArmTokenSpaceGuid.PcdFvSize
   gUefiOvmfPkgTokenSpaceGuid.PcdDeviceTreeInitialBaseAddress


### PR DESCRIPTION
## Description

Platforms today may use this PCD as a dynamic PCD as that is an allowed type in its PCD declaration. From `ArmPkg.dec`:

[PcdsFixedAtBuild.common, PcdsDynamic.common, PcdsPatchableInModule.common]
  gArmTokenSpaceGuid.PcdSystemMemorySize|0|UINT64|0x0000002A

This library causes a build error if it used as a dynamic PCD since it places the PCD in a `[FixedPcd]` section in the INF.

Other libraries do set the PCD and depend on the dynamic PCD behavior.

Since this library accesses the PCD with `PcdGet64 ()` which is compatible with FixedAtBuild PCDs, this change moves the PCD out an explicit `[FixedPcd]` section to resolve the following build error:

```
  INFO -  : error 3000: Building modules from source INFs, following
                        PCD use Dynamic and FixedAtBuild access method.
                        It must be corrected to use only one access
                        method.
  INFO - 	gArmTokenSpaceGuid.PcdSystemMemorySize
```

Cherry-picked from 8008cd06ec.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

Platform can use PcdSystemMemorySize as a non-fixed PCD with this lib.