### PR TITLE
[202405] Add Cumulative CodeQL changes.

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -146,10 +146,6 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
                 scopes += codeql_helpers.get_scopes(self.codeql)
 
                 if self.codeql:
-                    shell_environment.GetBuildVars().SetValue(
-                        "STUART_CODEQL_AUDIT_ONLY",
-                        "TRUE",
-                        "Set in CISettings.py")
                     codeql_filter_files = [str(n) for n in glob.glob(
                         os.path.join(self.GetWorkspaceRoot(),
                                      '**/CodeQlFilters.yml'),

--- a/ArmPkg/Drivers/ArmGic/ArmGicLib.c
+++ b/ArmPkg/Drivers/ArmGic/ArmGicLib.c
@@ -246,7 +246,7 @@ ArmGicSetInterruptPriority (
     MmioAndThenOr32 (
       GicDistributorBase + ARM_GIC_ICDIPR + (4 * RegOffset),
       ~(0xff << RegShift),
-      Priority << RegShift
+      (UINT32)(Priority << RegShift) // MU_CHANGE - CodeQL Change
       );
   } else {
     GicCpuRedistributorBase = GicGetCpuRedistributorBase (
@@ -260,7 +260,7 @@ ArmGicSetInterruptPriority (
     MmioAndThenOr32 (
       IPRIORITY_ADDRESS (GicCpuRedistributorBase, RegOffset),
       ~(0xff << RegShift),
-      Priority << RegShift
+      (UINT32)(Priority << RegShift) // MU_CHANGE - CodeQL Change
       );
   }
 }

--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -259,8 +259,17 @@ GetMmCompatibility (
 
   MmVersion = MmVersionArgs.Arg0;
 
+  // MU_CHANGE - CodeQL Change - unsigned-comparison-zero
+  // Make MM_CALLER_MINOR_VER more restrictive. Rquire
+  //  exact minor version match rather than >=.
+  // Add static_assert to check if/when verison change
+  // occurs.
+  STATIC_ASSERT (
+    MM_CALLER_MINOR_VER == 0,
+    "MM_CALLER_MINOR_VERSION has changed!"
+    );
   if ((MM_MAJOR_VER (MmVersion) == MM_CALLER_MAJOR_VER) &&
-      (MM_MINOR_VER (MmVersion) >= MM_CALLER_MINOR_VER))
+      (MM_MINOR_VER (MmVersion) == MM_CALLER_MINOR_VER))
   {
     DEBUG ((
       DEBUG_INFO,

--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -260,10 +260,13 @@ GetMmCompatibility (
   MmVersion = MmVersionArgs.Arg0;
 
   // MU_CHANGE - CodeQL Change - unsigned-comparison-zero
-  // Make MM_CALLER_MINOR_VER more restrictive. Rquire
+  // Make MM_CALLER_MINOR_VER more restrictive. Require
   //  exact minor version match rather than >=.
-  // Add static_assert to check if/when verison change
-  // occurs.
+
+  // Add static_assert to check if/when version change
+  // occurs. If a version change occurs,
+  // the static assert will need to be updated to
+  // match the new major/minor version.
   STATIC_ASSERT (
     MM_CALLER_MINOR_VER == 0,
     "MM_CALLER_MINOR_VERSION has changed!"

--- a/ArmPlatformPkg/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputBlt.c
+++ b/ArmPlatformPkg/Drivers/LcdGraphicsOutputDxe/LcdGraphicsOutputBlt.c
@@ -140,10 +140,10 @@ VideoCopyHorizontalOverlap (
   UINT16  *SourcePixel16bit;
   UINT16  *DestinationPixel16bit;
 
-  UINT32  SourcePixelY;
-  UINT32  DestinationPixelY;
-  UINTN   SizeIn32Bits;
-  UINTN   SizeIn16Bits;
+  UINTN  SourcePixelY;      // MU_CHANGE - CodeQL Change
+  UINTN  DestinationPixelY; // MU_CHANGE - CodeQL Change
+  UINTN  SizeIn32Bits;
+  UINTN  SizeIn16Bits;
 
   Status = EFI_SUCCESS;
 
@@ -271,8 +271,8 @@ BltVideoFill (
   VOID               *DestinationAddr;
   UINT16             *DestinationPixel16bit;
   UINT16             Pixel16bit;
-  UINT32             DestinationPixelX;
-  UINT32             DestinationLine;
+  UINTN              DestinationPixelX; // MU_CHANGE - CodeQL Change
+  UINTN              DestinationLine;   // MU_CHANGE - CodeQL Change
   UINTN              WidthInBytes;
 
   Status               = EFI_SUCCESS;
@@ -420,11 +420,11 @@ BltVideoToBltBuffer (
   VOID                           *DestinationAddr;
   UINT16                         *SourcePixel16bit;
   UINT16                         Pixel16bit;
-  UINT32                         SourcePixelX;
-  UINT32                         SourceLine;
-  UINT32                         DestinationPixelX;
-  UINT32                         DestinationLine;
-  UINT32                         BltBufferHorizontalResolution;
+  UINTN                          SourcePixelX;                  // MU_CHANGE - CodeQL Change
+  UINTN                          SourceLine;                    // MU_CHANGE - CodeQL Change
+  UINTN                          DestinationPixelX;             // MU_CHANGE - CodeQL Change
+  UINTN                          DestinationLine;               // MU_CHANGE - CodeQL Change
+  UINTN                          BltBufferHorizontalResolution; // MU_CHANGE - CodeQL Change
   UINTN                          WidthInBytes;
 
   Status               = EFI_SUCCESS;
@@ -583,11 +583,11 @@ BltBufferToVideo (
   VOID                           *SourceAddr;
   VOID                           *DestinationAddr;
   UINT16                         *DestinationPixel16bit;
-  UINT32                         SourcePixelX;
-  UINT32                         SourceLine;
-  UINT32                         DestinationPixelX;
-  UINT32                         DestinationLine;
-  UINT32                         BltBufferHorizontalResolution;
+  UINTN                          SourcePixelX;                  // MU_CHANGE - CodeQL Change
+  UINTN                          SourceLine;                    // MU_CHANGE - CodeQL Change
+  UINTN                          DestinationPixelX;             // MU_CHANGE - CodeQL Change
+  UINTN                          DestinationLine;               // MU_CHANGE - CodeQL Change
+  UINTN                          BltBufferHorizontalResolution; // MU_CHANGE - CodeQL Change
   UINTN                          WidthInBytes;
 
   Status               = EFI_SUCCESS;

--- a/ArmPlatformPkg/Drivers/PL061GpioDxe/PL061Gpio.c
+++ b/ArmPlatformPkg/Drivers/PL061GpioDxe/PL061Gpio.c
@@ -100,7 +100,7 @@ PL061SetPins (
   IN UINTN  Value
   )
 {
-  MmioWrite8 (PL061EffectiveAddress (Address, Mask), Value);
+  MmioWrite8 (PL061EffectiveAddress (Address, Mask), (UINT8)Value); // MU_CHANGE - CodeQL Change
 }
 
 /**
@@ -236,14 +236,14 @@ Set (
 
     case GPIO_MODE_OUTPUT_0:
       // Set the corresponding direction bit to HIGH for output
-      MmioOr8 (RegisterBase + PL061_GPIO_DIR_REG, GPIO_PIN_MASK (Offset));
+      MmioOr8 (RegisterBase + PL061_GPIO_DIR_REG, (UINT8)GPIO_PIN_MASK (Offset)); // MU_CHANGE - CodeQL Change
       // Set the corresponding data bit to LOW for 0
       PL061SetPins (RegisterBase, GPIO_PIN_MASK (Offset), 0);
       break;
 
     case GPIO_MODE_OUTPUT_1:
       // Set the corresponding direction bit to HIGH for output
-      MmioOr8 (RegisterBase + PL061_GPIO_DIR_REG, GPIO_PIN_MASK (Offset));
+      MmioOr8 (RegisterBase + PL061_GPIO_DIR_REG, (UINT8)GPIO_PIN_MASK (Offset)); // MU_CHANGE - CodeQL Change
       // Set the corresponding data bit to HIGH for 1
       PL061SetPins (RegisterBase, GPIO_PIN_MASK (Offset), 0xff);
       break;

--- a/ArmPlatformPkg/Drivers/PL061GpioDxe/PL061Gpio.h
+++ b/ArmPlatformPkg/Drivers/PL061GpioDxe/PL061Gpio.h
@@ -37,6 +37,6 @@
 #define PL061_GPIO_PINS  8
 
 // All bits low except one bit high, native bit length
-#define GPIO_PIN_MASK(Pin)  (1UL << ((UINTN)(Pin)))
+#define GPIO_PIN_MASK(Pin)  (LShiftU64(1UL, Pin)) // MU_CHANGE - CodeQL
 
 #endif // __PL061_GPIO_H__

--- a/ArmPlatformPkg/Drivers/SP805WatchdogDxe/SP805Watchdog.c
+++ b/ArmPlatformPkg/Drivers/SP805WatchdogDxe/SP805Watchdog.c
@@ -24,7 +24,7 @@
 STATIC EFI_EVENT                        mEfiExitBootServicesEvent;
 STATIC EFI_HARDWARE_INTERRUPT_PROTOCOL  *mInterrupt;
 STATIC EFI_WATCHDOG_TIMER_NOTIFY        mWatchdogNotify;
-STATIC UINT32                           mTimerPeriod;
+STATIC UINT64                           mTimerPeriod; // MU_CHANGE - CodeQL Change
 
 /**
   Make sure the SP805 registers are unlocked for writing.
@@ -101,7 +101,7 @@ SP805Stop (
 {
   // Disable interrupts
   if ((MmioRead32 (SP805_WDOG_CONTROL_REG) & SP805_WDOG_CTRL_INTEN) != 0) {
-    MmioAnd32 (SP805_WDOG_CONTROL_REG, ~SP805_WDOG_CTRL_INTEN);
+    MmioAnd32 (SP805_WDOG_CONTROL_REG, (UINT32) ~SP805_WDOG_CTRL_INTEN); // MU_CHANGE - CodeQL Change
   }
 }
 

--- a/ArmPlatformPkg/Library/PL111Lcd/PL111Lcd.c
+++ b/ArmPlatformPkg/Library/PL111Lcd/PL111Lcd.c
@@ -117,7 +117,7 @@ LcdSetMode (
   }
 
   // Disable the CLCD_LcdEn bit
-  MmioAnd32 (PL111_REG_LCD_CONTROL, ~PL111_CTRL_LCD_EN);
+  MmioAnd32 (PL111_REG_LCD_CONTROL, (UINT32) ~PL111_CTRL_LCD_EN); // MU_CHANGE - CodeQL Change
 
   // Set Timings
   MmioWrite32 (
@@ -167,5 +167,5 @@ LcdShutdown (
   )
 {
   // Disable the controller
-  MmioAnd32 (PL111_REG_LCD_CONTROL, ~PL111_CTRL_LCD_EN);
+  MmioAnd32 (PL111_REG_LCD_CONTROL, (UINT32) ~PL111_CTRL_LCD_EN); // MU_CHANGE - CodeQL Change
 }

--- a/ArmPlatformPkg/PrePeiCore/MainMPCore.c
+++ b/ArmPlatformPkg/PrePeiCore/MainMPCore.c
@@ -79,7 +79,7 @@ SecondaryMain (
   ASSERT (Index != ArmCoreCount);
 
   // Clear Secondary cores MailBox
-  MmioWrite32 (ArmCoreInfoTable[Index].MailboxClearAddress, ArmCoreInfoTable[Index].MailboxClearValue);
+  MmioWrite32 (ArmCoreInfoTable[Index].MailboxClearAddress, (UINT32)ArmCoreInfoTable[Index].MailboxClearValue); // MU_CHANGE - CodeQL Change
 
   do {
     ArmCallWFI ();
@@ -124,7 +124,7 @@ PrimaryMain (
   // If ArmVe has not been built as Standalone then we need to wake up the secondary cores
   if (FeaturePcdGet (PcdSendSgiToBringUpSecondaryCores)) {
     // Sending SGI to all the Secondary CPU interfaces
-    ArmGicSendSgiTo (PcdGet64 (PcdGicDistributorBase), ARM_GIC_ICDSGIR_FILTER_EVERYONEELSE, 0x0E, PcdGet32 (PcdGicSgiIntId));
+    ArmGicSendSgiTo (PcdGet64 (PcdGicDistributorBase), (UINT8)ARM_GIC_ICDSGIR_FILTER_EVERYONEELSE, (UINT8)0x0E, (UINT8)PcdGet32 (PcdGicSgiIntId));
   }
 
   // Adjust the Temporary Ram as the new Ppi List (Common + Platform Ppi Lists) is created at

--- a/ArmPlatformPkg/PrePi/MainMPCore.c
+++ b/ArmPlatformPkg/PrePi/MainMPCore.c
@@ -25,7 +25,7 @@ PrimaryMain (
   // In some cases, the secondary cores are waiting for an SGI from the next stage boot loader to resume their initialization
   if (!FixedPcdGet32 (PcdSendSgiToBringUpSecondaryCores)) {
     // Sending SGI to all the Secondary CPU interfaces
-    ArmGicSendSgiTo (PcdGet64 (PcdGicDistributorBase), ARM_GIC_ICDSGIR_FILTER_EVERYONEELSE, 0x0E, PcdGet32 (PcdGicSgiIntId));
+    ArmGicSendSgiTo (PcdGet64 (PcdGicDistributorBase), ARM_GIC_ICDSGIR_FILTER_EVERYONEELSE, 0x0E, (UINT8)PcdGet32 (PcdGicSgiIntId)); // MU_CHANGE - CodeQL Change
   }
 
   PrePiMain (UefiMemoryBase, StacksBase, StartTimeStamp);


### PR DESCRIPTION
## Description
Cumulative CodeQL fixes for the release 202405 Branch.

9553d450a0

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Ran local CI under WSL.

## Integration Instructions
New static build assert will occur if a mismatch MM_CALLER_MINOR_VER is integrated at some point in the future.
The fix for this will be to either remove the static assert at that time, or to update the static assert.
This is to alert the builder that a version change has occurred and the code needs examined to determine any impacts.