### PR TITLE
[FF-A] Supporting 18 registers for MM core

### DIFF
--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -144,7 +144,6 @@
   ArmPkg/Library/ArmFfaLibEx/ArmFfaLibEx.inf
   ArmPkg/Library/PlatformFfaInterruptLibNull/PlatformFfaInterruptLib.inf
   ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.inf
-  ArmPkg/Library/SecurePartitionEntryPoint/SecurePartitionEntryPoint.inf
 
   ArmPkg/Drivers/CpuDxe/CpuDxe.inf
   ArmPkg/Drivers/CpuPei/CpuPei.inf

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -204,6 +204,7 @@
   ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.inf
   ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
   ArmPkg/Library/ArmMmuLib/ArmMmuPeiLib.inf
+  ArmPkg/Library/SecurePartitionEntryPoint/SecurePartitionEntryPoint.inf
 
 [Components.AARCH64, Components.ARM]
   ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.inf

--- a/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/ModuleEntryPoint32.S
+++ b/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/ModuleEntryPoint32.S
@@ -17,7 +17,7 @@
 #
 #------------------------------------------------------------------------------
 
-#include <AsmMacroIoLibV8.h>
+#include <AsmMacroIoLib.h>
 #include <IndustryStandard/ArmMmSvc.h>
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <Uefi/UefiBaseType.h>

--- a/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.c
@@ -778,11 +778,21 @@ InitializeMiscMmCommunicateBuffer (
 {
   ZeroMem (Buffer, sizeof (MISC_MM_COMMUNICATE_BUFFER));
 
-  Buffer->MessageLength      = sizeof (DIRECT_MSG_ARGS);
-  Buffer->DirectMsgArgs.Arg0 = EventSvcArgs->Arg4;
-  Buffer->DirectMsgArgs.Arg1 = EventSvcArgs->Arg5;
-  Buffer->DirectMsgArgs.Arg2 = EventSvcArgs->Arg6;
-  Buffer->DirectMsgArgs.Arg3 = EventSvcArgs->Arg7;
+  Buffer->MessageLength       = sizeof (DIRECT_MSG_ARGS_EX);
+  Buffer->DirectMsgArgs.Arg0  = EventSvcArgs->Arg4;
+  Buffer->DirectMsgArgs.Arg1  = EventSvcArgs->Arg5;
+  Buffer->DirectMsgArgs.Arg2  = EventSvcArgs->Arg6;
+  Buffer->DirectMsgArgs.Arg3  = EventSvcArgs->Arg7;
+  Buffer->DirectMsgArgs.Arg4  = EventSvcArgs->Arg8;
+  Buffer->DirectMsgArgs.Arg5  = EventSvcArgs->Arg9;
+  Buffer->DirectMsgArgs.Arg6  = EventSvcArgs->Arg10;
+  Buffer->DirectMsgArgs.Arg7  = EventSvcArgs->Arg11;
+  Buffer->DirectMsgArgs.Arg8  = EventSvcArgs->Arg12;
+  Buffer->DirectMsgArgs.Arg9  = EventSvcArgs->Arg13;
+  Buffer->DirectMsgArgs.Arg10 = EventSvcArgs->Arg14;
+  Buffer->DirectMsgArgs.Arg11 = EventSvcArgs->Arg15;
+  Buffer->DirectMsgArgs.Arg12 = EventSvcArgs->Arg16;
+  Buffer->DirectMsgArgs.Arg13 = EventSvcArgs->Arg17;
   CopyGuid (&Buffer->HeaderGuid, ServiceGuid);
 }
 


### PR DESCRIPTION
## Description

This change added the support for using 18 registers when FF-A DIRECT_REQ2 is used to communicate with MM core.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This change was tested on QEMU SBSA and booted to UEFI shell.

## Integration Instructions

N/A
