### PR TITLE
[CHERRY-PICK] Create memory type control for PEI & FD ranges

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -223,6 +223,10 @@
   gArmTokenSpaceGuid.PcdFdSize|0|UINT32|0x0000002C
   gArmTokenSpaceGuid.PcdFvSize|0|UINT32|0x0000002E
 
+
+  # MU_CHANGE: PCD To configure memory type used for FD region allocation. Defaults to EfiBootServicesData
+  gArmTokenSpaceGuid.PcdFdMemoryType|4|UINT32|0x1000046 # MU_CHANGE
+
   #
   # Value to add to a host address to obtain a device address, using
   # unsigned 64-bit integer arithmetic on both ARM and AArch64. This

--- a/ArmPlatformPkg/Include/Library/ArmPlatformLib.h
+++ b/ArmPlatformPkg/Include/Library/ArmPlatformLib.h
@@ -136,4 +136,24 @@ ArmPlatformGetPlatformPpiList (
   OUT EFI_PEI_PPI_DESCRIPTOR  **PpiList
   );
 
+// MU_CHANGE START: Allow platform to customize initial memory region.
+
+/**
+  Checks if the platform requires a special initial EFI memory region.
+
+  @param[out]  EfiMemoryBase  The custom memory base, will be unchanged if FALSE is returned.
+  @param[out]  EfiMemorySize  The custom memory size, will be unchanged if FALSE is returned.
+
+  @retval   TRUE    A custom memory region was set.
+  @retval   FALSE   A custom memory region was not set.
+**/
+BOOLEAN
+EFIAPI
+ArmPlatformGetPeiMemory (
+  OUT UINTN   *EfiMemoryBase,
+  OUT UINT32  *EfiMemorySize
+  );
+
+// MU_CHANGE END
+
 #endif

--- a/ArmPlatformPkg/Library/ArmPlatformLibNull/ArmPlatformLibNullMem.c
+++ b/ArmPlatformPkg/Library/ArmPlatformLibNull/ArmPlatformLibNullMem.c
@@ -26,3 +26,26 @@ ArmPlatformGetVirtualMemoryMap (
 {
   ASSERT (0);
 }
+
+// MU_CHANGE START
+
+/**
+  Checks if the platform requires a special initial EFI memory region.
+
+  @param[out]  EfiMemoryBase  The custom memory base, will be unchanged if FALSE is returned.
+  @param[out]  EfiMemorySize  The custom memory size, will be unchanged if FALSE is returned.
+
+  @retval   TRUE    A custom memory region was set.
+  @retval   FALSE   A custom memory region was not set.
+**/
+BOOLEAN
+EFIAPI
+ArmPlatformGetPeiMemory (
+  OUT UINTN   *EfiMemoryBase,
+  OUT UINT32  *EfiMemorySize
+  )
+{
+  return FALSE;
+}
+
+// MU_CHANGE END

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -181,7 +181,7 @@ MemoryPeim (
         BuildMemoryAllocationHob (
           PcdGet64 (PcdFdBaseAddress),
           PcdGet32 (PcdFdSize),
-          EfiBootServicesData
+          PcdGet32 (PcdFdMemoryType) // MU_CHANGE
           );
 
         Found = TRUE;

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
@@ -39,6 +39,7 @@
 [FixedPcd]
   gArmTokenSpaceGuid.PcdFdBaseAddress
   gArmTokenSpaceGuid.PcdFdSize
+  gArmTokenSpaceGuid.PcdFdMemoryType # MU_CHANGE
 
   gArmPlatformTokenSpaceGuid.PcdSystemMemoryUefiRegionSize
 

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeim.c
@@ -89,6 +89,7 @@ InitializeMemory (
   UINTN       FdBase;
   UINTN       FdTop;
   UINTN       UefiMemoryBase;
+  UINT32      UefiMemorySize; // MU_CHANGE
 
   DEBUG ((DEBUG_LOAD | DEBUG_INFO, "Memory Init PEIM Loaded\n"));
 
@@ -109,8 +110,16 @@ InitializeMemory (
   // Declare the UEFI memory to PEI
   //
 
-  // In case the firmware has been shadowed in the System Memory
-  if ((FdBase >= SystemMemoryBase) && (FdTop <= SystemMemoryTop)) {
+  // MU_CHANGE START: Allow platform to customize initial memory region.
+  UefiMemorySize = FixedPcdGet32 (PcdSystemMemoryUefiRegionSize);
+  if (ArmPlatformGetPeiMemory (&UefiMemoryBase, &UefiMemorySize)) {
+    // Check the Firmware does not intersect with the provided memory region.
+    ASSERT ((FdBase < UefiMemoryBase) || (FdBase >= (UefiMemoryBase + UefiMemorySize)));
+    ASSERT ((FdTop <= UefiMemoryBase) || (FdTop > (UefiMemoryBase + UefiMemorySize)));
+  } else if ((FdBase >= SystemMemoryBase) && (FdTop <= SystemMemoryTop)) {
+    // In case the firmware has been shadowed in the System Memory
+    // MU_CHANGE END
+
     // Check if there is enough space between the top of the system memory and the top of the
     // firmware to place the UEFI memory (for PEI & DXE phases)
     if (SystemMemoryTop - FdTop >= FixedPcdGet32 (PcdSystemMemoryUefiRegionSize)) {
@@ -129,7 +138,7 @@ InitializeMemory (
     UefiMemoryBase = SystemMemoryTop - FixedPcdGet32 (PcdSystemMemoryUefiRegionSize);
   }
 
-  Status = PeiServicesInstallPeiMemory (UefiMemoryBase, FixedPcdGet32 (PcdSystemMemoryUefiRegionSize));
+  Status = PeiServicesInstallPeiMemory (UefiMemoryBase, UefiMemorySize); // MU_CHANGE: Allow platform to customize initial memory region.
   ASSERT_EFI_ERROR (Status);
 
   // Initialize MMU and Memory HOBs (Resource Descriptor HOBs)


### PR DESCRIPTION
## Description

Cherry picks the following PR changes that were dropped in the 2405 rebase.
https://github.com/microsoft/mu_silicon_arm_tiano/pull/63
https://github.com/microsoft/mu_silicon_arm_tiano/pull/140

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Cherry picking existing changes

## Integration Instructions

Platforms with their own arm platform package will need to add implementation of ArmPlatformGetPeiMemory that returns FALSE to be unaffected.
