### PR TITLE
Revert "ArmPkg: GICv3: Fix ARM_GICD_IROUTER incorrect writes for SPIs"

### DIFF
--- a/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
+++ b/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
@@ -457,10 +457,7 @@ GicV3DxeInitialize (
     }
 
     // Route the SPIs to the primary CPU. SPIs start at the INTID 32
-    // MU_CHANGE - SPIs per the GICv3 spec start at line 32, but the previous code
-    // relied on ARM_GICD_IROUTER to be a value different than the spec that
-    // skipped those first 32 lines.
-    for (Index = 32; Index < mGicNumInterrupts; Index++) {
+    for (Index = 0; Index < (mGicNumInterrupts - 32); Index++) {
       MmioWrite64 (
         mGicDistributorBase + ARM_GICD_IROUTER + (Index * 8),
         CpuTarget

--- a/ArmPkg/Include/Library/ArmGicLib.h
+++ b/ArmPkg/Include/Library/ArmGicLib.h
@@ -37,11 +37,7 @@
 #define ARM_GIC_ICDSGIR  0xF00        // Software Generated Interrupt Register
 
 // GICv3 specific registers
-// MU_CHANGE - This was 0x6100 before, which skips past the reserved lines but
-// requires subtracting 32 from every single usage programming this register as
-// the GICv3 spec defines it as 0x6000. Change it back to the specification
-// value.
-#define ARM_GICD_IROUTER  0x6000       // Interrupt Routing Registers
+#define ARM_GICD_IROUTER  0x6100       // Interrupt Routing Registers
 
 // GICD_CTLR bits
 #define ARM_GIC_ICDDCR_ARE  (1 << 4)     // Affinity Routing Enable (ARE)


### PR DESCRIPTION
## Description

This reverts commit f735cd4481511bc5dcfc9ac4afe10fb97e3528e4.

This commit references an older GICv3 spec (that cannot be found) that had a different ARM_GICD_ROUTER definition at 0x6000 instead of 0x6100. The current GICv3 spec defines ARM_GICD_ROUTER as 0x6100 [1].

It also was determined that the logic between this PR and the existing edk2 logic was the same but Mu kept this behavior as it was believed to better align to the spec, but again the current spec says 0x6100, so this logic is dropped.

No known Mu consumer was using this definition, but it is marked as a breaking change because if any consumer was using the definition, it is now different.

Bugzilla ref: https://bugzilla.tianocore.org/show_bug.cgi?id=1294

[1] https://developer.arm.com/documentation/ihi0069/latest

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested to boot SBSA.

## Integration Instructions

If ARM_GICD_IROUTER definition is being used by a platform, any surrounding logic needs to be updated to take account of the new definition.
