### PR TITLE
[2405] Revert "ArmPkg: ArmPsciMpServicesDxe: Fix CPU resource leakage"

### DIFF
--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
@@ -754,13 +754,6 @@ StartupThisAP (
     return EFI_SUCCESS;
   }
 
-  // MU_CHANGE: Set the timer anyway, otherwise this AP is spent on this boot if the AP routine timeout.
-  gBS->SetTimer (
-         CpuData->CheckThisAPEvent,
-         TimerPeriodic,
-         POLL_INTERVAL_US
-         );
-
   // Blocking
   while (TRUE) {
     if (GetApState (CpuData) == CpuStateFinished) {


### PR DESCRIPTION
## Description

This reverts commit 05caf20d865389fd0d0343bc7e0e3c0bd458bf5f. As the change was integrated into EDK2 in a different way which will cover the expected CPU state to fix the state machine.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This change was tested on QEMU SBSA and verified MP test works as expected.

## Integration Instructions

N/A