### PR TITLE
ArmPkg: Remove pragma pack from CpuDxe

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/PageTableMemoryAllocation.c
+++ b/ArmPkg/Drivers/CpuDxe/PageTableMemoryAllocation.c
@@ -13,16 +13,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiBootServicesTableLib.h>
 #include <Protocol/ArmPageTableMemoryAllocation.h>
 
-#pragma pack(1)
-
 typedef struct {
   UINT32        Signature;
   UINTN         Offset;
   UINTN         FreePages;
   LIST_ENTRY    NextPool;
 } PAGE_TABLE_POOL;
-
-#pragma pack()
 
 #define MIN_PAGES_AVAILABLE        5
 #define PAGE_TABLE_POOL_SIGNATURE  SIGNATURE_32 ('P','T','P','L')


### PR DESCRIPTION
## Description

PageTableMemoryAllocation.c

The packing was causing an MSVC compiler warning:
`Compiler #4366: The result of the unary '&' operator may be unaligned.`

Removing the packing also matches convention seen in https://github.com/microsoft/mu_basecore/blob/dev/202405/UefiCpuPkg/CpuDxe/CpuPageTable.c#L71

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Booted with QEMU SBSA

## Integration Instructions

N/A