### PR TITLE
[CHERRY-PICK] DynamicTablesPkg: AmlLib: Fix CodeQL Issue

### DIFF
--- a/DynamicTablesPkg/Library/Common/AmlLib/AmlEncoding/Aml.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/AmlEncoding/Aml.c
@@ -774,7 +774,7 @@ AmlSetPkgLength (
   // Write to the Buffer.
   *Buffer       = LeadByte;
   CurrentOffset = 1;
-  while (CurrentOffset < (Offset + 1)) {
+  while (CurrentOffset < (Offset + (UINT8)1)) {
     CurrentShift              = (UINT8)((CurrentOffset - 1) * 8);
     ComputedLength            = Length & (UINT32)(0x00000FF0 << CurrentShift);
     ComputedLength            = (ComputedLength) >> (4 + CurrentShift);


### PR DESCRIPTION
## Description

Without the addition of this cast, the compiler promotes 1 to a UINT32, which leads CodeQL to complain that different size types are being compared.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Cherry-picked from edk2.

## Integration Instructions

N/A.
