### PR TITLE
ArmVirtPkg: Fix MarkdownLint issues in Readme

### DIFF
--- a/ArmVirtPkg/PlatformCI/ReadMe.md
+++ b/ArmVirtPkg/PlatformCI/ReadMe.md
@@ -113,7 +113,7 @@ the generic set of edk2 [Build Instructions](https://github.com/tianocore/tianoc
 1. Including the expected build architecture and toolchain to the _stuart_update_ command is critical.
    This is because there are extra scopes and tools that will be resolved during the update step that
    need to match your build step.
-2. Configuring *ACTIVE_PLATFORM* and *TARGET_ARCH* in Conf/target.txt is **not** required. This
+2. Configuring _ACTIVE_PLATFORM_ and _TARGET_ARCH_ in Conf/target.txt is **not** required. This
    environment is set by PlatformBuild.py based upon the `[-a <TARGET_ARCH>]` parameter.
 3. QEMU must be on your path.  On Windows this is a manual process and not part of the QEMU installer.
 
@@ -121,9 +121,9 @@ the generic set of edk2 [Build Instructions](https://github.com/tianocore/tianoc
 
 ### Custom Build Options
 
-**MAKE_STARTUP_NSH=TRUE** will output a *startup.nsh* file to the location mapped as fs0. This is
+**MAKE_STARTUP_NSH=TRUE** will output a _startup.nsh_ file to the location mapped as fs0. This is
 used in CI in combination with the `--FlashOnly` feature to run QEMU to the UEFI shell and then execute
-the contents of *startup.nsh*.
+the contents of _startup.nsh_.
 
 **QEMU_HEADLESS=TRUE** Since CI servers run headless QEMU must be told to run with no display otherwise
 an error occurs. Locally you don't need to set this.
@@ -131,7 +131,7 @@ an error occurs. Locally you don't need to set this.
 ### Passing Build Defines
 
 To pass build defines through _stuart_build_, prepend `BLD_*_`to the define name and pass it on the
-command-line. _stuart_build_ currently requires values to be assigned, so add an`=1` suffix for bare defines.
+command-line. `stuart_build` currently requires values to be assigned, so add an `=1` suffix for bare defines.
 For example, to enable the TPM2 support, instead of the traditional "-D TPM2_ENABLE=TRUE", the stuart_build
 command-line would be:
 


### PR DESCRIPTION
## Description

This resolves using the wrong kind of emphasis in the ArmVirtPkg PlatformCI Readme.

Cherry-picked from 6eac241d1b3d72e69670d5e392329f0dd75b6c98.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.
