### PR TITLE
[Rebase & FF][FF-A] Adding FDT based MemoryAllocationLib and ServicesTableLib for Secure Partitions

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -120,6 +120,10 @@
   #
   PlatformFfaInterruptLib|Include/Library/PlatformFfaInterruptLib.h
 
+  ##  @libraryclass  Provides a services table for Secure partitions.
+  #
+  SecurePartitionServicesTableLib|Include/Library/SecurePartitionServicesTableLib.h
+
 [Guids.common]
   gArmTokenSpaceGuid       = { 0xBB11ECFE, 0x820F, 0x4968, { 0xBB, 0xA6, 0xF7, 0x6A, 0xFE, 0x30, 0x25, 0x96 } }
 

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -144,6 +144,7 @@
   ArmPkg/Library/ArmFfaLibEx/ArmFfaLibEx.inf
   ArmPkg/Library/PlatformFfaInterruptLibNull/PlatformFfaInterruptLib.inf
   ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.inf
+  ArmPkg/Library/SecurePartitionServicesTableLib/SecurePartitionServicesTableLib.inf
 
   ArmPkg/Drivers/CpuDxe/CpuDxe.inf
   ArmPkg/Drivers/CpuPei/CpuPei.inf

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -145,6 +145,7 @@
   ArmPkg/Library/PlatformFfaInterruptLibNull/PlatformFfaInterruptLib.inf
   ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.inf
   ArmPkg/Library/SecurePartitionServicesTableLib/SecurePartitionServicesTableLib.inf
+  ArmPkg/Library/SecurePartitionMemoryAllocationLib/SecurePartitionMemoryAllocationLib.inf
 
   ArmPkg/Drivers/CpuDxe/CpuDxe.inf
   ArmPkg/Drivers/CpuPei/CpuPei.inf

--- a/ArmPkg/Include/Library/SecurePartitionServicesTableLib.h
+++ b/ArmPkg/Include/Library/SecurePartitionServicesTableLib.h
@@ -1,0 +1,22 @@
+/** @file
+  Provides a service to retrieve a pointer to the EFI Boot Services Table.
+  Only available to DXE and UEFI module types.
+
+Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SECURE_PARTITION_SERVICES_TABLE_LIB_H_
+#define SECURE_PARTITION_SERVICES_TABLE_LIB_H_
+
+typedef struct {
+  ///
+  /// The table header for the EFI Boot Services Table.
+  ///
+  VOID    *FDTAddress;
+} SECURE_PARTITION_SERVICES_TABLE;
+
+extern SECURE_PARTITION_SERVICES_TABLE  *gSpst;
+
+#endif

--- a/ArmPkg/Library/SecurePartitionEntryPoint/SecurePartitionEntryPoint.inf
+++ b/ArmPkg/Library/SecurePartitionEntryPoint/SecurePartitionEntryPoint.inf
@@ -1,5 +1,5 @@
 ## @file
-# Module entry point library for DXE core.
+# Secure Partition System Table library implementation.
 #
 # Copyright (c) 2017 - 2021, Arm Ltd. All rights reserved.<BR>
 #

--- a/ArmPkg/Library/SecurePartitionEntryPoint/StandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/SecurePartitionEntryPoint/StandaloneMmCoreEntryPoint.c
@@ -20,11 +20,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/ArmMmuLib.h>
 #include <Library/ArmSvcLib.h>
 #include <Library/DebugLib.h>
-#include <Library/HobLib.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/SerialPortLib.h>
 #include <Library/ArmStandaloneMmMmuLib.h>
+#include <Library/SecurePartitionServicesTableLib.h>
 #include <Library/PcdLib.h>
 
 #include <IndustryStandard/ArmStdSmc.h>
@@ -32,24 +32,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <IndustryStandard/ArmFfaBootInfo.h>
 
-#define SPM_MAJOR_VER_MASK   0xFFFF0000
-#define SPM_MINOR_VER_MASK   0x0000FFFF
-#define SPM_MAJOR_VER_SHIFT  16
-
-#define SPM_MAJOR_VER  0
-#define SPM_MINOR_VER  1
-
-#define BOOT_PAYLOAD_VERSION  1
-
 #define FFA_PAGE_4K   0
 #define FFA_PAGE_16K  1
 #define FFA_PAGE_64K  2
 
-// Local variable to help Standalone MM Core decide whether FF-A ABIs can be
-// used for all communication. This variable is usable only after the StMM image
-// has been relocated and all image section permissions have been correctly
-// updated.
-STATIC BOOLEAN  mUseOnlyFfaAbis = FALSE;
+// Materialize the Secure Partition Services Table
+SECURE_PARTITION_SERVICES_TABLE  mSpst = {
+  .FDTAddress = NULL
+};
 
 /**
   This structure is used to stage boot information required to initialize the
@@ -336,7 +326,6 @@ ModuleEntryPoint (
   INT32                         Ret;
   UINT32                        SectionHeaderOffset;
   UINT16                        NumberOfSections;
-  VOID                          *HobStart;
   VOID                          *TeData;
   UINTN                         TeDataSize;
   EFI_PHYSICAL_ADDRESS          ImageBase;
@@ -411,6 +400,10 @@ ModuleEntryPoint (
     goto finish;
   }
 
+  // Now that we can update globals, initialize the SPST for other libraries
+  mSpst.FDTAddress = DtbAddress;
+  gSpst            = &mSpst;
+
   if (ImageContext.ImageAddress != (UINTN)TeData) {
     ImageContext.ImageAddress = (UINTN)TeData;
     ArmSetMemoryRegionNoExec (ImageBase, SIZE_4KB);
@@ -420,15 +413,14 @@ ModuleEntryPoint (
     ASSERT_EFI_ERROR (Status);
   }
 
-  // Update the global copy now that the image has been relocated.
-  mUseOnlyFfaAbis = UseOnlyFfaAbis;
+  ProcessLibraryConstructorList (NULL, NULL);
 
   ProcessLibraryConstructorList (NULL, NULL);
 
   //
   // Call the MM Core entry point
   //
-  ProcessModuleEntryPointList (HobStart);
+  ProcessModuleEntryPointList (NULL);
 
 finish:
   if (Status == RETURN_UNSUPPORTED) {

--- a/ArmPkg/Library/SecurePartitionMemoryAllocationLib/Page.c
+++ b/ArmPkg/Library/SecurePartitionMemoryAllocationLib/Page.c
@@ -1,0 +1,399 @@
+/** @file
+  MM Memory page management functions.
+
+  Copyright (c) 2009 - 2014, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2018, ARM Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+
+typedef struct {
+  LIST_ENTRY    Link;
+  UINTN         NumberOfPages;
+} FREE_PAGE_LIST;
+
+#define NEXT_MEMORY_DESCRIPTOR(MemoryDescriptor, Size) \
+  ((EFI_MEMORY_DESCRIPTOR *)((UINT8 *)(MemoryDescriptor) + (Size)))
+
+#define TRUNCATE_TO_PAGES(a)  ((a) >> EFI_PAGE_SHIFT)
+
+LIST_ENTRY  mMmMemoryMap = INITIALIZE_LIST_HEAD_VARIABLE (mMmMemoryMap);
+
+UINTN  mMapKey;
+
+/**
+  Internal Function. Allocate n pages from given free page node.
+
+  @param  Pages                  The free page node.
+  @param  NumberOfPages          Number of pages to be allocated.
+  @param  MaxAddress             Request to allocate memory below this address.
+
+  @return Memory address of allocated pages.
+
+**/
+UINTN
+InternalAllocPagesOnOneNode (
+  IN OUT FREE_PAGE_LIST  *Pages,
+  IN     UINTN           NumberOfPages,
+  IN     UINTN           MaxAddress
+  )
+{
+  UINTN           Top;
+  UINTN           Bottom;
+  FREE_PAGE_LIST  *Node;
+
+  Top = TRUNCATE_TO_PAGES (MaxAddress + 1 - (UINTN)Pages);
+  if (Top > Pages->NumberOfPages) {
+    Top = Pages->NumberOfPages;
+  }
+
+  Bottom = Top - NumberOfPages;
+
+  if (Top < Pages->NumberOfPages) {
+    Node                = (FREE_PAGE_LIST *)((UINTN)Pages + EFI_PAGES_TO_SIZE (Top));
+    Node->NumberOfPages = Pages->NumberOfPages - Top;
+    InsertHeadList (&Pages->Link, &Node->Link);
+  }
+
+  if (Bottom > 0) {
+    Pages->NumberOfPages = Bottom;
+  } else {
+    RemoveEntryList (&Pages->Link);
+  }
+
+  return (UINTN)Pages + EFI_PAGES_TO_SIZE (Bottom);
+}
+
+/**
+  Internal Function. Allocate n pages from free page list below MaxAddress.
+
+  @param  FreePageList           The free page node.
+  @param  NumberOfPages          Number of pages to be allocated.
+  @param  MaxAddress             Request to allocate memory below this address.
+
+  @return Memory address of allocated pages.
+
+**/
+UINTN
+InternalAllocMaxAddress (
+  IN OUT LIST_ENTRY  *FreePageList,
+  IN     UINTN       NumberOfPages,
+  IN     UINTN       MaxAddress
+  )
+{
+  LIST_ENTRY      *Node;
+  FREE_PAGE_LIST  *Pages;
+
+  for (Node = FreePageList->BackLink; Node != FreePageList; Node = Node->BackLink) {
+    Pages = BASE_CR (Node, FREE_PAGE_LIST, Link);
+    if ((Pages->NumberOfPages >= NumberOfPages) &&
+        ((UINTN)Pages + EFI_PAGES_TO_SIZE (NumberOfPages) - 1 <= MaxAddress))
+    {
+      return InternalAllocPagesOnOneNode (Pages, NumberOfPages, MaxAddress);
+    }
+  }
+
+  return (UINTN)(-1);
+}
+
+/**
+  Internal Function. Allocate n pages from free page list at given address.
+
+  @param  FreePageList           The free page node.
+  @param  NumberOfPages          Number of pages to be allocated.
+  @param  MaxAddress             Request to allocate memory below this address.
+
+  @return Memory address of allocated pages.
+
+**/
+UINTN
+InternalAllocAddress (
+  IN OUT LIST_ENTRY  *FreePageList,
+  IN     UINTN       NumberOfPages,
+  IN     UINTN       Address
+  )
+{
+  UINTN           EndAddress;
+  LIST_ENTRY      *Node;
+  FREE_PAGE_LIST  *Pages;
+
+  if ((Address & EFI_PAGE_MASK) != 0) {
+    return ~Address;
+  }
+
+  EndAddress = Address + EFI_PAGES_TO_SIZE (NumberOfPages);
+  for (Node = FreePageList->BackLink; Node != FreePageList; Node = Node->BackLink) {
+    Pages = BASE_CR (Node, FREE_PAGE_LIST, Link);
+    if ((UINTN)Pages <= Address) {
+      if ((UINTN)Pages + EFI_PAGES_TO_SIZE (Pages->NumberOfPages) < EndAddress) {
+        break;
+      }
+
+      return InternalAllocPagesOnOneNode (Pages, NumberOfPages, EndAddress);
+    }
+  }
+
+  return ~Address;
+}
+
+/**
+  Allocates pages from the memory map.
+
+  @param  Type                   The type of allocation to perform.
+  @param  MemoryType             The type of memory to turn the allocated pages
+                                 into.
+  @param  NumberOfPages          The number of pages to allocate.
+  @param  Memory                 A pointer to receive the base allocated memory
+                                 address.
+
+  @retval EFI_INVALID_PARAMETER  Parameters violate checking rules defined in spec.
+  @retval EFI_NOT_FOUND          Could not allocate pages match the requirement.
+  @retval EFI_OUT_OF_RESOURCES   No enough pages to allocate.
+  @retval EFI_SUCCESS            Pages successfully allocated.
+
+**/
+EFI_STATUS
+EFIAPI
+MmInternalAllocatePages (
+  IN  EFI_ALLOCATE_TYPE     Type,
+  IN  EFI_MEMORY_TYPE       MemoryType,
+  IN  UINTN                 NumberOfPages,
+  OUT EFI_PHYSICAL_ADDRESS  *Memory
+  )
+{
+  UINTN  RequestedAddress;
+
+  if ((MemoryType != EfiRuntimeServicesCode) &&
+      (MemoryType != EfiRuntimeServicesData))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (NumberOfPages > TRUNCATE_TO_PAGES ((UINTN)-1) + 1) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // We don't track memory type in MM
+  //
+  RequestedAddress = (UINTN)*Memory;
+  switch (Type) {
+    case AllocateAnyPages:
+      RequestedAddress = (UINTN)(-1);
+    case AllocateMaxAddress:
+      *Memory = InternalAllocMaxAddress (
+                  &mMmMemoryMap,
+                  NumberOfPages,
+                  RequestedAddress
+                  );
+      if (*Memory == (UINTN)-1) {
+        return EFI_OUT_OF_RESOURCES;
+      }
+
+      break;
+    case AllocateAddress:
+      *Memory = InternalAllocAddress (
+                  &mMmMemoryMap,
+                  NumberOfPages,
+                  RequestedAddress
+                  );
+      if (*Memory != RequestedAddress) {
+        return EFI_NOT_FOUND;
+      }
+
+      break;
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Allocates pages from the memory map.
+
+  @param  Type                   The type of allocation to perform.
+  @param  MemoryType             The type of memory to turn the allocated pages
+                                 into.
+  @param  NumberOfPages          The number of pages to allocate.
+  @param  Memory                 A pointer to receive the base allocated memory
+                                 address.
+
+  @retval EFI_INVALID_PARAMETER  Parameters violate checking rules defined in spec.
+  @retval EFI_NOT_FOUND          Could not allocate pages match the requirement.
+  @retval EFI_OUT_OF_RESOURCES   No enough pages to allocate.
+  @retval EFI_SUCCESS            Pages successfully allocated.
+
+**/
+EFI_STATUS
+EFIAPI
+MmAllocatePages (
+  IN  EFI_ALLOCATE_TYPE     Type,
+  IN  EFI_MEMORY_TYPE       MemoryType,
+  IN  UINTN                 NumberOfPages,
+  OUT EFI_PHYSICAL_ADDRESS  *Memory
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = MmInternalAllocatePages (Type, MemoryType, NumberOfPages, Memory);
+  return Status;
+}
+
+/**
+  Internal Function. Merge two adjacent nodes.
+
+  @param  First             The first of two nodes to merge.
+
+  @return Pointer to node after merge (if success) or pointer to next node (if fail).
+
+**/
+FREE_PAGE_LIST *
+InternalMergeNodes (
+  IN FREE_PAGE_LIST  *First
+  )
+{
+  FREE_PAGE_LIST  *Next;
+
+  Next = BASE_CR (First->Link.ForwardLink, FREE_PAGE_LIST, Link);
+  ASSERT (
+    TRUNCATE_TO_PAGES ((UINTN)Next - (UINTN)First) >= First->NumberOfPages
+    );
+
+  if (TRUNCATE_TO_PAGES ((UINTN)Next - (UINTN)First) == First->NumberOfPages) {
+    First->NumberOfPages += Next->NumberOfPages;
+    RemoveEntryList (&Next->Link);
+    Next = First;
+  }
+
+  return Next;
+}
+
+/**
+  Frees previous allocated pages.
+
+  @param  Memory                 Base address of memory being freed.
+  @param  NumberOfPages          The number of pages to free.
+
+  @retval EFI_NOT_FOUND          Could not find the entry that covers the range.
+  @retval EFI_INVALID_PARAMETER  Address not aligned.
+  @return EFI_SUCCESS            Pages successfully freed.
+
+**/
+EFI_STATUS
+EFIAPI
+MmInternalFreePages (
+  IN EFI_PHYSICAL_ADDRESS  Memory,
+  IN UINTN                 NumberOfPages
+  )
+{
+  LIST_ENTRY      *Node;
+  FREE_PAGE_LIST  *Pages;
+
+  if ((Memory & EFI_PAGE_MASK) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Pages = NULL;
+  Node  = mMmMemoryMap.ForwardLink;
+  while (Node != &mMmMemoryMap) {
+    Pages = BASE_CR (Node, FREE_PAGE_LIST, Link);
+    if (Memory < (UINTN)Pages) {
+      break;
+    }
+
+    Node = Node->ForwardLink;
+  }
+
+  if ((Node != &mMmMemoryMap) &&
+      (Memory + EFI_PAGES_TO_SIZE (NumberOfPages) > (UINTN)Pages))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Node->BackLink != &mMmMemoryMap) {
+    Pages = BASE_CR (Node->BackLink, FREE_PAGE_LIST, Link);
+    if ((UINTN)Pages + EFI_PAGES_TO_SIZE (Pages->NumberOfPages) > Memory) {
+      return EFI_INVALID_PARAMETER;
+    }
+  }
+
+  Pages                = (FREE_PAGE_LIST *)(UINTN)Memory;
+  Pages->NumberOfPages = NumberOfPages;
+  InsertTailList (Node, &Pages->Link);
+
+  if (Pages->Link.BackLink != &mMmMemoryMap) {
+    Pages = InternalMergeNodes (
+              BASE_CR (Pages->Link.BackLink, FREE_PAGE_LIST, Link)
+              );
+  }
+
+  if (Node != &mMmMemoryMap) {
+    InternalMergeNodes (Pages);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Frees previous allocated pages.
+
+  @param  Memory                 Base address of memory being freed.
+  @param  NumberOfPages          The number of pages to free.
+
+  @retval EFI_NOT_FOUND          Could not find the entry that covers the range.
+  @retval EFI_INVALID_PARAMETER  Address not aligned.
+  @return EFI_SUCCESS            Pages successfully freed.
+
+**/
+EFI_STATUS
+EFIAPI
+MmFreePages (
+  IN EFI_PHYSICAL_ADDRESS  Memory,
+  IN UINTN                 NumberOfPages
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = MmInternalFreePages (Memory, NumberOfPages);
+  return Status;
+}
+
+/**
+  Add free MMRAM region for use by memory service.
+
+  @param  MemBase                Base address of memory region.
+  @param  MemLength              Length of the memory region.
+  @param  Type                   Memory type.
+  @param  Attributes             Memory region state.
+
+**/
+VOID
+MmAddMemoryRegion (
+  IN  EFI_PHYSICAL_ADDRESS  MemBase,
+  IN  UINT64                MemLength,
+  IN  EFI_MEMORY_TYPE       Type,
+  IN  UINT64                Attributes
+  )
+{
+  UINTN  AlignedMemBase;
+
+  //
+  // Do not add memory regions that is already allocated, needs testing, or needs ECC initialization
+  //
+  if ((Attributes & (EFI_ALLOCATED | EFI_NEEDS_TESTING | EFI_NEEDS_ECC_INITIALIZATION)) != 0) {
+    return;
+  }
+
+  //
+  // Align range on an EFI_PAGE_SIZE boundary
+  //
+  AlignedMemBase = (UINTN)(MemBase + EFI_PAGE_MASK) & ~EFI_PAGE_MASK;
+  MemLength     -= AlignedMemBase - MemBase;
+  MmFreePages (AlignedMemBase, TRUNCATE_TO_PAGES ((UINTN)MemLength));
+}

--- a/ArmPkg/Library/SecurePartitionMemoryAllocationLib/Pool.c
+++ b/ArmPkg/Library/SecurePartitionMemoryAllocationLib/Pool.c
@@ -1,0 +1,333 @@
+/** @file
+  SMM Memory pool management functions.
+
+  Copyright (c) 2009 - 2014, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2021, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+
+#include "SecurePartitionMemoryAllocationLib.h"
+
+typedef struct {
+  UINT32             Signature;
+  BOOLEAN            Available;
+  EFI_MEMORY_TYPE    Type;
+  UINTN              Size;
+} POOL_HEADER;
+
+typedef struct {
+  POOL_HEADER    Header;
+  LIST_ENTRY     Link;
+} FREE_POOL_HEADER;
+
+//
+// MIN_POOL_SHIFT must not be less than 5
+//
+#define MIN_POOL_SHIFT  6
+#define MIN_POOL_SIZE   (1 << MIN_POOL_SHIFT)
+
+//
+// MAX_POOL_SHIFT must not be less than EFI_PAGE_SHIFT - 1
+//
+#define MAX_POOL_SHIFT  (EFI_PAGE_SHIFT - 1)
+#define MAX_POOL_SIZE   (1 << MAX_POOL_SHIFT)
+
+//
+// MAX_POOL_INDEX are calculated by maximum and minimum pool sizes
+//
+#define MAX_POOL_INDEX  (MAX_POOL_SHIFT - MIN_POOL_SHIFT + 1)
+
+LIST_ENTRY  mMmPoolLists[MAX_POOL_INDEX];
+//
+// To cache the MMRAM base since when Loading modules At fixed address feature is enabled,
+// all module is assigned an offset relative the MMRAM base in build time.
+//
+GLOBAL_REMOVE_IF_UNREFERENCED  EFI_PHYSICAL_ADDRESS  gLoadModuleAtFixAddressMmramBase = 0;
+
+/**
+  Called to initialize the memory service.
+
+  @param   MmramRangeCount       Number of MMRAM Regions
+  @param   MmramRanges           Pointer to MMRAM Descriptors
+
+**/
+VOID
+MmInitializeMemoryServices (
+  IN UINTN                 MmramRangeCount,
+  IN EFI_MMRAM_DESCRIPTOR  *MmramRanges
+  )
+{
+  UINTN  Index;
+
+  //
+  // Initialize Pool list
+  //
+  for (Index = sizeof (mMmPoolLists) / sizeof (*mMmPoolLists); Index > 0;) {
+    InitializeListHead (&mMmPoolLists[--Index]);
+  }
+
+  //
+  // Initialize free MMRAM regions
+  //
+  for (Index = 0; Index < MmramRangeCount; Index++) {
+    //
+    // BUGBUG: Add legacy MMRAM region is buggy.
+    //
+    if (MmramRanges[Index].CpuStart < BASE_1MB) {
+      continue;
+    }
+
+    DEBUG ((
+      DEBUG_INFO,
+      "MmAddMemoryRegion %d : 0x%016lx - 0x%016lx\n",
+      Index,
+      MmramRanges[Index].CpuStart,
+      MmramRanges[Index].PhysicalSize
+      ));
+    MmAddMemoryRegion (
+      MmramRanges[Index].CpuStart,
+      MmramRanges[Index].PhysicalSize,
+      EfiConventionalMemory,
+      MmramRanges[Index].RegionState
+      );
+  }
+}
+
+/**
+  Internal Function. Allocate a pool by specified PoolIndex.
+
+  @param  PoolIndex             Index which indicate the Pool size.
+  @param  FreePoolHdr           The returned Free pool.
+
+  @retval EFI_OUT_OF_RESOURCES   Allocation failed.
+  @retval EFI_SUCCESS            Pool successfully allocated.
+
+**/
+EFI_STATUS
+InternalAllocPoolByIndex (
+  IN  UINTN             PoolIndex,
+  OUT FREE_POOL_HEADER  **FreePoolHdr
+  )
+{
+  EFI_STATUS            Status;
+  FREE_POOL_HEADER      *Hdr;
+  EFI_PHYSICAL_ADDRESS  Address;
+
+  ASSERT (PoolIndex <= MAX_POOL_INDEX);
+  Status = EFI_SUCCESS;
+  Hdr    = NULL;
+  if (PoolIndex == MAX_POOL_INDEX) {
+    Status = MmInternalAllocatePages (
+               AllocateAnyPages,
+               EfiRuntimeServicesData,
+               EFI_SIZE_TO_PAGES (MAX_POOL_SIZE << 1),
+               &Address
+               );
+    if (EFI_ERROR (Status)) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Hdr = (FREE_POOL_HEADER *)(UINTN)Address;
+  } else if (!IsListEmpty (&mMmPoolLists[PoolIndex])) {
+    Hdr = BASE_CR (GetFirstNode (&mMmPoolLists[PoolIndex]), FREE_POOL_HEADER, Link);
+    RemoveEntryList (&Hdr->Link);
+  } else {
+    Status = InternalAllocPoolByIndex (PoolIndex + 1, &Hdr);
+    if (!EFI_ERROR (Status)) {
+      Hdr->Header.Size    >>= 1;
+      Hdr->Header.Available = TRUE;
+      InsertHeadList (&mMmPoolLists[PoolIndex], &Hdr->Link);
+      Hdr = (FREE_POOL_HEADER *)((UINT8 *)Hdr + Hdr->Header.Size);
+    }
+  }
+
+  if (!EFI_ERROR (Status)) {
+    Hdr->Header.Size      = MIN_POOL_SIZE << PoolIndex;
+    Hdr->Header.Available = FALSE;
+  }
+
+  *FreePoolHdr = Hdr;
+  return Status;
+}
+
+/**
+  Internal Function. Free a pool by specified PoolIndex.
+
+  @param  FreePoolHdr           The pool to free.
+
+  @retval EFI_SUCCESS           Pool successfully freed.
+
+**/
+EFI_STATUS
+InternalFreePoolByIndex (
+  IN FREE_POOL_HEADER  *FreePoolHdr
+  )
+{
+  UINTN  PoolIndex;
+
+  ASSERT ((FreePoolHdr->Header.Size & (FreePoolHdr->Header.Size - 1)) == 0);
+  ASSERT (((UINTN)FreePoolHdr & (FreePoolHdr->Header.Size - 1)) == 0);
+  ASSERT (FreePoolHdr->Header.Size >= MIN_POOL_SIZE);
+
+  PoolIndex                     = (UINTN)(HighBitSet32 ((UINT32)FreePoolHdr->Header.Size) - MIN_POOL_SHIFT);
+  FreePoolHdr->Header.Available = TRUE;
+  if (PoolIndex >= MAX_POOL_INDEX) {
+    ASSERT (PoolIndex < MAX_POOL_INDEX);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  InsertHeadList (&mMmPoolLists[PoolIndex], &FreePoolHdr->Link);
+  return EFI_SUCCESS;
+}
+
+/**
+  Allocate pool of a particular type.
+
+  @param  PoolType               Type of pool to allocate.
+  @param  Size                   The amount of pool to allocate.
+  @param  Buffer                 The address to return a pointer to the allocated
+                                 pool.
+
+  @retval EFI_INVALID_PARAMETER  PoolType not valid.
+  @retval EFI_OUT_OF_RESOURCES   Size exceeds max pool size or allocation failed.
+  @retval EFI_SUCCESS            Pool successfully allocated.
+
+**/
+EFI_STATUS
+EFIAPI
+MmInternalAllocatePool (
+  IN   EFI_MEMORY_TYPE  PoolType,
+  IN   UINTN            Size,
+  OUT  VOID             **Buffer
+  )
+{
+  POOL_HEADER           *PoolHdr;
+  FREE_POOL_HEADER      *FreePoolHdr;
+  EFI_STATUS            Status;
+  EFI_PHYSICAL_ADDRESS  Address;
+  UINTN                 PoolIndex;
+
+  if ((PoolType != EfiRuntimeServicesCode) &&
+      (PoolType != EfiRuntimeServicesData))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Size += sizeof (*PoolHdr);
+  if (Size > MAX_POOL_SIZE) {
+    Size   = EFI_SIZE_TO_PAGES (Size);
+    Status = MmInternalAllocatePages (AllocateAnyPages, PoolType, Size, &Address);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    PoolHdr            = (POOL_HEADER *)(UINTN)Address;
+    PoolHdr->Size      = EFI_PAGES_TO_SIZE (Size);
+    PoolHdr->Available = FALSE;
+    *Buffer            = PoolHdr + 1;
+    return Status;
+  }
+
+  Size      = (Size + MIN_POOL_SIZE - 1) >> MIN_POOL_SHIFT;
+  PoolIndex = (UINTN)HighBitSet32 ((UINT32)Size);
+  if ((Size & (Size - 1)) != 0) {
+    PoolIndex++;
+  }
+
+  Status = InternalAllocPoolByIndex (PoolIndex, &FreePoolHdr);
+  if (!EFI_ERROR (Status)) {
+    *Buffer = &FreePoolHdr->Header + 1;
+  }
+
+  return Status;
+}
+
+/**
+  Allocate pool of a particular type.
+
+  @param  PoolType               Type of pool to allocate.
+  @param  Size                   The amount of pool to allocate.
+  @param  Buffer                 The address to return a pointer to the allocated
+                                 pool.
+
+  @retval EFI_INVALID_PARAMETER  PoolType not valid.
+  @retval EFI_OUT_OF_RESOURCES   Size exceeds max pool size or allocation failed.
+  @retval EFI_SUCCESS            Pool successfully allocated.
+
+**/
+EFI_STATUS
+EFIAPI
+MmAllocatePool (
+  IN   EFI_MEMORY_TYPE  PoolType,
+  IN   UINTN            Size,
+  OUT  VOID             **Buffer
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = MmInternalAllocatePool (PoolType, Size, Buffer);
+  return Status;
+}
+
+/**
+  Frees pool.
+
+  @param  Buffer                 The allocated pool entry to free.
+
+  @retval EFI_INVALID_PARAMETER  Buffer is not a valid value.
+  @retval EFI_SUCCESS            Pool successfully freed.
+
+**/
+EFI_STATUS
+EFIAPI
+MmInternalFreePool (
+  IN VOID  *Buffer
+  )
+{
+  FREE_POOL_HEADER  *FreePoolHdr;
+
+  if (Buffer == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FreePoolHdr = (FREE_POOL_HEADER *)((POOL_HEADER *)Buffer - 1);
+  ASSERT (!FreePoolHdr->Header.Available);
+
+  if (FreePoolHdr->Header.Size > MAX_POOL_SIZE) {
+    ASSERT (((UINTN)FreePoolHdr & EFI_PAGE_MASK) == 0);
+    ASSERT ((FreePoolHdr->Header.Size & EFI_PAGE_MASK) == 0);
+    return MmInternalFreePages (
+             (EFI_PHYSICAL_ADDRESS)(UINTN)FreePoolHdr,
+             EFI_SIZE_TO_PAGES (FreePoolHdr->Header.Size)
+             );
+  }
+
+  return InternalFreePoolByIndex (FreePoolHdr);
+}
+
+/**
+  Frees pool.
+
+  @param  Buffer                 The allocated pool entry to free.
+
+  @retval EFI_INVALID_PARAMETER  Buffer is not a valid value.
+  @retval EFI_SUCCESS            Pool successfully freed.
+
+**/
+EFI_STATUS
+EFIAPI
+MmFreePool (
+  IN VOID  *Buffer
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = MmInternalFreePool (Buffer);
+  return Status;
+}

--- a/ArmPkg/Library/SecurePartitionMemoryAllocationLib/SecurePartitionMemoryAllocationLib.c
+++ b/ArmPkg/Library/SecurePartitionMemoryAllocationLib/SecurePartitionMemoryAllocationLib.c
@@ -1,0 +1,1054 @@
+/** @file
+  Support routines for memory allocation routines based on Standalone MM Core internal functions.
+
+  Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2021, ARM Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+
+#include <libfdt.h>
+
+#include <Guid/MmramMemoryReserve.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/SecurePartitionServicesTableLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+
+#include "SecurePartitionMemoryAllocationLib.h"
+
+/**
+  Allocates one or more 4KB pages of a certain memory type.
+
+  Allocates the number of 4KB pages of a certain memory type and returns a pointer to the allocated
+  buffer.  The buffer returned is aligned on a 4KB boundary.  If Pages is 0, then NULL is returned.
+  If there is not enough memory remaining to satisfy the request, then NULL is returned.
+
+  @param  MemoryType            The type of memory to allocate.
+  @param  Pages                 The number of 4 KB pages to allocate.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+InternalAllocatePages (
+  IN EFI_MEMORY_TYPE  MemoryType,
+  IN UINTN            Pages
+  )
+{
+  EFI_STATUS            Status;
+  EFI_PHYSICAL_ADDRESS  Memory;
+
+  if (Pages == 0) {
+    return NULL;
+  }
+
+  Status = MmAllocatePages (AllocateAnyPages, MemoryType, Pages, &Memory);
+  if (EFI_ERROR (Status)) {
+    return NULL;
+  }
+
+  return (VOID *)(UINTN)Memory;
+}
+
+/**
+  Allocates one or more 4KB pages of type EfiBootServicesData.
+
+  Allocates the number of 4KB pages of type EfiBootServicesData and returns a pointer to the
+  allocated buffer.  The buffer returned is aligned on a 4KB boundary.  If Pages is 0, then NULL
+  is returned.  If there is not enough memory remaining to satisfy the request, then NULL is
+  returned.
+
+  @param  Pages                 The number of 4 KB pages to allocate.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocatePages (
+  IN UINTN  Pages
+  )
+{
+  return InternalAllocatePages (EfiRuntimeServicesData, Pages);
+}
+
+/**
+  Allocates one or more 4KB pages of type EfiRuntimeServicesData.
+
+  Allocates the number of 4KB pages of type EfiRuntimeServicesData and returns a pointer to the
+  allocated buffer.  The buffer returned is aligned on a 4KB boundary.  If Pages is 0, then NULL
+  is returned.  If there is not enough memory remaining to satisfy the request, then NULL is
+  returned.
+
+  @param  Pages                 The number of 4 KB pages to allocate.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateRuntimePages (
+  IN UINTN  Pages
+  )
+{
+  return InternalAllocatePages (EfiRuntimeServicesData, Pages);
+}
+
+/**
+  Allocates one or more 4KB pages of type EfiReservedMemoryType.
+
+  Allocates the number of 4KB pages of type EfiReservedMemoryType and returns a pointer to the
+  allocated buffer.  The buffer returned is aligned on a 4KB boundary.  If Pages is 0, then NULL
+  is returned.  If there is not enough memory remaining to satisfy the request, then NULL is
+  returned.
+
+  @param  Pages                 The number of 4 KB pages to allocate.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateReservedPages (
+  IN UINTN  Pages
+  )
+{
+  return NULL;
+}
+
+/**
+  Frees one or more 4KB pages that were previously allocated with one of the page allocation
+  functions in the Memory Allocation Library.
+
+  Frees the number of 4KB pages specified by Pages from the buffer specified by Buffer.  Buffer
+  must have been allocated on a previous call to the page allocation services of the Memory
+  Allocation Library.  If it is not possible to free allocated pages, then this function will
+  perform no actions.
+
+  If Buffer was not allocated with a page allocation function in the Memory Allocation Library,
+  then ASSERT().
+  If Pages is zero, then ASSERT().
+
+  @param  Buffer                Pointer to the buffer of pages to free.
+  @param  Pages                 The number of 4 KB pages to free.
+
+**/
+VOID
+EFIAPI
+FreePages (
+  IN VOID   *Buffer,
+  IN UINTN  Pages
+  )
+{
+  EFI_STATUS  Status;
+
+  ASSERT (Pages != 0);
+  ASSERT (Buffer != NULL);
+  Status = MmFreePages ((EFI_PHYSICAL_ADDRESS)(UINTN)Buffer, Pages);
+  ASSERT_EFI_ERROR (Status);
+}
+
+/**
+  Allocates one or more 4KB pages of a certain memory type at a specified alignment.
+
+  Allocates the number of 4KB pages specified by Pages of a certain memory type with an alignment
+  specified by Alignment.  The allocated buffer is returned.  If Pages is 0, then NULL is returned.
+  If there is not enough memory at the specified alignment remaining to satisfy the request, then
+  NULL is returned.
+  If Alignment is not a power of two and Alignment is not zero, then ASSERT().
+  If Pages plus EFI_SIZE_TO_PAGES (Alignment) overflows, then ASSERT().
+
+  @param  MemoryType            The type of memory to allocate.
+  @param  Pages                 The number of 4 KB pages to allocate.
+  @param  Alignment             The requested alignment of the allocation.  Must be a power of two.
+                                If Alignment is zero, then byte alignment is used.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+InternalAllocateAlignedPages (
+  IN EFI_MEMORY_TYPE  MemoryType,
+  IN UINTN            Pages,
+  IN UINTN            Alignment
+  )
+{
+  EFI_STATUS            Status;
+  EFI_PHYSICAL_ADDRESS  Memory;
+  UINTN                 AlignedMemory;
+  UINTN                 AlignmentMask;
+  UINTN                 UnalignedPages;
+  UINTN                 RealPages;
+
+  //
+  // Alignment must be a power of two or zero.
+  //
+  ASSERT ((Alignment & (Alignment - 1)) == 0);
+
+  if (Pages == 0) {
+    return NULL;
+  }
+
+  if (Alignment > EFI_PAGE_SIZE) {
+    //
+    // Calculate the total number of pages since alignment is larger than page size.
+    //
+    AlignmentMask = Alignment - 1;
+    RealPages     = Pages + EFI_SIZE_TO_PAGES (Alignment);
+    //
+    // Make sure that Pages plus EFI_SIZE_TO_PAGES (Alignment) does not overflow.
+    //
+    ASSERT (RealPages > Pages);
+
+    Status = MmAllocatePages (AllocateAnyPages, MemoryType, RealPages, &Memory);
+    if (EFI_ERROR (Status)) {
+      return NULL;
+    }
+
+    AlignedMemory  = ((UINTN)Memory + AlignmentMask) & ~AlignmentMask;
+    UnalignedPages = EFI_SIZE_TO_PAGES (AlignedMemory - (UINTN)Memory);
+    if (UnalignedPages > 0) {
+      //
+      // Free first unaligned page(s).
+      //
+      Status = MmFreePages (Memory, UnalignedPages);
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    Memory         = (EFI_PHYSICAL_ADDRESS)(AlignedMemory + EFI_PAGES_TO_SIZE (Pages));
+    UnalignedPages = RealPages - Pages - UnalignedPages;
+    if (UnalignedPages > 0) {
+      //
+      // Free last unaligned page(s).
+      //
+      Status = MmFreePages (Memory, UnalignedPages);
+      ASSERT_EFI_ERROR (Status);
+    }
+  } else {
+    //
+    // Do not over-allocate pages in this case.
+    //
+    Status = MmAllocatePages (AllocateAnyPages, MemoryType, Pages, &Memory);
+    if (EFI_ERROR (Status)) {
+      return NULL;
+    }
+
+    AlignedMemory = (UINTN)Memory;
+  }
+
+  return (VOID *)AlignedMemory;
+}
+
+/**
+  Allocates one or more 4KB pages of type EfiBootServicesData at a specified alignment.
+
+  Allocates the number of 4KB pages specified by Pages of type EfiBootServicesData with an
+  alignment specified by Alignment.  The allocated buffer is returned.  If Pages is 0, then NULL is
+  returned.  If there is not enough memory at the specified alignment remaining to satisfy the
+  request, then NULL is returned.
+
+  If Alignment is not a power of two and Alignment is not zero, then ASSERT().
+  If Pages plus EFI_SIZE_TO_PAGES (Alignment) overflows, then ASSERT().
+
+  @param  Pages                 The number of 4 KB pages to allocate.
+  @param  Alignment             The requested alignment of the allocation.  Must be a power of two.
+                                If Alignment is zero, then byte alignment is used.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateAlignedPages (
+  IN UINTN  Pages,
+  IN UINTN  Alignment
+  )
+{
+  return InternalAllocateAlignedPages (EfiRuntimeServicesData, Pages, Alignment);
+}
+
+/**
+  Allocates one or more 4KB pages of type EfiRuntimeServicesData at a specified alignment.
+
+  Allocates the number of 4KB pages specified by Pages of type EfiRuntimeServicesData with an
+  alignment specified by Alignment.  The allocated buffer is returned.  If Pages is 0, then NULL is
+  returned.  If there is not enough memory at the specified alignment remaining to satisfy the
+  request, then NULL is returned.
+
+  If Alignment is not a power of two and Alignment is not zero, then ASSERT().
+  If Pages plus EFI_SIZE_TO_PAGES (Alignment) overflows, then ASSERT().
+
+  @param  Pages                 The number of 4 KB pages to allocate.
+  @param  Alignment             The requested alignment of the allocation.  Must be a power of two.
+                                If Alignment is zero, then byte alignment is used.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateAlignedRuntimePages (
+  IN UINTN  Pages,
+  IN UINTN  Alignment
+  )
+{
+  return InternalAllocateAlignedPages (EfiRuntimeServicesData, Pages, Alignment);
+}
+
+/**
+  Allocates one or more 4KB pages of type EfiReservedMemoryType at a specified alignment.
+
+  Allocates the number of 4KB pages specified by Pages of type EfiReservedMemoryType with an
+  alignment specified by Alignment.  The allocated buffer is returned.  If Pages is 0, then NULL is
+  returned.  If there is not enough memory at the specified alignment remaining to satisfy the
+  request, then NULL is returned.
+
+  If Alignment is not a power of two and Alignment is not zero, then ASSERT().
+  If Pages plus EFI_SIZE_TO_PAGES (Alignment) overflows, then ASSERT().
+
+  @param  Pages                 The number of 4 KB pages to allocate.
+  @param  Alignment             The requested alignment of the allocation.  Must be a power of two.
+                                If Alignment is zero, then byte alignment is used.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateAlignedReservedPages (
+  IN UINTN  Pages,
+  IN UINTN  Alignment
+  )
+{
+  return NULL;
+}
+
+/**
+  Frees one or more 4KB pages that were previously allocated with one of the aligned page
+  allocation functions in the Memory Allocation Library.
+
+  Frees the number of 4KB pages specified by Pages from the buffer specified by Buffer.  Buffer
+  must have been allocated on a previous call to the aligned page allocation services of the Memory
+  Allocation Library.  If it is not possible to free allocated pages, then this function will
+  perform no actions.
+
+  If Buffer was not allocated with an aligned page allocation function in the Memory Allocation
+  Library, then ASSERT().
+  If Pages is zero, then ASSERT().
+
+  @param  Buffer                Pointer to the buffer of pages to free.
+  @param  Pages                 The number of 4 KB pages to free.
+
+**/
+VOID
+EFIAPI
+FreeAlignedPages (
+  IN VOID   *Buffer,
+  IN UINTN  Pages
+  )
+{
+  EFI_STATUS  Status;
+
+  ASSERT (Pages != 0);
+  ASSERT (Buffer != NULL);
+  Status = MmFreePages ((EFI_PHYSICAL_ADDRESS)(UINTN)Buffer, Pages);
+  ASSERT_EFI_ERROR (Status);
+}
+
+/**
+  Allocates a buffer of a certain pool type.
+
+  Allocates the number bytes specified by AllocationSize of a certain pool type and returns a
+  pointer to the allocated buffer.  If AllocationSize is 0, then a valid buffer of 0 size is
+  returned.  If there is not enough memory remaining to satisfy the request, then NULL is returned.
+
+  @param  MemoryType            The type of memory to allocate.
+  @param  AllocationSize        The number of bytes to allocate.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+InternalAllocatePool (
+  IN EFI_MEMORY_TYPE  MemoryType,
+  IN UINTN            AllocationSize
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Memory;
+
+  Memory = NULL;
+
+  Status = MmAllocatePool (MemoryType, AllocationSize, &Memory);
+  if (EFI_ERROR (Status)) {
+    Memory = NULL;
+  }
+
+  return Memory;
+}
+
+/**
+  Allocates a buffer of type EfiBootServicesData.
+
+  Allocates the number bytes specified by AllocationSize of type EfiBootServicesData and returns a
+  pointer to the allocated buffer.  If AllocationSize is 0, then a valid buffer of 0 size is
+  returned.  If there is not enough memory remaining to satisfy the request, then NULL is returned.
+
+  @param  AllocationSize        The number of bytes to allocate.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocatePool (
+  IN UINTN  AllocationSize
+  )
+{
+  return InternalAllocatePool (EfiRuntimeServicesData, AllocationSize);
+}
+
+/**
+  Allocates a buffer of type EfiRuntimeServicesData.
+
+  Allocates the number bytes specified by AllocationSize of type EfiRuntimeServicesData and returns
+  a pointer to the allocated buffer.  If AllocationSize is 0, then a valid buffer of 0 size is
+  returned.  If there is not enough memory remaining to satisfy the request, then NULL is returned.
+
+  @param  AllocationSize        The number of bytes to allocate.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateRuntimePool (
+  IN UINTN  AllocationSize
+  )
+{
+  return InternalAllocatePool (EfiRuntimeServicesData, AllocationSize);
+}
+
+/**
+  Allocates a buffer of type EfiReservedMemoryType.
+
+  Allocates the number bytes specified by AllocationSize of type EfiReservedMemoryType and returns
+  a pointer to the allocated buffer.  If AllocationSize is 0, then a valid buffer of 0 size is
+  returned.  If there is not enough memory remaining to satisfy the request, then NULL is returned.
+
+  @param  AllocationSize        The number of bytes to allocate.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateReservedPool (
+  IN UINTN  AllocationSize
+  )
+{
+  return NULL;
+}
+
+/**
+  Allocates and zeros a buffer of a certain pool type.
+
+  Allocates the number bytes specified by AllocationSize of a certain pool type, clears the buffer
+  with zeros, and returns a pointer to the allocated buffer.  If AllocationSize is 0, then a valid
+  buffer of 0 size is returned.  If there is not enough memory remaining to satisfy the request,
+  then NULL is returned.
+
+  @param  PoolType              The type of memory to allocate.
+  @param  AllocationSize        The number of bytes to allocate and zero.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+InternalAllocateZeroPool (
+  IN EFI_MEMORY_TYPE  PoolType,
+  IN UINTN            AllocationSize
+  )
+{
+  VOID  *Memory;
+
+  Memory = InternalAllocatePool (PoolType, AllocationSize);
+  if (Memory != NULL) {
+    Memory = ZeroMem (Memory, AllocationSize);
+  }
+
+  return Memory;
+}
+
+/**
+  Allocates and zeros a buffer of type EfiBootServicesData.
+
+  Allocates the number bytes specified by AllocationSize of type EfiBootServicesData, clears the
+  buffer with zeros, and returns a pointer to the allocated buffer.  If AllocationSize is 0, then a
+  valid buffer of 0 size is returned.  If there is not enough memory remaining to satisfy the
+  request, then NULL is returned.
+
+  @param  AllocationSize        The number of bytes to allocate and zero.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateZeroPool (
+  IN UINTN  AllocationSize
+  )
+{
+  return InternalAllocateZeroPool (EfiRuntimeServicesData, AllocationSize);
+}
+
+/**
+  Allocates and zeros a buffer of type EfiRuntimeServicesData.
+
+  Allocates the number bytes specified by AllocationSize of type EfiRuntimeServicesData, clears the
+  buffer with zeros, and returns a pointer to the allocated buffer.  If AllocationSize is 0, then a
+  valid buffer of 0 size is returned.  If there is not enough memory remaining to satisfy the
+  request, then NULL is returned.
+
+  @param  AllocationSize        The number of bytes to allocate and zero.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateRuntimeZeroPool (
+  IN UINTN  AllocationSize
+  )
+{
+  return InternalAllocateZeroPool (EfiRuntimeServicesData, AllocationSize);
+}
+
+/**
+  Allocates and zeros a buffer of type EfiReservedMemoryType.
+
+  Allocates the number bytes specified by AllocationSize of type EfiReservedMemoryType, clears the
+  buffer with zeros, and returns a pointer to the allocated buffer.  If AllocationSize is 0, then a
+  valid buffer of 0 size is returned.  If there is not enough memory remaining to satisfy the
+  request, then NULL is returned.
+
+  @param  AllocationSize        The number of bytes to allocate and zero.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateReservedZeroPool (
+  IN UINTN  AllocationSize
+  )
+{
+  return NULL;
+}
+
+/**
+  Copies a buffer to an allocated buffer of a certain pool type.
+
+  Allocates the number bytes specified by AllocationSize of a certain pool type, copies
+  AllocationSize bytes from Buffer to the newly allocated buffer, and returns a pointer to the
+  allocated buffer.  If AllocationSize is 0, then a valid buffer of 0 size is returned.  If there
+  is not enough memory remaining to satisfy the request, then NULL is returned.
+  If Buffer is NULL, then ASSERT().
+  If AllocationSize is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  PoolType              The type of pool to allocate.
+  @param  AllocationSize        The number of bytes to allocate and zero.
+  @param  Buffer                The buffer to copy to the allocated buffer.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+InternalAllocateCopyPool (
+  IN EFI_MEMORY_TYPE  PoolType,
+  IN UINTN            AllocationSize,
+  IN CONST VOID       *Buffer
+  )
+{
+  VOID  *Memory;
+
+  ASSERT (Buffer != NULL);
+  ASSERT (AllocationSize <= (MAX_ADDRESS - (UINTN)Buffer + 1));
+
+  Memory = InternalAllocatePool (PoolType, AllocationSize);
+  if (Memory != NULL) {
+    Memory = CopyMem (Memory, Buffer, AllocationSize);
+  }
+
+  return Memory;
+}
+
+/**
+  Copies a buffer to an allocated buffer of type EfiBootServicesData.
+
+  Allocates the number bytes specified by AllocationSize of type EfiBootServicesData, copies
+  AllocationSize bytes from Buffer to the newly allocated buffer, and returns a pointer to the
+  allocated buffer.  If AllocationSize is 0, then a valid buffer of 0 size is returned.  If there
+  is not enough memory remaining to satisfy the request, then NULL is returned.
+
+  If Buffer is NULL, then ASSERT().
+  If AllocationSize is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  AllocationSize        The number of bytes to allocate and zero.
+  @param  Buffer                The buffer to copy to the allocated buffer.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateCopyPool (
+  IN UINTN       AllocationSize,
+  IN CONST VOID  *Buffer
+  )
+{
+  return InternalAllocateCopyPool (EfiRuntimeServicesData, AllocationSize, Buffer);
+}
+
+/**
+  Copies a buffer to an allocated buffer of type EfiRuntimeServicesData.
+
+  Allocates the number bytes specified by AllocationSize of type EfiRuntimeServicesData, copies
+  AllocationSize bytes from Buffer to the newly allocated buffer, and returns a pointer to the
+  allocated buffer.  If AllocationSize is 0, then a valid buffer of 0 size is returned.  If there
+  is not enough memory remaining to satisfy the request, then NULL is returned.
+
+  If Buffer is NULL, then ASSERT().
+  If AllocationSize is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  AllocationSize        The number of bytes to allocate and zero.
+  @param  Buffer                The buffer to copy to the allocated buffer.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateRuntimeCopyPool (
+  IN UINTN       AllocationSize,
+  IN CONST VOID  *Buffer
+  )
+{
+  return InternalAllocateCopyPool (EfiRuntimeServicesData, AllocationSize, Buffer);
+}
+
+/**
+  Copies a buffer to an allocated buffer of type EfiReservedMemoryType.
+
+  Allocates the number bytes specified by AllocationSize of type EfiReservedMemoryType, copies
+  AllocationSize bytes from Buffer to the newly allocated buffer, and returns a pointer to the
+  allocated buffer.  If AllocationSize is 0, then a valid buffer of 0 size is returned.  If there
+  is not enough memory remaining to satisfy the request, then NULL is returned.
+
+  If Buffer is NULL, then ASSERT().
+  If AllocationSize is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  AllocationSize        The number of bytes to allocate and zero.
+  @param  Buffer                The buffer to copy to the allocated buffer.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateReservedCopyPool (
+  IN UINTN       AllocationSize,
+  IN CONST VOID  *Buffer
+  )
+{
+  return NULL;
+}
+
+/**
+  Reallocates a buffer of a specified memory type.
+
+  Allocates and zeros the number bytes specified by NewSize from memory of the type
+  specified by PoolType.  If OldBuffer is not NULL, then the smaller of OldSize and
+  NewSize bytes are copied from OldBuffer to the newly allocated buffer, and
+  OldBuffer is freed.  A pointer to the newly allocated buffer is returned.
+  If NewSize is 0, then a valid buffer of 0 size is  returned.  If there is not
+  enough memory remaining to satisfy the request, then NULL is returned.
+
+  If the allocation of the new buffer is successful and the smaller of NewSize and OldSize
+  is greater than (MAX_ADDRESS - OldBuffer + 1), then ASSERT().
+
+  @param  PoolType       The type of pool to allocate.
+  @param  OldSize        The size, in bytes, of OldBuffer.
+  @param  NewSize        The size, in bytes, of the buffer to reallocate.
+  @param  OldBuffer      The buffer to copy to the allocated buffer.  This is an optional
+                         parameter that may be NULL.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+InternalReallocatePool (
+  IN EFI_MEMORY_TYPE  PoolType,
+  IN UINTN            OldSize,
+  IN UINTN            NewSize,
+  IN VOID             *OldBuffer  OPTIONAL
+  )
+{
+  VOID  *NewBuffer;
+
+  NewBuffer = InternalAllocateZeroPool (PoolType, NewSize);
+  if ((NewBuffer != NULL) && (OldBuffer != NULL)) {
+    CopyMem (NewBuffer, OldBuffer, MIN (OldSize, NewSize));
+    FreePool (OldBuffer);
+  }
+
+  return NewBuffer;
+}
+
+/**
+  Reallocates a buffer of type EfiBootServicesData.
+
+  Allocates and zeros the number bytes specified by NewSize from memory of type
+  EfiBootServicesData.  If OldBuffer is not NULL, then the smaller of OldSize and
+  NewSize bytes are copied from OldBuffer to the newly allocated buffer, and
+  OldBuffer is freed.  A pointer to the newly allocated buffer is returned.
+  If NewSize is 0, then a valid buffer of 0 size is  returned.  If there is not
+  enough memory remaining to satisfy the request, then NULL is returned.
+
+  If the allocation of the new buffer is successful and the smaller of NewSize and OldSize
+  is greater than (MAX_ADDRESS - OldBuffer + 1), then ASSERT().
+
+  @param  OldSize        The size, in bytes, of OldBuffer.
+  @param  NewSize        The size, in bytes, of the buffer to reallocate.
+  @param  OldBuffer      The buffer to copy to the allocated buffer.  This is an optional
+                         parameter that may be NULL.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+ReallocatePool (
+  IN UINTN  OldSize,
+  IN UINTN  NewSize,
+  IN VOID   *OldBuffer  OPTIONAL
+  )
+{
+  return InternalReallocatePool (EfiRuntimeServicesData, OldSize, NewSize, OldBuffer);
+}
+
+/**
+  Reallocates a buffer of type EfiRuntimeServicesData.
+
+  Allocates and zeros the number bytes specified by NewSize from memory of type
+  EfiRuntimeServicesData.  If OldBuffer is not NULL, then the smaller of OldSize and
+  NewSize bytes are copied from OldBuffer to the newly allocated buffer, and
+  OldBuffer is freed.  A pointer to the newly allocated buffer is returned.
+  If NewSize is 0, then a valid buffer of 0 size is  returned.  If there is not
+  enough memory remaining to satisfy the request, then NULL is returned.
+
+  If the allocation of the new buffer is successful and the smaller of NewSize and OldSize
+  is greater than (MAX_ADDRESS - OldBuffer + 1), then ASSERT().
+
+  @param  OldSize        The size, in bytes, of OldBuffer.
+  @param  NewSize        The size, in bytes, of the buffer to reallocate.
+  @param  OldBuffer      The buffer to copy to the allocated buffer.  This is an optional
+                         parameter that may be NULL.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+ReallocateRuntimePool (
+  IN UINTN  OldSize,
+  IN UINTN  NewSize,
+  IN VOID   *OldBuffer  OPTIONAL
+  )
+{
+  return InternalReallocatePool (EfiRuntimeServicesData, OldSize, NewSize, OldBuffer);
+}
+
+/**
+  Reallocates a buffer of type EfiReservedMemoryType.
+
+  Allocates and zeros the number bytes specified by NewSize from memory of type
+  EfiReservedMemoryType.  If OldBuffer is not NULL, then the smaller of OldSize and
+  NewSize bytes are copied from OldBuffer to the newly allocated buffer, and
+  OldBuffer is freed.  A pointer to the newly allocated buffer is returned.
+  If NewSize is 0, then a valid buffer of 0 size is  returned.  If there is not
+  enough memory remaining to satisfy the request, then NULL is returned.
+
+  If the allocation of the new buffer is successful and the smaller of NewSize and OldSize
+  is greater than (MAX_ADDRESS - OldBuffer + 1), then ASSERT().
+
+  @param  OldSize        The size, in bytes, of OldBuffer.
+  @param  NewSize        The size, in bytes, of the buffer to reallocate.
+  @param  OldBuffer      The buffer to copy to the allocated buffer.  This is an optional
+                         parameter that may be NULL.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+ReallocateReservedPool (
+  IN UINTN  OldSize,
+  IN UINTN  NewSize,
+  IN VOID   *OldBuffer  OPTIONAL
+  )
+{
+  return NULL;
+}
+
+/**
+  Frees a buffer that was previously allocated with one of the pool allocation functions in the
+  Memory Allocation Library.
+
+  Frees the buffer specified by Buffer.  Buffer must have been allocated on a previous call to the
+  pool allocation services of the Memory Allocation Library.  If it is not possible to free pool
+  resources, then this function will perform no actions.
+
+  If Buffer was not allocated with a pool allocation function in the Memory Allocation Library,
+  then ASSERT().
+
+  @param  Buffer                Pointer to the buffer to free.
+
+**/
+VOID
+EFIAPI
+FreePool (
+  IN VOID  *Buffer
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = MmFreePool (Buffer);
+  ASSERT_EFI_ERROR (Status);
+}
+
+STATIC
+EFI_STATUS
+ReadProperty32 (
+  IN  VOID    *DtbAddress,
+  IN  INT32   Offset,
+  IN  CHAR8   *Property,
+  OUT UINT32  *Value
+  )
+{
+  CONST UINT32  *Property32;
+
+  Property32 =  fdt_getprop (DtbAddress, Offset, Property, NULL);
+  if (Property32 == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Missing in FF-A boot information manifest\n",
+      Property
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Value = fdt32_to_cpu (*Property32);
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+ReadProperty64 (
+  IN  VOID    *DtbAddress,
+  IN  INT32   Offset,
+  IN  CHAR8   *Property,
+  OUT UINT64  *Value
+  )
+{
+  CONST UINT64  *Property64;
+
+  Property64 =  fdt_getprop (DtbAddress, Offset, Property, NULL);
+  if (Property64 == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Missing in FF-A boot information manifest\n",
+      Property
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Value = fdt64_to_cpu (*Property64);
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+BOOLEAN
+CheckDescription (
+  IN VOID     *DtbAddress,
+  IN INT32    Offset,
+  OUT CHAR8   *Description,
+  OUT UINT32  Size
+  )
+{
+  CONST CHAR8  *Property;
+  INT32        LenP;
+
+  Property = fdt_getprop (DtbAddress, Offset, "description", &LenP);
+  if (Property == NULL) {
+    return FALSE;
+  }
+
+  return CompareMem (Description, Property, MIN (Size, (UINT32)LenP)) == 0;
+}
+
+STATIC
+BOOLEAN
+ReadRegionInfo (
+  IN VOID     *DtbAddress,
+  IN INT32    Node,
+  IN CHAR8    *Region,
+  IN UINTN    RegionStrSize,
+  IN UINT32   PageSize,
+  OUT UINT64  *Address,
+  OUT UINT64  *Size
+  )
+{
+  BOOLEAN  FoundBuffer;
+  INTN     Status = 0;
+  UINT32   LocalSize;
+
+  FoundBuffer = CheckDescription (
+                  DtbAddress,
+                  Node,
+                  Region,
+                  RegionStrSize
+                  );
+  if (!FoundBuffer) {
+    return FALSE;
+  }
+
+  DEBUG ((DEBUG_INFO, "Found Node: %a\n", Region));
+  Status = ReadProperty64 (
+             DtbAddress,
+             Node,
+             "base-address",
+             Address
+             );
+  if (Status != EFI_SUCCESS) {
+    DEBUG ((DEBUG_ERROR, "base-address missing in DTB"));
+    return FALSE;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "base = 0x%llx\n",
+    *Address
+    ));
+
+  Status = ReadProperty32 (
+             DtbAddress,
+             Node,
+             "pages-count",
+             &LocalSize
+             );
+  if (Status != EFI_SUCCESS) {
+    DEBUG ((DEBUG_ERROR, "pages-count missing in DTB"));
+    return FALSE;
+  }
+
+  DEBUG ((DEBUG_ERROR, "pages-count: 0x%lx\n", LocalSize));
+
+  *Size = LocalSize * PageSize;
+  DEBUG ((
+    DEBUG_INFO,
+    "Size = 0x%llx\n",
+    *Size
+    ));
+
+  return TRUE;
+}
+
+/**
+  The constructor function calls MmInitializeMemoryServices to initialize
+  memory in MMRAM and caches EFI_MM_SYSTEM_TABLE pointer.
+
+  @param  [in]  ImageHandle     The firmware allocated handle for the EFI image.
+  @param  [in]  MmSystemTable   A pointer to the Management mode System Table.
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+
+**/
+EFI_STATUS
+EFIAPI
+MemoryAllocationLibConstructor (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *MmSystemTable
+  )
+{
+  EFI_MMRAM_DESCRIPTOR  MmramRange;
+  INT32                 Node;
+  INT32                 Offset;
+  VOID                  *DtbAddress;
+  BOOLEAN               Result;
+
+  DtbAddress = gSpst->FDTAddress;
+  DEBUG ((DEBUG_INFO, "%a - 0x%x\n", __func__, DtbAddress));
+
+  Offset = fdt_node_offset_by_compatible (DtbAddress, -1, "arm,ffa-manifest-1.0");
+
+  DEBUG ((DEBUG_INFO, "Offset  = %d \n", Offset));
+
+  Offset = fdt_subnode_offset_namelen (
+             DtbAddress,
+             Offset,
+             "memory-regions",
+             sizeof ("memory-regions") - 1
+             );
+  if (Offset < 1) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Missing in FF-A boot information manifest\n",
+      "memory-regions"
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((DEBUG_INFO, "mem region offset  = %d \n", Offset));
+
+  for (Node = fdt_first_subnode (DtbAddress, Offset);
+       Node >= 0;
+       Node = fdt_next_subnode (DtbAddress, Node))
+  {
+    Result = ReadRegionInfo (
+               DtbAddress,
+               Node,
+               "heap",
+               sizeof ("heap") - 1,
+               EFI_PAGE_SIZE,
+               &MmramRange.CpuStart,
+               &MmramRange.PhysicalSize
+               );
+    if (!Result) {
+      DEBUG ((DEBUG_ERROR, "Failed to read heap region\n"));
+      return EFI_UNSUPPORTED;
+    }
+
+    DEBUG ((
+      DEBUG_INFO,
+      "MmramRange: 0x%016lx - 0x%016lx\n",
+      MmramRange.CpuStart,
+      MmramRange.PhysicalSize
+      ));
+
+    //
+    // Initialize memory service using free MMRAM
+    //
+    DEBUG ((DEBUG_INFO, "MmInitializeMemoryServices\n"));
+    MmInitializeMemoryServices (1, (VOID *)(UINTN)&MmramRange);
+    break;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/ArmPkg/Library/SecurePartitionMemoryAllocationLib/SecurePartitionMemoryAllocationLib.h
+++ b/ArmPkg/Library/SecurePartitionMemoryAllocationLib/SecurePartitionMemoryAllocationLib.h
@@ -1,0 +1,166 @@
+/** @file
+  Support routines for memory allocation routines based on Standalone MM Core internal functions.
+
+  Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2021, ARM Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SECURE_PARTITION_MEM_ALLOC_LIB_H_
+#define SECURE_PARTITION_MEM_ALLOC_LIB_H_
+
+/**
+  Allocates pages from the memory map.
+
+  @param  Type                   The type of allocation to perform.
+  @param  MemoryType             The type of memory to turn the allocated pages
+                                 into.
+  @param  NumberOfPages          The number of pages to allocate.
+  @param  Memory                 A pointer to receive the base allocated memory
+                                 address.
+
+  @retval EFI_INVALID_PARAMETER  Parameters violate checking rules defined in spec.
+  @retval EFI_NOT_FOUND          Could not allocate pages match the requirement.
+  @retval EFI_OUT_OF_RESOURCES   No enough pages to allocate.
+  @retval EFI_SUCCESS            Pages successfully allocated.
+
+**/
+EFI_STATUS
+EFIAPI
+MmAllocatePages (
+  IN  EFI_ALLOCATE_TYPE     Type,
+  IN  EFI_MEMORY_TYPE       MemoryType,
+  IN  UINTN                 NumberOfPages,
+  OUT EFI_PHYSICAL_ADDRESS  *Memory
+  );
+
+/**
+  Frees previous allocated pages.
+
+  @param  Memory                 Base address of memory being freed.
+  @param  NumberOfPages          The number of pages to free.
+
+  @retval EFI_NOT_FOUND          Could not find the entry that covers the range.
+  @retval EFI_INVALID_PARAMETER  Address not aligned.
+  @return EFI_SUCCESS            Pages successfully freed.
+
+**/
+EFI_STATUS
+EFIAPI
+MmFreePages (
+  IN EFI_PHYSICAL_ADDRESS  Memory,
+  IN UINTN                 NumberOfPages
+  );
+
+/**
+  Allocate pool of a particular type.
+
+  @param  PoolType               Type of pool to allocate.
+  @param  Size                   The amount of pool to allocate.
+  @param  Buffer                 The address to return a pointer to the allocated
+                                 pool.
+
+  @retval EFI_INVALID_PARAMETER  PoolType not valid.
+  @retval EFI_OUT_OF_RESOURCES   Size exceeds max pool size or allocation failed.
+  @retval EFI_SUCCESS            Pool successfully allocated.
+
+**/
+EFI_STATUS
+EFIAPI
+MmAllocatePool (
+  IN   EFI_MEMORY_TYPE  PoolType,
+  IN   UINTN            Size,
+  OUT  VOID             **Buffer
+  );
+
+/**
+  Frees pool.
+
+  @param  Buffer                 The allocated pool entry to free.
+
+  @retval EFI_INVALID_PARAMETER  Buffer is not a valid value.
+  @retval EFI_SUCCESS            Pool successfully freed.
+
+**/
+EFI_STATUS
+EFIAPI
+MmFreePool (
+  IN VOID  *Buffer
+  );
+
+/**
+  Allocates pages from the memory map.
+
+  @param  Type                   The type of allocation to perform.
+  @param  MemoryType             The type of memory to turn the allocated pages
+                                 into.
+  @param  NumberOfPages          The number of pages to allocate.
+  @param  Memory                 A pointer to receive the base allocated memory
+                                 address.
+
+  @retval EFI_INVALID_PARAMETER  Parameters violate checking rules defined in spec.
+  @retval EFI_NOT_FOUND          Could not allocate pages match the requirement.
+  @retval EFI_OUT_OF_RESOURCES   No enough pages to allocate.
+  @retval EFI_SUCCESS            Pages successfully allocated.
+
+**/
+EFI_STATUS
+EFIAPI
+MmInternalAllocatePages (
+  IN  EFI_ALLOCATE_TYPE     Type,
+  IN  EFI_MEMORY_TYPE       MemoryType,
+  IN  UINTN                 NumberOfPages,
+  OUT EFI_PHYSICAL_ADDRESS  *Memory
+  );
+
+/**
+  Frees previous allocated pages.
+
+  @param  Memory                 Base address of memory being freed.
+  @param  NumberOfPages          The number of pages to free.
+
+  @retval EFI_NOT_FOUND          Could not find the entry that covers the range.
+  @retval EFI_INVALID_PARAMETER  Address not aligned.
+  @return EFI_SUCCESS            Pages successfully freed.
+
+**/
+EFI_STATUS
+EFIAPI
+MmInternalFreePages (
+  IN EFI_PHYSICAL_ADDRESS  Memory,
+  IN UINTN                 NumberOfPages
+  );
+
+/**
+  Add free MMRAM region for use by memory service.
+
+  @param  MemBase                Base address of memory region.
+  @param  MemLength              Length of the memory region.
+  @param  Type                   Memory type.
+  @param  Attributes             Memory region state.
+
+**/
+VOID
+MmAddMemoryRegion (
+  IN      EFI_PHYSICAL_ADDRESS  MemBase,
+  IN      UINT64                MemLength,
+  IN      EFI_MEMORY_TYPE       Type,
+  IN      UINT64                Attributes
+  );
+
+/**
+  Called to initialize the memory service.
+
+  @param   MmramRangeCount       Number of MMRAM Regions
+  @param   MmramRanges           Pointer to MMRAM Descriptors
+
+**/
+VOID
+MmInitializeMemoryServices (
+  IN UINTN                 MmramRangeCount,
+  IN EFI_MMRAM_DESCRIPTOR  *MmramRanges
+  );
+
+#endif // SECURE_PARTITION_MEM_ALLOC_LIB_H_

--- a/ArmPkg/Library/SecurePartitionMemoryAllocationLib/SecurePartitionMemoryAllocationLib.inf
+++ b/ArmPkg/Library/SecurePartitionMemoryAllocationLib/SecurePartitionMemoryAllocationLib.inf
@@ -1,0 +1,49 @@
+## @file
+# Memory Allocation Library instance dedicated to MM Core.
+# The implementation borrows the MM Core Memory Allocation services as the primitive
+# for memory allocation instead of using MM System Table services in an indirect way.
+# It is assumed that this library instance must be linked with MM Core in this package.
+#
+# Copyright (c) 2010 - 2015, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2021, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = MemoryAllocationLib
+  FILE_GUID                      = CFF19383-3006-4408-B069-4F37EF64381D
+  MODULE_TYPE                    = MM_CORE_STANDALONE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  LIBRARY_CLASS                  = MemoryAllocationLib|MM_CORE_STANDALONE
+  CONSTRUCTOR                    = MemoryAllocationLibConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = AARCH64
+#
+
+[Sources]
+  Page.c
+  Pool.c
+  SecurePartitionMemoryAllocationLib.c
+  SecurePartitionMemoryAllocationLib.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec
+  ArmPkg/ArmPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  FdtLib
+  SecurePartitionServicesTableLib
+
+[Guids]
+  gEfiMmPeiMmramMemoryReserveGuid

--- a/ArmPkg/Library/SecurePartitionServicesTableLib/SecurePartitionServicesTableLib.c
+++ b/ArmPkg/Library/SecurePartitionServicesTableLib/SecurePartitionServicesTableLib.c
@@ -1,0 +1,13 @@
+/** @file
+  Services table for the Secure Partition on ARM platforms.
+
+Copyright (c), Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+
+#include <Library/SecurePartitionServicesTableLib.h>
+
+SECURE_PARTITION_SERVICES_TABLE  *gSpst = NULL;

--- a/ArmPkg/Library/SecurePartitionServicesTableLib/SecurePartitionServicesTableLib.inf
+++ b/ArmPkg/Library/SecurePartitionServicesTableLib/SecurePartitionServicesTableLib.inf
@@ -1,0 +1,39 @@
+## @file
+# Secure Partition System Table library implementation.
+#
+# Copyright (c) Microsoft Corporation.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = SecurePartitionSystemTableLib
+  FILE_GUID                      = 5118C38F-D97D-4FF8-8B44-971273B07342
+  MODULE_TYPE                    = MM_CORE_STANDALONE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  LIBRARY_CLASS                  = SecurePartitionSystemTableLib|MM_CORE_STANDALONE
+
+#
+#  VALID_ARCHITECTURES           = AARCH64
+#
+
+[Sources]
+  SecurePartitionServicesTableLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  ArmPkg/ArmPkg.dec
+
+#
+# This configuration fails for CLANGPDB, which does not support PIE in the GCC
+# sense. Such however is required for ARM family StandaloneMmCore
+# self-relocation, and thus the CLANGPDB toolchain is unsupported for ARM and
+# AARCH64 for this module.
+#
+[BuildOptions]
+  GCC:*_*_ARM_CC_FLAGS = -fpie
+  GCC:*_*_AARCH64_CC_FLAGS = -fpie


### PR DESCRIPTION
## Description

This change adds a new library instance to support heap allocation management for secure partitions.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This was tested on feature/ffa_enablement branch with QEMU SBSA platform.

## Integration Instructions

- The platform needs to link this new library as the memory allocation library for secure partition builds.
- In the secure partition DTS, adding a memory region for heap will allow the memory allocation library to allocate memory from this region.
