### PR TITLE
[CHERRY-PICK] [REBASE & FF] DynamicTablesPkg: TableHelperLib: Add Missing Libraries

### DIFF
--- a/DynamicTablesPkg/Library/Common/TableHelperLib/TableHelperLib.inf
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/TableHelperLib.inf
@@ -27,3 +27,7 @@
 [LibraryClasses]
   AmlLib
   BaseLib
+# MU_CHANGE Starts
+  AmlLib
+  MemoryAllocationLib
+# MU_CHANGE Ends


### PR DESCRIPTION
## Description

The existing library inf misses a few used libraries in its [LibraryClasses] section and thus break the build.

This change adds those libraries and does not have functional change other than minimal section literals.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

From 2311.

## Integration Instructions

N/A.
