### PR TITLE
Revert SGIv3 change from 2405

### DIFF
--- a/ArmPkg/Drivers/ArmGic/GicV3/AArch64/ArmGicV3.S
+++ b/ArmPkg/Drivers/ArmGic/GicV3/AArch64/ArmGicV3.S
@@ -23,7 +23,6 @@
 #define ICC_IAR1_EL1            S3_0_C12_C12_0
 #define ICC_PMR_EL1             S3_0_C4_C6_0
 #define ICC_BPR1_EL1            S3_0_C12_C12_3
-#define ICC_SGI1R_EL1           S3_0_C12_C11_5  // MU_CHANGE
 
 #endif
 
@@ -55,18 +54,6 @@ ASM_FUNC(ArmGicV3SetControlSystemRegisterEnable)
 3:  msr ICC_SRE_EL3, x0
 4:  isb
         ret
-
-// MU_CHANGE Starts: Add ArmGicV3SendNsG1Sgi, to allow sending SGI from one core to other cores on GICv3
-// VOID
-// ArmGicV3SendNsG1Sgi (
-//  IN UINT64          SgiVal
-//  );
-ASM_FUNC(ArmGicV3SendNsG1Sgi)
-        dsb     ishst
-        msr     ICC_SGI1R_EL1, x0
-        isb
-        ret
-// MU_CHANGE Ends
 
 //VOID
 //ArmGicV3EnableInterruptInterface (

--- a/ArmPkg/Drivers/ArmGic/GicV3/AArch64/ArmGicV3.masm
+++ b/ArmPkg/Drivers/ArmGic/GicV3/AArch64/ArmGicV3.masm
@@ -71,7 +71,7 @@ ArmGicV3SetControlSystemRegisterEnable ENDP
 //  );
 ArmGicV3SendNsG1Sgi PROC
         dsb     ishst
-        msr     ICC_SGI1R_EL1, x0
+        msr     ICC_SGI1R, x0
         isb
         ret
 ArmGicV3SendNsG1Sgi ENDP

--- a/ArmPkg/Drivers/ArmGic/GicV3/AArch64/ArmGicV3.masm
+++ b/ArmPkg/Drivers/ArmGic/GicV3/AArch64/ArmGicV3.masm
@@ -17,7 +17,6 @@
 
     EXPORT ArmGicV3GetControlSystemRegisterEnable
     EXPORT ArmGicV3SetControlSystemRegisterEnable
-    EXPORT ArmGicV3SendNsG1Sgi  // MU_CHANGE
     EXPORT ArmGicV3EnableInterruptInterface
     EXPORT ArmGicV3DisableInterruptInterface
     EXPORT ArmGicV3EndOfInterrupt
@@ -63,19 +62,6 @@ ArmGicV3SetControlSystemRegisterEnable PROC
     isb sy
         ret
 ArmGicV3SetControlSystemRegisterEnable ENDP
-
-// MU_CHANGE Starts: Add ArmGicV3SendNsG1Sgi, to allow sending SGI from one core to other cores on GICv3
-// VOID
-// ArmGicV3SendNsG1Sgi (
-//  IN UINT64          SgiVal
-//  );
-ArmGicV3SendNsG1Sgi PROC
-        dsb     ishst
-        msr     ICC_SGI1R, x0
-        isb
-        ret
-ArmGicV3SendNsG1Sgi ENDP
-// MU_CHANGE Ends
 
 //VOID
 //ArmGicV3EnableInterruptInterface (

--- a/ArmPkg/Drivers/ArmGic/GicV3/Arm/ArmGicV3.S
+++ b/ArmPkg/Drivers/ArmGic/GicV3/Arm/ArmGicV3.S
@@ -29,18 +29,6 @@ ASM_FUNC(ArmGicV3SetControlSystemRegisterEnable)
         isb
         bx      lr
 
-// MU_CHANGE Starts: Add ArmGicV3SendNsG1Sgi, to allow sending SGI from one core to other cores on GICv3
-// VOID
-// ArmGicV3SendNsG1Sgi (
-//  IN UINT64          SgiVal
-//  );
-ASM_FUNC(ArmGicV3SendNsG1Sgi)
-        dsb     ishst
-        mcrr    p15, 0, r0, r1, c12 // ICC_SGI1R_EL1
-        isb
-        bx      lr
-// MU_CHANGE Ends
-
 //VOID
 //ArmGicV3EnableInterruptInterface (
 //  VOID

--- a/ArmPkg/Include/Library/ArmGicLib.h
+++ b/ArmPkg/Include/Library/ArmGicLib.h
@@ -336,12 +336,4 @@ ArmGicV3SetPriorityMask (
   IN UINTN  Priority
   );
 
-// MU_CHANGE Starts: Add ArmGicV3SendNsG1Sgi, to allow sending SGI from one core to other cores on GICv3
-VOID
-ArmGicV3SendNsG1Sgi (
-  IN UINT64  SgiVal
-  );
-
-// MU_CHANGE Ends
-
 #endif // ARMGIC_H_


### PR DESCRIPTION
## Description

This change reverts the `ArmGicV3SendNsG1Sgi` change from ArmPkg as it will be hosted in MsCorePkg eventually.

For details on how to complete to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Interfaces using this function should change to `MuArmGicExLib`.

## Integration Instructions

N/A
