### PR TITLE
[SQUASH] Revert some MU_CHANGEs that are incorrect during integration

### DIFF
--- a/ArmPkg/Drivers/ArmGic/GicV2/ArmGicV2Dxe.c
+++ b/ArmPkg/Drivers/ArmGic/GicV2/ArmGicV2Dxe.c
@@ -165,7 +165,7 @@ GicV2IrqInterruptHandler (
   UINTN                       GicInterrupt;
   HARDWARE_INTERRUPT_HANDLER  InterruptHandler;
 
-  GicInterrupt = (UINT32)ArmGicV2AcknowledgeInterrupt (mGicInterruptInterfaceBase); // MU_CHANGE - ARM64 VS change
+  GicInterrupt = ArmGicV2AcknowledgeInterrupt (mGicInterruptInterfaceBase);
 
   // Special Interrupts (ID1020-ID1023) have an Interrupt ID greater than the
   // number of interrupt (ie: Spurious interrupt).
@@ -359,7 +359,7 @@ GicV2ExitBootServicesEvent (
 
   // Acknowledge all pending interrupts
   do {
-    GicInterrupt = (UINT32)ArmGicV2AcknowledgeInterrupt (mGicInterruptInterfaceBase); // MU_CHANGE - ARM64 VS change
+    GicInterrupt = ArmGicV2AcknowledgeInterrupt (mGicInterruptInterfaceBase);
 
     if ((GicInterrupt & ARM_GIC_ICCIAR_ACKINTID) < mGicNumInterrupts) {
       GicV2EndOfInterrupt (&gHardwareInterruptV2Protocol, GicInterrupt);

--- a/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
+++ b/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
@@ -423,7 +423,7 @@ GicV3DxeInitialize (
       for (Index = 8; Index < (mGicNumInterrupts / 4); Index++) {
         MmioWrite32 (
           mGicDistributorBase + ARM_GIC_ICDIPTR + (Index * 4),
-          (UINT32)CpuTarget      // MU_CHANGE - ARM64 VS change
+          CpuTarget
           );
       }
     }
@@ -463,7 +463,7 @@ GicV3DxeInitialize (
     for (Index = 32; Index < mGicNumInterrupts; Index++) {
       MmioWrite64 (
         mGicDistributorBase + ARM_GICD_IROUTER + (Index * 8),
-        (UINT32)CpuTarget   // MU_CHANGE - ARM64 VS change
+        CpuTarget
         );
     }
   }


### PR DESCRIPTION
## Description

This change reverts some MU_CHANGE that are incorrect given the updated context of EDK2 baseline.

Specifically, EDK2 updated their implementation which makes our casting no longer valid:
https://github.com/tianocore/edk2/commit/1bb76029eff4993b31dbbb19acd86d1c8ad4933f
https://github.com/tianocore/edk2/commit/7f198321eec0f520373261a15b6d0922906d06bc

Please squash this change upon the next integration.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change was tested with QEMU sbsa virtual platform.

## Integration Instructions

 N/A
