### PR TITLE
[REBASE & FF] ArmPkg: Fix call to BuildCpuHob in CpuPei.c

### DIFF
--- a/ArmPkg/Drivers/CpuPei/CpuPei.c
+++ b/ArmPkg/Drivers/CpuPei/CpuPei.c
@@ -138,7 +138,7 @@ InitializeCpuPeim (
   ArmEnableBranchPrediction ();
 
   // Publish the CPU memory and io spaces sizes
-  BuildCpuHob (ArmGetPhysicalAddressBits (), PcdGet8 (PcdPrePiCpuIoSize));
+  BuildCpuHob ((UINT8)ArmGetPhysicalAddressBits (), PcdGet8 (PcdPrePiCpuIoSize)); // MU_CHANGE Add typecast
 
   // Only MP Core platform need to produce gArmMpCoreInfoPpiGuid
   Status = PeiServicesLocatePpi (&gArmMpCoreInfoPpiGuid, 0, NULL, (VOID **)&ArmMpCoreInfoPpi);


### PR DESCRIPTION
## Description

Cherry picking the following commit from dev/202405
2fb024f4d0f4d9fd98a9a1f84027d7dbcf26e168

Fix CpuPei.c for aarch64. Cast type on return value from ArmGetPhysicalAddressBits.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested in dev/202405.
Validated handoff on virtual platform bringup

## Integration Instructions

N/A