### PR TITLE
ArmPkg: CpuDxe: Fix Bad Cast

### DIFF
--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -24,8 +24,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @param T0SZ                 The T0SZ value to be parsed.
   @param RootTableLevel       The level of the root table.
-  @param RootTableEntryCount  T
-  he number of entries in the root table.
+  @param RootTableEntryCount  The number of entries in the root table.
 **/
 STATIC
 VOID
@@ -315,7 +314,7 @@ SyncCacheConfig (
   GetRootTranslationTableInfo (T0SZ, &TableLevel, &TableCount);
 
   // First Attribute of the Page Tables
-  PageAttribute = (UINT32)GetFirstPageAttribute (FirstLevelTableAddress, TableLevel); // MU_CHANGE - ARM64 VS change
+  PageAttribute = GetFirstPageAttribute (FirstLevelTableAddress, TableLevel);
 
   // We scan from the start of the memory map (ie: at the address 0x0)
   BaseAddressGcdRegion = 0x0;


### PR DESCRIPTION
## Description

When 2405 was done, the inexact order of rebasing caused an old commit https://github.com/microsoft/mu_silicon_arm_tiano/commit/41c707373489fe55c87f0f057408207de45d1cd8 to take precedence over a newer commit https://github.com/microsoft/mu_silicon_arm_tiano/commit/38ba4a64c513d84fa65a0c4f8403aefe90818720.

This causes the upper attributes to be dropped, which in the case of an invalid entry, will send 0xFFFFFFFF to be set as attributes to set in the GCD, instead of signifying an INVALID_ENTRY, because (UINT32)INVALID_ENTRY != INVALID_ENTRY.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

On a platform where this was failing.

## Integration Instructions

N/A.