### PR TITLE
StandaloneMmPkg: Arm/StandaloneMmCoreEntryPoint Remove Check for SMC ID

### DIFF
--- a/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.c
@@ -141,80 +141,68 @@ DelegatedEventLoop (
     DEBUG ((DEBUG_INFO, "X6 :  0x%x\n", (UINT32)EventCompleteSvcArgs->Arg6));
     DEBUG ((DEBUG_INFO, "X7 :  0x%x\n", (UINT32)EventCompleteSvcArgs->Arg7));
 
-    //
-    // ARM TF passes SMC FID of the MM_COMMUNICATE interface as the Event ID upon
-    // receipt of a synchronous MM request. Use the Event ID to distinguish
-    // between synchronous and asynchronous events.
-    //
-    if ((ARM_SMC_ID_MM_COMMUNICATE != (UINT32)EventCompleteSvcArgs->Arg0) &&
-        (ARM_SVC_ID_FFA_MSG_SEND_DIRECT_REQ != (UINT32)EventCompleteSvcArgs->Arg0))
-    {
-      DEBUG ((DEBUG_ERROR, "UnRecognized Event - 0x%x\n", (UINT32)EventCompleteSvcArgs->Arg0));
-      Status = EFI_INVALID_PARAMETER;
+    FfaEnabled = FeaturePcdGet (PcdFfaEnable);
+    if (FfaEnabled) {
+      Status = CpuDriverEntryPoint (
+                 EventCompleteSvcArgs->Arg0,
+                 EventCompleteSvcArgs->Arg6,
+                 EventCompleteSvcArgs->Arg3
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "Failed delegated event 0x%x, Status 0x%x\n",
+          EventCompleteSvcArgs->Arg3,
+          Status
+          ));
+      }
     } else {
-      FfaEnabled = FeaturePcdGet (PcdFfaEnable);
-      if (FfaEnabled) {
-        Status = CpuDriverEntryPoint (
-                   EventCompleteSvcArgs->Arg0,
-                   EventCompleteSvcArgs->Arg6,
-                   EventCompleteSvcArgs->Arg3
-                   );
-        if (EFI_ERROR (Status)) {
-          DEBUG ((
-            DEBUG_ERROR,
-            "Failed delegated event 0x%x, Status 0x%x\n",
-            EventCompleteSvcArgs->Arg3,
-            Status
-            ));
-        }
-      } else {
-        Status = CpuDriverEntryPoint (
-                   EventCompleteSvcArgs->Arg0,
-                   EventCompleteSvcArgs->Arg3,
-                   EventCompleteSvcArgs->Arg1
-                   );
-        if (EFI_ERROR (Status)) {
-          DEBUG ((
-            DEBUG_ERROR,
-            "Failed delegated event 0x%x, Status 0x%x\n",
-            EventCompleteSvcArgs->Arg0,
-            Status
-            ));
-        }
+      Status = CpuDriverEntryPoint (
+                 EventCompleteSvcArgs->Arg0,
+                 EventCompleteSvcArgs->Arg3,
+                 EventCompleteSvcArgs->Arg1
+                 );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "Failed delegated event 0x%x, Status 0x%x\n",
+          EventCompleteSvcArgs->Arg0,
+          Status
+          ));
       }
     }
+  }
 
-    switch (Status) {
-      case EFI_SUCCESS:
-        SvcStatus = ARM_SVC_SPM_RET_SUCCESS;
-        break;
-      case EFI_INVALID_PARAMETER:
-        SvcStatus = ARM_SVC_SPM_RET_INVALID_PARAMS;
-        break;
-      case EFI_ACCESS_DENIED:
-        SvcStatus = ARM_SVC_SPM_RET_DENIED;
-        break;
-      case EFI_OUT_OF_RESOURCES:
-        SvcStatus = ARM_SVC_SPM_RET_NO_MEMORY;
-        break;
-      case EFI_UNSUPPORTED:
-        SvcStatus = ARM_SVC_SPM_RET_NOT_SUPPORTED;
-        break;
-      default:
-        SvcStatus = ARM_SVC_SPM_RET_NOT_SUPPORTED;
-        break;
-    }
+  switch (Status) {
+    case EFI_SUCCESS:
+      SvcStatus = ARM_SVC_SPM_RET_SUCCESS;
+      break;
+    case EFI_INVALID_PARAMETER:
+      SvcStatus = ARM_SVC_SPM_RET_INVALID_PARAMS;
+      break;
+    case EFI_ACCESS_DENIED:
+      SvcStatus = ARM_SVC_SPM_RET_DENIED;
+      break;
+    case EFI_OUT_OF_RESOURCES:
+      SvcStatus = ARM_SVC_SPM_RET_NO_MEMORY;
+      break;
+    case EFI_UNSUPPORTED:
+      SvcStatus = ARM_SVC_SPM_RET_NOT_SUPPORTED;
+      break;
+    default:
+      SvcStatus = ARM_SVC_SPM_RET_NOT_SUPPORTED;
+      break;
+  }
 
-    if (FfaEnabled) {
-      EventCompleteSvcArgs->Arg0 = ARM_SVC_ID_FFA_MSG_SEND_DIRECT_RESP;
-      EventCompleteSvcArgs->Arg1 = 0;
-      EventCompleteSvcArgs->Arg2 = 0;
-      EventCompleteSvcArgs->Arg3 = ARM_SVC_ID_SP_EVENT_COMPLETE;
-      EventCompleteSvcArgs->Arg4 = SvcStatus;
-    } else {
-      EventCompleteSvcArgs->Arg0 = ARM_SVC_ID_SP_EVENT_COMPLETE;
-      EventCompleteSvcArgs->Arg1 = SvcStatus;
-    }
+  if (FfaEnabled) {
+    EventCompleteSvcArgs->Arg0 = ARM_SVC_ID_FFA_MSG_SEND_DIRECT_RESP;
+    EventCompleteSvcArgs->Arg1 = 0;
+    EventCompleteSvcArgs->Arg2 = 0;
+    EventCompleteSvcArgs->Arg3 = ARM_SVC_ID_SP_EVENT_COMPLETE;
+    EventCompleteSvcArgs->Arg4 = SvcStatus;
+  } else {
+    EventCompleteSvcArgs->Arg0 = ARM_SVC_ID_SP_EVENT_COMPLETE;
+    EventCompleteSvcArgs->Arg1 = SvcStatus;
   }
 }
 


### PR DESCRIPTION
## Description

Today, StandaloneMmCoreEntryPoint checks for an SMC EventId of MM_COMMUNICATE or FF-A Direct and drops all other SMCs. However, the TCG ACPI spec dictates that a different SMC ID, platform defined, will be send to communicate with the TPM[1]. When a platform is using StandaloneMM and the SPM_MM configuration, this check causes this valid SMC to be dropped. This is an issue because TPM calls cannot be routed, including TPM calls originating from the OS.

This patch drops the check to allow StandaloneMmCoreEntryPoint to route the calls to StandaloneMmCpu to decide whether it can handle the SMC (which on platforms with this TPM configuration it can).

"This field provides the SMC/HVC call function ID that will invoke the TPM start method.
Firmware SHALL implement the SMC call as an SMC32 or SMC64 Fast Call, compliant with the SMC Calling convention
 specification.  The call takes no parameters, no
client ID, no Secure OS ID, and no Session ID. The call SHALL return zero. The function ID SHALL be allocated from a Service Call Range over which the platform vendor has authority."

[1]: https://trustedcomputinggroup.org/wp-content/uploads/TCG_ACPIGeneralSpecification_v1p3_r6_14april2021.pdf Section 8.3.1

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on platform using TPM SMCs.

## Integration Instructions

N/A.
