### PR TITLE
Fix while loop in delegated event API

### DIFF
--- a/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.c
@@ -144,10 +144,10 @@ DelegatedEventLoop (
     FfaEnabled = FeaturePcdGet (PcdFfaEnable);
     if (FfaEnabled) {
       Status = CpuDriverEntryPoint (
-                 EventCompleteSvcArgs->Arg0,
-                 EventCompleteSvcArgs->Arg6,
-                 EventCompleteSvcArgs->Arg3
-                 );
+                  EventCompleteSvcArgs->Arg0,
+                  EventCompleteSvcArgs->Arg6,
+                  EventCompleteSvcArgs->Arg3
+                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((
           DEBUG_ERROR,
@@ -158,10 +158,10 @@ DelegatedEventLoop (
       }
     } else {
       Status = CpuDriverEntryPoint (
-                 EventCompleteSvcArgs->Arg0,
-                 EventCompleteSvcArgs->Arg3,
-                 EventCompleteSvcArgs->Arg1
-                 );
+                  EventCompleteSvcArgs->Arg0,
+                  EventCompleteSvcArgs->Arg3,
+                  EventCompleteSvcArgs->Arg1
+                  );
       if (EFI_ERROR (Status)) {
         DEBUG ((
           DEBUG_ERROR,
@@ -171,38 +171,38 @@ DelegatedEventLoop (
           ));
       }
     }
-  }
 
-  switch (Status) {
-    case EFI_SUCCESS:
-      SvcStatus = ARM_SVC_SPM_RET_SUCCESS;
-      break;
-    case EFI_INVALID_PARAMETER:
-      SvcStatus = ARM_SVC_SPM_RET_INVALID_PARAMS;
-      break;
-    case EFI_ACCESS_DENIED:
-      SvcStatus = ARM_SVC_SPM_RET_DENIED;
-      break;
-    case EFI_OUT_OF_RESOURCES:
-      SvcStatus = ARM_SVC_SPM_RET_NO_MEMORY;
-      break;
-    case EFI_UNSUPPORTED:
-      SvcStatus = ARM_SVC_SPM_RET_NOT_SUPPORTED;
-      break;
-    default:
-      SvcStatus = ARM_SVC_SPM_RET_NOT_SUPPORTED;
-      break;
-  }
+    switch (Status) {
+      case EFI_SUCCESS:
+        SvcStatus = ARM_SVC_SPM_RET_SUCCESS;
+        break;
+      case EFI_INVALID_PARAMETER:
+        SvcStatus = ARM_SVC_SPM_RET_INVALID_PARAMS;
+        break;
+      case EFI_ACCESS_DENIED:
+        SvcStatus = ARM_SVC_SPM_RET_DENIED;
+        break;
+      case EFI_OUT_OF_RESOURCES:
+        SvcStatus = ARM_SVC_SPM_RET_NO_MEMORY;
+        break;
+      case EFI_UNSUPPORTED:
+        SvcStatus = ARM_SVC_SPM_RET_NOT_SUPPORTED;
+        break;
+      default:
+        SvcStatus = ARM_SVC_SPM_RET_NOT_SUPPORTED;
+        break;
+    }
 
-  if (FfaEnabled) {
-    EventCompleteSvcArgs->Arg0 = ARM_SVC_ID_FFA_MSG_SEND_DIRECT_RESP;
-    EventCompleteSvcArgs->Arg1 = 0;
-    EventCompleteSvcArgs->Arg2 = 0;
-    EventCompleteSvcArgs->Arg3 = ARM_SVC_ID_SP_EVENT_COMPLETE;
-    EventCompleteSvcArgs->Arg4 = SvcStatus;
-  } else {
-    EventCompleteSvcArgs->Arg0 = ARM_SVC_ID_SP_EVENT_COMPLETE;
-    EventCompleteSvcArgs->Arg1 = SvcStatus;
+    if (FfaEnabled) {
+      EventCompleteSvcArgs->Arg0 = ARM_SVC_ID_FFA_MSG_SEND_DIRECT_RESP;
+      EventCompleteSvcArgs->Arg1 = 0;
+      EventCompleteSvcArgs->Arg2 = 0;
+      EventCompleteSvcArgs->Arg3 = ARM_SVC_ID_SP_EVENT_COMPLETE;
+      EventCompleteSvcArgs->Arg4 = SvcStatus;
+    } else {
+      EventCompleteSvcArgs->Arg0 = ARM_SVC_ID_SP_EVENT_COMPLETE;
+      EventCompleteSvcArgs->Arg1 = SvcStatus;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

this commit introduced the bug https://github.com/microsoft/mu_silicon_arm_tiano/commit/de3cf0cfa9216637b8879ef14682d4d895e9a013#diff-516242aa392b05a93f0222ff1e534b10a1f905124a16abd5704fa938d6590b48R143 where the swtch case and if loop for return status were moved outside the while loop

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

tested on arm platform

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
