### PR TITLE
[REBASE & FF] ArmPkg: Remove pragma pack from CpuDxe

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/PageTableMemoryAllocation.c
+++ b/ArmPkg/Drivers/CpuDxe/PageTableMemoryAllocation.c
@@ -13,16 +13,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiBootServicesTableLib.h>
 #include <Protocol/ArmPageTableMemoryAllocation.h>
 
-#pragma pack(1)
-
 typedef struct {
   UINT32        Signature;
   UINTN         Offset;
   UINTN         FreePages;
   LIST_ENTRY    NextPool;
 } PAGE_TABLE_POOL;
-
-#pragma pack()
 
 #define MIN_PAGES_AVAILABLE        5
 #define PAGE_TABLE_POOL_SIGNATURE  SIGNATURE_32 ('P','T','P','L')


### PR DESCRIPTION
## Description

PageTableMemoryAllocation.c

The packing was causing an MSVC ARM64 build warning \#4366: The result of the unary '&' operator may be unaligned

Cherry-picked from dev/202405: 1ad3ff0f0012fb6e0a7ab4830030e895be11913e

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Boot to QEMU SBSA 

## Integration Instructions
N/A