### PR TITLE
[FF-A] Fix build break for using null memory allocation library

### DIFF
--- a/ArmPkg/Library/SecurePartitionEntryPoint/SecurePartitionEntryPoint.inf
+++ b/ArmPkg/Library/SecurePartitionEntryPoint/SecurePartitionEntryPoint.inf
@@ -38,6 +38,7 @@
   DebugLib
   FdtLib
   ArmSvcLib
+  SecurePartitionServicesTableLib
 
 #
 # This configuration fails for CLANGPDB, which does not support PIE in the GCC

--- a/ArmPkg/Library/SecurePartitionEntryPoint/StandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/SecurePartitionEntryPoint/StandaloneMmCoreEntryPoint.c
@@ -415,8 +415,6 @@ ModuleEntryPoint (
 
   ProcessLibraryConstructorList (NULL, NULL);
 
-  ProcessLibraryConstructorList (NULL, NULL);
-
   //
   // Call the MM Core entry point
   //

--- a/ArmPkg/Library/SecurePartitionServicesTableLib/SecurePartitionServicesTableLib.inf
+++ b/ArmPkg/Library/SecurePartitionServicesTableLib/SecurePartitionServicesTableLib.inf
@@ -10,12 +10,12 @@
 
 [Defines]
   INF_VERSION                    = 0x0001001A
-  BASE_NAME                      = SecurePartitionServiceTableLib
+  BASE_NAME                      = SecurePartitionServicesTableLib
   FILE_GUID                      = 5118C38F-D97D-4FF8-8B44-971273B07342
   MODULE_TYPE                    = MM_CORE_STANDALONE
   VERSION_STRING                 = 1.0
   PI_SPECIFICATION_VERSION       = 0x00010032
-  LIBRARY_CLASS                  = SecurePartitionServiceTableLib|MM_CORE_STANDALONE
+  LIBRARY_CLASS                  = SecurePartitionServicesTableLib|MM_CORE_STANDALONE
 
 #
 #  VALID_ARCHITECTURES           = AARCH64

--- a/ArmPkg/Library/SecurePartitionServicesTableLib/SecurePartitionServicesTableLib.inf
+++ b/ArmPkg/Library/SecurePartitionServicesTableLib/SecurePartitionServicesTableLib.inf
@@ -10,12 +10,12 @@
 
 [Defines]
   INF_VERSION                    = 0x0001001A
-  BASE_NAME                      = SecurePartitionSystemTableLib
+  BASE_NAME                      = SecurePartitionServiceTableLib
   FILE_GUID                      = 5118C38F-D97D-4FF8-8B44-971273B07342
   MODULE_TYPE                    = MM_CORE_STANDALONE
   VERSION_STRING                 = 1.0
   PI_SPECIFICATION_VERSION       = 0x00010032
-  LIBRARY_CLASS                  = SecurePartitionSystemTableLib|MM_CORE_STANDALONE
+  LIBRARY_CLASS                  = SecurePartitionServiceTableLib|MM_CORE_STANDALONE
 
 #
 #  VALID_ARCHITECTURES           = AARCH64


### PR DESCRIPTION
## Description

This pull request fixes a build break that occurs where the library usage is not specified in the MM entrypoint library.

No functional change.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This change was tested on pipeline.

## Integration Instructions

N/A
