### PR TITLE
Make DynamicTablesPkg changes to allow more platform customization

### DIFF
--- a/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
@@ -456,6 +456,25 @@ typedef struct CmArmGenericWatchdogInfo {
   UINT32    Flags;
 } CM_ARM_GENERIC_WATCHDOG_INFO;
 
+// MU_CHANGE [BEGIN] - Set OSC Ctrl Bits based on EArmObjPciConfigSpaceInfo
+
+/** These masks define the bit positions in the PCI OSC CTRL buffer
+    for the features that OS may requests control over. For firmware
+    to grant control of a specific feature, the bit must be set in the
+    CTRL buffer. For more info, see PCI FW Spec v3.3 section 4.5.1
+*/
+#define PCI_OSC_ALLOW_NATIVE_HOT_PLUG_CONTROL       0x0001
+#define PCI_OSC_ALLOW_NATIVE_SHPC_CONTROL           0x0002
+#define PCI_OSC_ALLOW_NATIVE_PME_CONTROL            0x0004
+#define PCI_OSC_ALLOW_NATIVE_AER_CONTROL            0x0008
+#define PCI_OSC_ALLOW_NATIVE_CAPABILITY_CONTROL     0x0010
+#define PCI_OSC_ALLOW_NATIVE_LTR_CONTROL            0x0020
+#define PCI_OSC_SUPRESS_HOT_REMOVE_ERRORS           0x0040
+#define PCI_OSC_ALLOW_NATIVE_DPC_CONTROL            0x0080
+#define PCI_OSC_ALLOW_NATIVE_COMPL_TIMEOUT_CONTROL  0x0100
+#define PCI_OSC_ALLOW_NATIVE_SFI_CONTROL            0x0200
+#define PCI_OSC_CTRL_BUFFER_VALID_BITS              0x03FF
+
 /** A structure that describes the
     PCI Configuration Space information for the Platform.
 
@@ -481,7 +500,12 @@ typedef struct CmArmPciConfigSpaceInfo {
   /// Optional field: Reference Token for interrupt mapping.
   /// Token identifying a CM_ARM_OBJ_REF structure.
   CM_OBJECT_TOKEN    InterruptMapToken;
+
+  /// Bits to enable/disable native OS control of certain features
+  UINT32             OscControlBuffer;
 } CM_ARM_PCI_CONFIG_SPACE_INFO;
+
+// MU_CHANGE [END]
 
 /** A structure that describes the
     Hypervisor Vendor ID information for the Platform.

--- a/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
@@ -1082,6 +1082,13 @@ typedef struct CmArmPciInterruptMapInfo {
   /// Value on 5 bits (max 31).
   UINT8    PciDevice;
 
+  // MU_CHANGE [BEGIN] Allow user to specify PciFunction in InterruptMapInfo
+  /// Pci Function.
+  /// up to 3 bits (max 7)
+  /// Value of 0xFFFF implies all functions under device
+  UINT16   PciFunction;
+  // MU_CHANGE [END]
+
   /** PCI interrupt
 
   ACPI bindings are used:

--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtPcieLibArm/SsdtPcieGenerator.c
@@ -377,7 +377,7 @@ GeneratePrt (
     }
 
     // Add the device to the DeviceTable.
-    MappingTableAdd (&Generator->DeviceTable, IrqMapInfo->PciDevice);
+    MappingTableAdd (&Generator->DeviceTable, (IrqMapInfo->PciDevice << 16) | IrqMapInfo->PciFunction); // MU_CHANGE
 
     /* Add a _PRT entry.
        ASL


### PR DESCRIPTION
## Description

This PR pulls in three changes that effect DynamicTablesPkg.

---

9b8d2aa779 
Brings in changes to support setting OSC CTRL bits based on PCI config space info.  This uses the aml fixup libraries to set the CTRL bits in the OSC method so that consumers can specify if certain features should be granted to the OS or not.

---

96107b0633
Allows users to specify Function number in the InterruptInfo structure which is necessary for some operating systems.

---

5e3536d275
This is a partial reverts of the commit linked above (96107b0633) which updated the PciFunction to no longer be 0xFFFF for _PRT which goes against the ACPI specification that states that the PciFunction should be 0xFFFF for _PRT

---


For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [X] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a platform that utilizes DynamicTablesPkg.

## Integration Instructions
1.  Consumers who utlize the DynamicTablesPkg should specify in CM_ARM_PCI_CONFIG_SPACE_INFO.OscControlBitmap which OSC CTRL bits should be set if the OS requests them
2.  Ensure that desired function number is added in the Interrupt Info structure.