### PR TITLE
Set PciFunction to 0xFFFF for _PRT per specification

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
@@ -395,7 +395,7 @@ GeneratePrt (
       Use the second model for _PRT object and describe a hardwired interrupt.
     */
     Status = AmlAddPrtEntry (
-               (IrqMapInfo->PciDevice << 16) | IrqMapInfo->PciFunction, // MU_CHANGE
+               (IrqMapInfo->PciDevice << 16) | 0xFFFF,
                IrqMapInfo->PciInterrupt,
                NULL,
                IrqMapInfo->IntcInterrupt.Interrupt,


### PR DESCRIPTION
## Description

partially reverts #37 which updated the PciFunction to no longer be 0xFFFF for _PRT which goes against the ACPI specification that states that the PciFunction should be 0xFFFF for _PRT.

This is per ACPI specification 6.4 section 6.2.13

![image](https://github.com/user-attachments/assets/20b72995-ce14-4a4f-8999-3f3d5bd36b00)


- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A - Spec compliance

## Integration Instructions

Platforms should verify PciFunction for _PRT is 0xFFFF