### PR TITLE
[REBASE][FF-A] Ported MS Services to UEFI Style

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -189,7 +189,7 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
             {
                 "Path": "Common/MU_TIANO",
                 "Url": "https://github.com/microsoft/mu_tiano_plus.git",
-                "Branch": "release/202405"
+                "Branch": "feature/ffa_enablement"
             },
             {
                 "Path": "MU_BASECORE",

--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -132,6 +132,10 @@
   #
   TestServiceLib|Include/Library/TestServiceLib.h
 
+  ##  @libraryclass  Provides an implementation of the TPM Service
+  #
+  TpmServiceLib|Include/Library/TpmServiceLib.h
+
 [Guids.common]
   gArmTokenSpaceGuid       = { 0xBB11ECFE, 0x820F, 0x4968, { 0xBB, 0xA6, 0xF7, 0x6A, 0xFE, 0x30, 0x25, 0x96 } }
 

--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -128,6 +128,10 @@
   #
   NotificationServiceLib|Include/Library/NotificationServiceLib.h
 
+  ##  @libraryclass  Provides an implementation of the Test Service
+  #
+  TestServiceLib|Include/Library/TestServiceLib.h
+
 [Guids.common]
   gArmTokenSpaceGuid       = { 0xBB11ECFE, 0x820F, 0x4968, { 0xBB, 0xA6, 0xF7, 0x6A, 0xFE, 0x30, 0x25, 0x96 } }
 

--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -124,6 +124,10 @@
   #
   SecurePartitionServicesTableLib|Include/Library/SecurePartitionServicesTableLib.h
 
+  ##  @libraryclass  Provides an implementation of the Notification Service
+  #
+  NotificationServiceLib|Include/Library/NotificationServiceLib.h
+
 [Guids.common]
   gArmTokenSpaceGuid       = { 0xBB11ECFE, 0x820F, 0x4968, { 0xBB, 0xA6, 0xF7, 0x6A, 0xFE, 0x30, 0x25, 0x96 } }
 

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -202,6 +202,7 @@
   ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
 
   ArmPkg/Library/ArmArchTimerLibEx/ArmArchTimerLibEx.inf
+  ArmPkg/Library/NotificationServiceLib/NotificationServiceLib.inf
 
 [Components.AARCH64]
   ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.inf

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -203,6 +203,7 @@
 
   ArmPkg/Library/ArmArchTimerLibEx/ArmArchTimerLibEx.inf
   ArmPkg/Library/NotificationServiceLib/NotificationServiceLib.inf
+  ArmPkg/Library/TestServiceLib/TestServiceLib.inf
 
 [Components.AARCH64]
   ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.inf

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -201,6 +201,8 @@
   # MU_CHANGE [END]
   ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
 
+  ArmPkg/Library/ArmArchTimerLibEx/ArmArchTimerLibEx.inf
+
 [Components.AARCH64]
   ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.inf
   ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -204,6 +204,7 @@
   ArmPkg/Library/ArmArchTimerLibEx/ArmArchTimerLibEx.inf
   ArmPkg/Library/NotificationServiceLib/NotificationServiceLib.inf
   ArmPkg/Library/TestServiceLib/TestServiceLib.inf
+  ArmPkg/Library/TpmServiceLib/TpmServiceLib.inf
 
 [Components.AARCH64]
   ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.inf

--- a/ArmPkg/Include/Library/NotificationServiceLib.h
+++ b/ArmPkg/Include/Library/NotificationServiceLib.h
@@ -1,0 +1,96 @@
+/** @file
+  Definitions for the Notification Service
+
+  Copyright (c), Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef NOTIFICATION_SERVICE_LIB_H_
+#define NOTIFICATION_SERVICE_LIB_H_
+
+#include <Base.h>
+#include <IndustryStandard/ArmFfaPartInfo.h>
+#include <Library/ArmSvcLib.h>
+#include <Library/ArmFfaLibEx.h>
+
+typedef INT32 NotificationStatus;
+
+#define NOTIFICATION_STATUS_SUCCESS            ((NotificationStatus)0)
+#define NOTIFICATION_STATUS_GENERIC_ERROR      ((NotificationStatus)-1)
+#define NOTIFICATION_STATUS_INVALID_PARAMETER  ((NotificationStatus)-2)
+
+#define NOTIFICATION_OPCODE_BASE     (0)
+#define NOTIFICATION_OPCODE_QUERY    (NOTIFICATION_OPCODE_BASE + 0)
+#define NOTIFICATION_OPCODE_SETUP    (NOTIFICATION_OPCODE_BASE + 1)
+#define NOTIFICATION_OPCODE_DESTROY  (NOTIFICATION_OPCODE_BASE + 2)
+
+#define NOTIFICATION_SERVICE_UUID \
+{ \
+    0xb510b3a3, 0x59f6, 0x4054, { 0xba, 0x7a, 0xff, 0x2e, 0xb1, 0xea, 0xc7, 0x65 } \
+}
+
+/**
+  Initializes the Notification service
+
+**/
+VOID
+NotificationServiceInit (
+  VOID
+  );
+
+/**
+  Deinitializes the Notification service
+
+**/
+VOID
+NotificationServiceDeInit (
+  VOID
+  );
+
+/**
+  Handler for Notification service commands
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+**/
+VOID
+NotificationServiceHandle (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  );
+
+/**
+  Calls NotificationSet on the given ID with the given flag
+
+  @param  Id           The ID to trigger the event on
+  @param  ServiceUuid  The service containing the ID to trigger
+  @param  Flag         The NotificationSet flag to use
+
+  @retval NOTIFICATION_STATUS_SUCCESS           Success
+  @retval NOTIFICATION_STATUS_INVALID_PARAMETER Invalid parameter
+  @retval NOTIFICATION_STATUS_GENERIC_ERROR     NotificationSet failed
+
+**/
+NotificationStatus
+NotificationServiceIdSet (
+  UINT16  Id,
+  UINT8   *ServiceUuid,
+  UINT32  Flag
+  );
+
+/**
+  Extracts the UUID from the message arguments
+
+  @param  Request   The incoming message to extract the UUID from
+  @param  Uuid      The UUID to populate
+
+**/
+VOID
+NotificationServiceExtractUuid (
+  DIRECT_MSG_ARGS_EX  *Request,
+  UINT8               *Uuid
+  );
+
+#endif /* NOTIFICATION_SERVICE_LIB_H_ */

--- a/ArmPkg/Include/Library/TestServiceLib.h
+++ b/ArmPkg/Include/Library/TestServiceLib.h
@@ -1,0 +1,62 @@
+/** @file
+  Definitions for the Test Service
+
+  Copyright (c), Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef TEST_SERVICE_LIB_H_
+#define TEST_SERVICE_LIB_H_
+
+#include <Base.h>
+#include <IndustryStandard/ArmFfaPartInfo.h>
+#include <Library/ArmSvcLib.h>
+#include <Library/ArmFfaLibEx.h>
+
+typedef INT32 TestStatus;
+
+#define TEST_STATUS_SUCCESS            ((TestStatus)0)
+#define TEST_STATUS_GENERIC_ERROR      ((TestStatus)-1)
+#define TEST_STATUS_INVALID_PARAMETER  ((TestStatus)-2)
+
+#define TEST_OPCODE_BASE               (0xDEF0)
+#define TEST_OPCODE_TEST_NOTIFICATION  (TEST_OPCODE_BASE + 0x01)
+
+#define TEST_SERVICE_UUID \
+{ \
+  0xe0fad9b3, 0x7f5c, 0x42c5, { 0xb2, 0xee, 0xb7, 0xa8, 0x23, 0x13, 0xcd, 0xb2 } \
+}
+
+/**
+  Initializes the Test service
+
+**/
+VOID
+TestServiceInit (
+  VOID
+  );
+
+/**
+  Deinitializes the Test service
+
+**/
+VOID
+TestServiceDeInit (
+  VOID
+  );
+
+/**
+  Handler for Test service commands
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+**/
+VOID
+TestServiceHandle (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  );
+
+#endif /* TEST_SERVICE_LIB_H_ */

--- a/ArmPkg/Include/Library/TpmServiceLib.h
+++ b/ArmPkg/Include/Library/TpmServiceLib.h
@@ -1,0 +1,48 @@
+/** @file
+  Definitions for the TPM Service
+
+  Copyright (c), Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef TPM_SERVICE_LIB_H_
+#define TPM_SERVICE_LIB_H_
+
+#include <Base.h>
+#include <IndustryStandard/ArmFfaPartInfo.h>
+#include <Library/ArmSvcLib.h>
+#include <Library/ArmFfaLibEx.h>
+
+/**
+  Initializes the TPM service
+
+**/
+VOID
+TpmServiceInit (
+  VOID
+  );
+
+/**
+  Deinitializes the TPM service
+
+**/
+VOID
+TpmServiceDeInit (
+  VOID
+  );
+
+/**
+  Handler for TPM service commands
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+**/
+VOID
+TpmServiceHandle (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  );
+
+#endif /* TPM_SERVICE_LIB_H_ */

--- a/ArmPkg/Library/ArmArchTimerLibEx/ArmArchTimerLibEx.c
+++ b/ArmPkg/Library/ArmArchTimerLibEx/ArmArchTimerLibEx.c
@@ -1,0 +1,280 @@
+/** @file
+  Generic ARM implementation of TimerLib.h
+
+  Copyright (c) 2011 - 2021, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/ArmLib.h>
+#include <Library/BaseLib.h>
+#include <Library/TimerLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/ArmGenericTimerCounterLib.h>
+
+#define TICKS_PER_MICRO_SEC  (PcdGet32 (PcdArmArchTimerFreqInHz)/1000000U)
+
+// Select appropriate multiply function for platform architecture.
+#ifdef MDE_CPU_ARM
+#define MULT_U64_X_N  MultU64x32
+#else
+#define MULT_U64_X_N  MultU64x64
+#endif
+
+RETURN_STATUS
+EFIAPI
+TimerConstructorEx (
+  VOID
+  )
+{
+  //
+  // Check if the ARM Generic Timer Extension is implemented.
+  //
+  if (ArmIsArchTimerImplemented ()) {
+    //
+    // Check if Architectural Timer frequency is pre-determined by the platform
+    // (ie. nonzero).
+    //
+    if (PcdGet32 (PcdArmArchTimerFreqInHz) != 0) {
+      //
+      // Check if ticks/uS is not 0. The Architectural timer runs at constant
+      // frequency, irrespective of CPU frequency. According to Generic Timer
+      // Ref manual, lower bound of the frequency is in the range of 1-10MHz.
+      //
+      ASSERT (TICKS_PER_MICRO_SEC);
+
+ #ifdef MDE_CPU_ARM
+      //
+      // Only set the frequency for ARMv7. We expect the secure firmware to
+      // have already done it.
+      // If the security extension is not implemented, set Timer Frequency
+      // here.
+      //
+      if (ArmHasSecurityExtensions ()) {
+        ArmGenericTimerSetTimerFreq (PcdGet32 (PcdArmArchTimerFreqInHz));
+      }
+
+ #endif
+    }
+
+    //
+    // Architectural Timer Frequency must be set in Secure privileged
+    // mode (if secure extension is supported).
+    // If the reset value (0) is returned, just ASSERT.
+    //
+    // ASSERT (ArmGenericTimerGetTimerFreq () != 0);
+  } else {
+    DEBUG ((DEBUG_ERROR, "ARM Architectural Timer is not available in the CPU, hence this library cannot be used.\n"));
+    ASSERT (0);
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  A local utility function that returns the PCD value, if specified.
+  Otherwise it defaults to ArmGenericTimerGetTimerFreq.
+
+  @return The timer frequency.
+
+**/
+STATIC
+UINTN
+EFIAPI
+GetPlatformTimerFreq (
+  )
+{
+  UINTN  TimerFreq;
+
+  TimerFreq = PcdGet32 (PcdArmArchTimerFreqInHz);
+  if (TimerFreq == 0) {
+    TimerFreq = ArmGenericTimerGetTimerFreq ();
+  }
+
+  return TimerFreq;
+}
+
+/**
+  Stalls the CPU for the number of microseconds specified by MicroSeconds.
+
+  @param  MicroSeconds  The minimum number of microseconds to delay.
+
+  @return The value of MicroSeconds input.
+
+**/
+UINTN
+EFIAPI
+MicroSecondDelay (
+  IN      UINTN  MicroSeconds
+  )
+{
+  UINT64  TimerTicks64;
+  UINT64  SystemCounterVal;
+
+  // Calculate counter ticks that represent requested delay:
+  //  = MicroSeconds x TICKS_PER_MICRO_SEC
+  //  = MicroSeconds x Frequency.10^-6
+  TimerTicks64 = DivU64x32 (
+                   MULT_U64_X_N (
+                     MicroSeconds,
+                     GetPlatformTimerFreq ()
+                     ),
+                   1000000U
+                   );
+
+  // Wait until delay count expires.
+  SystemCounterVal = 0;
+  while (SystemCounterVal < TimerTicks64) {
+    SystemCounterVal++;
+  }
+
+  return MicroSeconds;
+}
+
+/**
+  Stalls the CPU for at least the given number of nanoseconds.
+
+  Stalls the CPU for the number of nanoseconds specified by NanoSeconds.
+
+  When the timer frequency is 1MHz, each tick corresponds to 1 microsecond.
+  Therefore, the nanosecond delay will be rounded up to the nearest 1 microsecond.
+
+  @param  NanoSeconds The minimum number of nanoseconds to delay.
+
+  @return The value of NanoSeconds inputted.
+
+**/
+UINTN
+EFIAPI
+NanoSecondDelay (
+  IN  UINTN  NanoSeconds
+  )
+{
+  UINTN  MicroSeconds;
+
+  // Round up to 1us Tick Number
+  MicroSeconds  = NanoSeconds / 1000;
+  MicroSeconds += ((NanoSeconds % 1000) == 0) ? 0 : 1;
+
+  MicroSecondDelay (MicroSeconds);
+
+  return NanoSeconds;
+}
+
+/**
+  Retrieves the current value of a 64-bit free running performance counter.
+
+  The counter can either count up by 1 or count down by 1. If the physical
+  performance counter counts by a larger increment, then the counter values
+  must be translated. The properties of the counter can be retrieved from
+  GetPerformanceCounterProperties().
+
+  @return The current value of the free running performance counter.
+
+**/
+UINT64
+EFIAPI
+GetPerformanceCounter (
+  VOID
+  )
+{
+  // Just return the value of system count
+  return ArmGenericTimerGetSystemCount ();
+}
+
+/**
+  Retrieves the 64-bit frequency in Hz and the range of performance counter
+  values.
+
+  If StartValue is not NULL, then the value that the performance counter starts
+  with immediately after is it rolls over is returned in StartValue. If
+  EndValue is not NULL, then the value that the performance counter end with
+  immediately before it rolls over is returned in EndValue. The 64-bit
+  frequency of the performance counter in Hz is always returned. If StartValue
+  is less than EndValue, then the performance counter counts up. If StartValue
+  is greater than EndValue, then the performance counter counts down. For
+  example, a 64-bit free running counter that counts up would have a StartValue
+  of 0 and an EndValue of 0xFFFFFFFFFFFFFFFF. A 24-bit free running counter
+  that counts down would have a StartValue of 0xFFFFFF and an EndValue of 0.
+
+  @param  StartValue  The value the performance counter starts with when it
+                      rolls over.
+  @param  EndValue    The value that the performance counter ends with before
+                      it rolls over.
+
+  @return The frequency in Hz.
+
+**/
+UINT64
+EFIAPI
+GetPerformanceCounterProperties (
+  OUT      UINT64  *StartValue   OPTIONAL,
+  OUT      UINT64  *EndValue     OPTIONAL
+  )
+{
+  if (StartValue != NULL) {
+    // Timer starts at 0
+    *StartValue = (UINT64)0ULL;
+  }
+
+  if (EndValue != NULL) {
+    // Timer counts up.
+    *EndValue = 0xFFFFFFFFFFFFFFFFUL;
+  }
+
+  return (UINT64)ArmGenericTimerGetTimerFreq ();
+}
+
+/**
+  Converts elapsed ticks of performance counter to time in nanoseconds.
+
+  This function converts the elapsed ticks of running performance counter to
+  time value in unit of nanoseconds.
+
+  @param  Ticks     The number of elapsed ticks of running performance counter.
+
+  @return The elapsed time in nanoseconds.
+
+**/
+UINT64
+EFIAPI
+GetTimeInNanoSecond (
+  IN      UINT64  Ticks
+  )
+{
+  UINT64  NanoSeconds;
+  UINT32  Remainder;
+  UINT32  TimerFreq;
+
+  TimerFreq = (UINT32)GetPlatformTimerFreq ();  // MU_CHANGE - ARM64 VS change
+  //
+  //          Ticks
+  // Time = --------- x 1,000,000,000
+  //        Frequency
+  //
+  NanoSeconds = MULT_U64_X_N (
+                  DivU64x32Remainder (
+                    Ticks,
+                    TimerFreq,
+                    &Remainder
+                    ),
+                  1000000000U
+                  );
+
+  //
+  // Frequency < 0x100000000, so Remainder < 0x100000000, then (Remainder * 1,000,000,000)
+  // will not overflow 64-bit.
+  //
+  NanoSeconds += DivU64x32 (
+                   MULT_U64_X_N (
+                     (UINT64)Remainder,
+                     1000000000U
+                     ),
+                   TimerFreq
+                   );
+
+  return NanoSeconds;
+}

--- a/ArmPkg/Library/ArmArchTimerLibEx/ArmArchTimerLibEx.inf
+++ b/ArmPkg/Library/ArmArchTimerLibEx/ArmArchTimerLibEx.inf
@@ -1,0 +1,34 @@
+#/** @file
+#
+#  Copyright (c) 2011 - 2014, ARM Limited. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+#Override : 00000002 | ArmPkg/Library/ArmArchTimerLib/ArmArchTimerLib.inf | 62633f727f284a943e87dda73655eb32 | 2024-12-18T22-54-40 | bd2b459bd102b6d889958ef57b06541b3a515e20
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ArmArchTimerLibEx
+  FILE_GUID                      = acb06836-a3e0-456c-8093-7125edccc62e
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = TimerLib
+  CONSTRUCTOR                    = TimerConstructorEx
+
+[Sources.common]
+  ArmArchTimerLibEx.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  ArmPkg/ArmPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  ArmLib
+  BaseLib
+  ArmGenericTimerCounterLib
+
+[Pcd]
+  gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz

--- a/ArmPkg/Library/NotificationServiceLib/NotificationServiceLib.c
+++ b/ArmPkg/Library/NotificationServiceLib/NotificationServiceLib.c
@@ -1,0 +1,518 @@
+/** @file
+  Implementation for the Notification Service
+
+  Copyright (c), Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/NotificationServiceLib.h>
+
+/* Notification Service Defines */
+#define NOTIFICATION_MAX_SERVICES  (16)
+#define NOTIFICATION_MAX_IDS       (64)
+#define NOTIFICATION_ID_NOT_FOUND  (-1)
+
+/* Notification Service Structures */
+typedef struct {
+  UINT16     BitNum; // The OS translation bitmap value
+  UINT16     IdNum;  // The logical ID for the service
+  BOOLEAN    InUse;
+} NotifBits;
+
+typedef struct  {
+  UINT8        ServiceUuid[16];
+  NotifBits    ServiceBits[NOTIFICATION_MAX_IDS];
+  BOOLEAN      InUse;
+} NotifService;
+
+/* Notification Service Variables */
+STATIC BOOLEAN       IdsAcquired                                     = FALSE;
+STATIC UINT16        SourceId                                        = 0;
+STATIC UINT16        DestinationId                                   = 0;
+STATIC UINT64        GlobalBitmask                                   = 0;
+STATIC NotifService  NotificationServices[NOTIFICATION_MAX_SERVICES] = { 0 };
+
+/**
+  Checks if the ID passed in matches one stored within the service structure
+
+  @param  IdNum   The ID number to look for
+  @param  Service The service to search for the given ID
+
+  @return The index of the ID if found, otherwise -1 (NOTIFICATION_ID_NOT_FOUND)
+
+**/
+STATIC
+INT8
+IsMatchingId (
+  UINT16        IdNum,
+  NotifService  *Service
+  )
+{
+  /* Validate the incoming function parameters */
+  if (Service == NULL) {
+    return NOTIFICATION_ID_NOT_FOUND;
+  }
+
+  for (UINT8 i = 0; i < NOTIFICATION_MAX_IDS; i++) {
+    if (Service->ServiceBits[i].InUse && (Service->ServiceBits[i].IdNum == IdNum)) {
+      return i;
+    }
+  }
+
+  return NOTIFICATION_ID_NOT_FOUND;
+}
+
+/**
+  Validates the incoming message parameters
+
+  @param  Destroy   Whether or not we are adding or removing bit information
+  @param  Request   The incoming message containing the bit information to validate
+  @param  Service   The service we are updating bit information for
+
+  @retval TRUE  Parameters are valid
+  @retval FALSE Parameters are invalid
+
+**/
+STATIC
+BOOLEAN
+ValidParameters (
+  BOOLEAN             Destroy,
+  DIRECT_MSG_ARGS_EX  *Request,
+  NotifService        *Service
+  )
+{
+  /* Validate the incoming function parameters */
+  if ((Request == NULL) || (Service == NULL)) {
+    return FALSE;
+  }
+
+  /* Validate the setup and destroy parameters for the service. You must be setting/destroying at
+    * least one bit and you can't set more than the service supports. */
+  UINT8  NumBits = Request->Arg3;
+
+  if ((NumBits <= 0) || (NumBits > NOTIFICATION_MAX_IDS)) {
+    return FALSE;
+  }
+
+  UINTN  *Mappings = &Request->Arg4;
+
+  for (UINT8 i = 0; i < NumBits; i++) {
+    /* Validate that a user is not trying to setup an ID that has already been setup previously or
+      * attempting to destroy an ID that doesn't exist. */
+    UINT16  NotificationId = Mappings[i];
+    INT8    IdIndex        = IsMatchingId (NotificationId, Service);
+    if (!Destroy && (IdIndex != NOTIFICATION_ID_NOT_FOUND)) {
+      return FALSE;
+    } else if (Destroy && (IdIndex == NOTIFICATION_ID_NOT_FOUND)) {
+      return FALSE;
+    }
+
+    /* Validate that a user is not trying to set a bit that is already in use or destroy a bit
+      * they haven't previously set up. */
+    UINT16  BitmapBitNum = (Mappings[i] >> 16);
+    if (!Destroy && (GlobalBitmask & (1 << BitmapBitNum))) {
+      return FALSE;
+    } else if (Destroy && (Service->ServiceBits[IdIndex].BitNum != BitmapBitNum)) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  Adds or removes service bit information to the local notification services struct array
+
+  @param  Destroy   Whether or not we are adding or removing bit information
+  @param  Request   The incoming message containing the bit information
+  @param  Service   The service we are updating bit information for
+
+  @retval NOTIFICATION_STATUS_SUCCESS           Success
+  @retval NOTIFICATION_STATUS_INVALID_PARAMETER Invalid parameter
+
+**/
+STATIC
+NotificationStatus
+UpdateServiceBits (
+  BOOLEAN             Destroy,
+  DIRECT_MSG_ARGS_EX  *Request,
+  NotifService        *Service
+  )
+{
+  /* Validate the incoming function parameters */
+  if ((Request == NULL) || (Service == NULL)) {
+    return NOTIFICATION_STATUS_INVALID_PARAMETER;
+  }
+
+  NotificationStatus  ReturnVal = NOTIFICATION_STATUS_INVALID_PARAMETER;
+  UINT8               NumBits   = Request->Arg3;
+
+  /* Need to go through all of the setup bits and update the structure */
+  UINTN  *Mappings = &Request->Arg4;
+
+  for (UINT8 i = 0; i < NumBits; i++) {
+    UINT16  NotificationId = Mappings[i];
+    UINT16  BitmapBitNum   = Mappings[i] >> 16;
+
+    if (Destroy) {
+      /* If we can not find the ID to destroy, it is an error */
+      INT8  Index = IsMatchingId (NotificationId, Service);
+      if (Index != NOTIFICATION_ID_NOT_FOUND) {
+        Service->ServiceBits[Index].BitNum = 0;
+        Service->ServiceBits[Index].IdNum  = 0;
+        Service->ServiceBits[Index].InUse  = FALSE;
+
+        /* Clear the global bitmask bit */
+        GlobalBitmask &= ~(1 << BitmapBitNum);
+        ReturnVal      = NOTIFICATION_STATUS_SUCCESS;
+      }
+    } else {
+      /* Need to loop through the bits within the structure and find an empty location, if
+        * unable to, we ran out of room, return an error */
+      UINT8    Index;
+      BOOLEAN  EmptyFound = FALSE;
+      for (Index = 0; Index < NOTIFICATION_MAX_IDS; Index++) {
+        if (!Service->ServiceBits[Index].InUse) {
+          EmptyFound = TRUE;
+          break;
+        }
+      }
+
+      /* If we can not find an empty space, it is an error */
+      if (EmptyFound) {
+        Service->ServiceBits[Index].BitNum = BitmapBitNum;
+        Service->ServiceBits[Index].IdNum  = NotificationId;
+        Service->ServiceBits[Index].InUse  = TRUE;
+
+        /* Set the global bitmask bit */
+        GlobalBitmask |= (1 << BitmapBitNum);
+        ReturnVal      = NOTIFICATION_STATUS_SUCCESS;
+      }
+    }
+  }
+
+  return ReturnVal;
+}
+
+/**
+  Handler for Notification Query command
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+  @retval NOTIFICATION_STATUS_GENERIC_ERROR Unsupported Function
+
+**/
+STATIC
+NotificationStatus
+QueryHandler (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  /* TODO: Remove when/if we decided to support Query */
+  Response->Arg0 = NOTIFICATION_STATUS_GENERIC_ERROR;
+  DEBUG ((DEBUG_ERROR, "Notification Service Query Unsupported\n"));
+  return NOTIFICATION_STATUS_GENERIC_ERROR;
+
+  NotifService        *Service  = NULL;
+  UINT8               Uuid[16]  = { 0 };
+  NotificationStatus  ReturnVal = NOTIFICATION_STATUS_INVALID_PARAMETER;
+
+  /* Extract the UUID from the message */
+  NotificationServiceExtractUuid (Request, Uuid);
+
+  /* Attempt to find the UUID within our list */
+  for (UINT8 i = 0; i < NOTIFICATION_MAX_SERVICES; i++) {
+    if (!CompareMem (Uuid, NotificationServices[i].ServiceUuid, sizeof (Uuid))) {
+      Service = &NotificationServices[i];
+      break;
+    }
+  }
+
+  /* Check for a valid UUID */
+  if (Service != NULL) {
+    /* Count the number of IDs that are in use */
+    UINT8  NumIds = 0;
+    for (UINT8 i = 0; i < NOTIFICATION_MAX_IDS; i++) {
+      if (Service->ServiceBits[NumIds].InUse) {
+        NumIds++;
+      }
+    }
+
+    Response->Arg1 = NumIds;
+    ReturnVal      = NOTIFICATION_STATUS_SUCCESS;
+  } else {
+    DEBUG ((DEBUG_ERROR, "Invalid Notification Service UUID\n"));
+  }
+
+  Response->Arg0 = ReturnVal;
+  return ReturnVal;
+}
+
+/**
+  Handler for Notification Setup command
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+  @retval NOTIFICATION_STATUS_SUCCESS           Success
+  @retval NOTIFICATION_STATUS_INVALID_PARAMETER Invalid parameter
+
+**/
+STATIC
+NotificationStatus
+SetupHandler (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  NotifService        *Service  = NULL;
+  UINT8               Uuid[16]  = { 0 };
+  NotificationStatus  ReturnVal = NOTIFICATION_STATUS_INVALID_PARAMETER;
+
+  /* Extract the UUID from the message */
+  NotificationServiceExtractUuid (Request, Uuid);
+
+  /* If we haven't stored the source and destination IDs, store them */
+  if (!IdsAcquired) {
+    SourceId      = Request->SourceId;
+    DestinationId = Request->DestinationId;
+    IdsAcquired   = TRUE;
+  }
+
+  /* Attempt to find the UUID within our list */
+  for (UINT8 i = 0; i < NOTIFICATION_MAX_SERVICES; i++) {
+    if (!CompareMem (Uuid, NotificationServices[i].ServiceUuid, sizeof (Uuid))) {
+      Service = &NotificationServices[i];
+      break;
+    }
+  }
+
+  /* The UUID was not found in the list, attempt to find an empty location to add it */
+  if (Service == NULL) {
+    for (UINT8 i = 0; i < NOTIFICATION_MAX_SERVICES; i++) {
+      if (!NotificationServices[i].InUse) {
+        Service = &NotificationServices[i];
+        CopyMem (Service->ServiceUuid, Uuid, sizeof (Uuid));
+        Service->InUse = TRUE;
+        break;
+      }
+    }
+  }
+
+  /* Check for a valid UUID and validate the input parameters */
+  if ((Service != NULL) && (ValidParameters (FALSE, Request, Service))) {
+    ReturnVal = UpdateServiceBits (FALSE, Request, Service);
+  } else if (Service != NULL) {
+    DEBUG ((DEBUG_ERROR, "Invalid Parameters\n"));
+  } else {
+    DEBUG ((DEBUG_ERROR, "Invalid Notification Service UUID\n"));
+  }
+
+  Response->Arg0 = ReturnVal;
+  return ReturnVal;
+}
+
+/**
+  Handler for Notification Destroy command
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+  @retval NOTIFICATION_STATUS_SUCCESS           Success
+  @retval NOTIFICATION_STATUS_INVALID_PARAMETER Invalid parameter
+
+**/
+STATIC
+NotificationStatus
+DestroyHandler (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  NotifService        *Service  = NULL;
+  UINT8               Uuid[16]  = { 0 };
+  NotificationStatus  ReturnVal = NOTIFICATION_STATUS_INVALID_PARAMETER;
+
+  /* Extract the UUID from the message */
+  NotificationServiceExtractUuid (Request, Uuid);
+
+  /* Attempt to find the UUID within our list */
+  for (UINT8 i = 0; i < NOTIFICATION_MAX_SERVICES; i++) {
+    if (!CompareMem (Uuid, NotificationServices[i].ServiceUuid, sizeof (Uuid))) {
+      Service = &NotificationServices[i];
+      break;
+    }
+  }
+
+  /* Check for a valid UUID and validate the input parameters */
+  if ((Service != NULL) && (ValidParameters (TRUE, Request, Service))) {
+    ReturnVal = UpdateServiceBits (TRUE, Request, Service);
+  } else if (Service != NULL) {
+    DEBUG ((DEBUG_ERROR, "Invalid Parameters\n"));
+  } else {
+    DEBUG ((DEBUG_ERROR, "Invalid Notification Service UUID\n"));
+  }
+
+  Response->Arg0 = ReturnVal;
+  return ReturnVal;
+}
+
+/**
+  Initializes the Notification service
+
+**/
+VOID
+NotificationServiceInit (
+  VOID
+  )
+{
+  /* Nothing to Init */
+}
+
+/**
+  Deinitializes the Notification service
+
+**/
+VOID
+NotificationServiceDeInit (
+  VOID
+  )
+{
+  /* Nothing to DeInit */
+}
+
+/**
+  Handler for Notification service commands
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+**/
+VOID
+NotificationServiceHandle (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  /* Validate the input parameters before attempting to dereference or pass them along */
+  if ((Request == NULL) || (Response == NULL)) {
+    return;
+  }
+
+  UINT64  Opcode = Request->Arg0;
+
+  switch (Opcode) {
+    case NOTIFICATION_OPCODE_QUERY:
+      QueryHandler (Request, Response);
+      break;
+
+    case NOTIFICATION_OPCODE_SETUP:
+      SetupHandler (Request, Response);
+      break;
+
+    case NOTIFICATION_OPCODE_DESTROY:
+      DestroyHandler (Request, Response);
+      break;
+
+    default:
+      Response->Arg0 = NOTIFICATION_STATUS_INVALID_PARAMETER;
+      DEBUG ((DEBUG_ERROR, "Invalid Notification Service Opcode\n"));
+      break;
+  }
+}
+
+/**
+  Calls NotificationSet on the given ID with the given flag
+
+  @param  Id           The ID to trigger the event on
+  @param  ServiceUuid  The service containing the ID to trigger
+  @param  Flag         The NotificationSet flag to use
+
+  @retval NOTIFICATION_STATUS_SUCCESS           Success
+  @retval NOTIFICATION_STATUS_INVALID_PARAMETER Invalid parameter
+  @retval NOTIFICATION_STATUS_GENERIC_ERROR     NotificationSet failed
+
+**/
+NotificationStatus
+NotificationServiceIdSet (
+  UINT16  Id,
+  UINT8   *ServiceUuid,
+  UINT32  Flag
+  )
+{
+  /* Validate the incoming function parameters */
+  if (ServiceUuid == NULL) {
+    return NOTIFICATION_STATUS_INVALID_PARAMETER;
+  }
+
+  NotifService        *Service  = NULL;
+  NotificationStatus  ReturnVal = NOTIFICATION_STATUS_INVALID_PARAMETER;
+
+  /* Attempt to find the UUID within our list */
+  for (UINT8 i = 0; i < NOTIFICATION_MAX_SERVICES; i++) {
+    if (!CompareMem (ServiceUuid, NotificationServices[i].ServiceUuid, sizeof (NotificationServices[i].ServiceUuid))) {
+      Service = &NotificationServices[i];
+      break;
+    }
+  }
+
+  /* UUID was found */
+  if (Service != NULL) {
+    /* Attempt to find the logical ID within the mapped list */
+    for (UINT8 i = 0; i < NOTIFICATION_MAX_IDS; i++) {
+      if (Service->ServiceBits[i].IdNum == Id) {
+        UINT64      Bitmask = (1 << Service->ServiceBits[i].BitNum);
+        EFI_STATUS  Status  = FfaNotificationSet (SourceId, Flag, Bitmask);
+        if (EFI_ERROR (Status)) {
+          ReturnVal = NOTIFICATION_STATUS_GENERIC_ERROR;
+        } else {
+          ReturnVal = NOTIFICATION_STATUS_SUCCESS;
+        }
+
+        break;
+      }
+    }
+  }
+
+  return ReturnVal;
+}
+
+/**
+  Extracts the UUID from the message arguments
+
+  @param  Request   The incoming message to extract the UUID from
+  @param  Uuid      The UUID to populate
+
+**/
+VOID
+NotificationServiceExtractUuid (
+  DIRECT_MSG_ARGS_EX  *Request,
+  UINT8               *Uuid
+  )
+{
+  /* Validate the incoming function parameters */
+  if ((Request == NULL) || (Uuid == NULL)) {
+    return;
+  }
+
+  UINT64  UuidLo = Request->Arg1;
+  UINT64  UuidHi = Request->Arg2;
+
+  /* Copy the upper 8 bytes */
+  for (UINT8 i = 0; i < 8; i++) {
+    UINT8  UuidHiByte = (UINT8)(UuidHi >> ((7 - i) * 8));
+    Uuid[i] = UuidHiByte;
+  }
+
+  /* Copy the lower 8 bytes */
+  for (UINT8 i = 8; i < 16; i++) {
+    UINT8  UuidLoByte = (UINT8)(UuidLo >> ((15 - i) * 8));
+    Uuid[i] = UuidLoByte;
+  }
+}

--- a/ArmPkg/Library/NotificationServiceLib/NotificationServiceLib.inf
+++ b/ArmPkg/Library/NotificationServiceLib/NotificationServiceLib.inf
@@ -1,0 +1,35 @@
+#/** @file
+#
+#  Component description file for the Notification Service
+#
+#  Copyright (c), Microsoft Corporation.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = NotificationServiceLib
+  FILE_GUID                      = 115afb27-e754-4618-8ff8-9e7efbd9998a
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NotificationServiceLib
+
+[Sources.common]
+  NotificationServiceLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  ArmPkg/ArmPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  PlatformFfaInterruptLib
+  ArmSvcLib
+  ArmSmcLib
+  ArmFfaLib
+  ArmFfaLibEx
+
+[Pcd]
+  gArmTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/ArmPkg/Library/TestServiceLib/TestServiceLib.c
+++ b/ArmPkg/Library/TestServiceLib/TestServiceLib.c
@@ -1,0 +1,112 @@
+/** @file
+  Implementation for the Test Service
+
+  Copyright (c), Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/TestServiceLib.h>
+#include <Library/NotificationServiceLib.h>
+
+/* Test Service Defines */
+#define DELAYED_SRI_BIT_POS  (1)
+
+/**
+  Handler for Test Notification command
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+  @retval TEST_STATUS_SUCCESS           Success
+  @retval TEST_STATUS_INVALID_PARAMETER Invalid Parameter
+
+**/
+STATIC
+TestStatus
+TestNotificationHandler (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  UINT8       Uuid[16]  = { 0 };
+  TestStatus  ReturnVal = TEST_STATUS_INVALID_PARAMETER;
+
+  /* Extract the UUID from the message */
+  NotificationServiceExtractUuid (Request, Uuid);
+
+  /* Set the notification set flag to be a delayed SRI */
+  UINT32  Flag = (1 << DELAYED_SRI_BIT_POS);
+
+  UINT16              LogicalId = Request->Arg3;
+  NotificationStatus  Status    = NotificationServiceIdSet (LogicalId, Uuid, Flag);
+
+  /* Check for a valid UUID and validate the input parameters */
+  if (Status == NOTIFICATION_STATUS_SUCCESS) {
+    ReturnVal = TEST_STATUS_SUCCESS;
+  } else {
+    DEBUG ((DEBUG_ERROR, "Test Notification Handler Failed\n"));
+  }
+
+  Response->Arg0 = ReturnVal;
+  return ReturnVal;
+}
+
+/**
+  Initializes the Test service
+
+**/
+VOID
+TestServiceInit (
+  VOID
+  )
+{
+  /* Nothing to Init */
+}
+
+/**
+  Deinitializes the Test service
+
+**/
+VOID
+TestServiceDeInit (
+  VOID
+  )
+{
+  /* Nothing to Deinit */
+}
+
+/**
+  Handler for Test service commands
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+**/
+VOID
+TestServiceHandle (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  /* Validate the input parameters before attempting to dereference or pass them along */
+  if ((Request == NULL) || (Response == NULL)) {
+    return;
+  }
+
+  UINT64  Opcode = Request->Arg0;
+
+  switch (Opcode) {
+    case TEST_OPCODE_TEST_NOTIFICATION:
+      TestNotificationHandler (Request, Response);
+      break;
+
+    default:
+      Response->Arg0 = TEST_STATUS_INVALID_PARAMETER;
+      DEBUG ((DEBUG_ERROR, "Invalid Test Service Opcode\n"));
+      break;
+  }
+}

--- a/ArmPkg/Library/TestServiceLib/TestServiceLib.inf
+++ b/ArmPkg/Library/TestServiceLib/TestServiceLib.inf
@@ -1,0 +1,36 @@
+#/** @file
+#
+#  Component description file for the Test Service
+#
+#  Copyright (c), Microsoft Corporation.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = TestServiceLib
+  FILE_GUID                      = b774be23-7976-49ff-8783-d0ea05f963d6
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = TestServiceLib
+
+[Sources.common]
+  TestServiceLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  ArmPkg/ArmPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  PlatformFfaInterruptLib
+  ArmSvcLib
+  ArmSmcLib
+  ArmFfaLib
+  ArmFfaLibEx
+  NotificationServiceLib
+
+[Pcd]
+  gArmTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/ArmPkg/Library/TpmServiceLib/TpmServiceLib.c
+++ b/ArmPkg/Library/TpmServiceLib/TpmServiceLib.c
@@ -1,0 +1,479 @@
+/** @file
+  Implementation for the TPM Service
+
+  Copyright (c), Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/TpmServiceLib.h>
+#include <Guid/Tpm2ServiceFfa.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <IndustryStandard/TpmPtp.h>
+
+/* TPM Service Defines */
+#define TPM_MAJOR_VER  (1)
+#define TPM_MINOR_VER  (0)
+
+#define TPM_START_PROCESS_CMD      (0)
+#define TPM_START_PROCESS_LOC_REQ  (1)
+
+#define TPM_LOC_STATE_MASK   (0x9F)
+#define TPM_LOC_STS_MASK     (0x01)
+#define TPM_CTRL_START_MASK  (0x01)
+
+// Default Value - tpmEstablished
+#define TPM_LOC_STATE_DEFAULT     (0x01)
+// Default Value - CRB Interface Selected, Only Locality0 Supported
+#define TPM_INTERFACE_ID_DEFAULT  (0x4011) 
+
+typedef UINTN TpmStatus;
+
+/**
+  Converts the passed in EFI_STATUS to a TPM_STATUS
+
+  @param  Status   The EFI_STATUS to convert
+
+  @retval TPM_STATUS_OK      Success
+  @retval TPM_STATUS_INVARG  Invalid parameter
+  @retval TPM_STATUS_DENIED  Access denied
+  @retval TPM_STATUS_NOMEM   Insufficient memory
+
+**/
+STATIC
+TpmStatus
+ConvertEfiToTpmStatus (
+  EFI_STATUS  Status
+  )
+{
+  TpmStatus  ReturnVal;
+
+  switch (Status) {
+    case EFI_SUCCESS:
+      ReturnVal = TPM2_FFA_SUCCESS_OK;
+      break;
+
+    case EFI_DEVICE_ERROR:
+      ReturnVal = TPM2_FFA_ERROR_DENIED;
+      break;
+
+    case EFI_BUFFER_TOO_SMALL:
+      ReturnVal = TPM2_FFA_ERROR_NOMEM;
+      break;
+
+    default:
+      ReturnVal = TPM2_FFA_ERROR_DENIED;
+      break;
+  }
+
+  return ReturnVal;
+}
+
+/**
+  Initializes the internal CRB
+
+**/
+STATIC
+VOID
+InitInternalCrb (
+  VOID
+  )
+{
+  /* TODO: If we end up supporting more than Locality0, this will need to init all localities supported */
+  PTP_CRB_REGISTERS_PTR  InternalTpmCrb;
+
+  InternalTpmCrb = (PTP_CRB_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmInternalBaseAddress);
+  DEBUG ((DEBUG_INFO, "PcdTpmInternalBaseAddress: %lx\n", PcdGet64 (PcdTpmInternalBaseAddress)));
+  SetMem ((void *)InternalTpmCrb, sizeof (PTP_CRB_REGISTERS), 0x00);
+  InternalTpmCrb->LocalityState = TPM_LOC_STATE_DEFAULT;
+  InternalTpmCrb->InterfaceId   = TPM_INTERFACE_ID_DEFAULT; 
+}
+
+/**
+  Updates the internal CRB with the locality information for the locality requested
+
+**/
+STATIC
+VOID
+UpdateInternalCrb (
+  VOID
+  )
+{
+  /* TODO: If we end up supporting more than Locality0, this will need to update the correct locality registers */
+  PTP_CRB_REGISTERS_PTR  InternalTpmCrb;
+
+  InternalTpmCrb                 = (PTP_CRB_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmInternalBaseAddress);
+  InternalTpmCrb->LocalityState |= PTP_CRB_LOCALITY_STATE_TPM_REG_VALID_STATUS;
+  InternalTpmCrb->LocalityState &= ~(PTP_CRB_LOCALITY_STATE_ACTIVE_LOCALITY_MASK);
+  /* NOTE: Leaving the ActiveLocality as 0 as that is our only supported locality */
+  InternalTpmCrb->LocalityState |= PTP_CRB_LOCALITY_STATE_LOCALITY_ASSIGNED;
+  InternalTpmCrb->LocalityState |= PTP_CRB_LOCALITY_STATE_TPM_ESTABLISHED;
+  DEBUG ((DEBUG_INFO, "LocalityState: %x\n", InternalTpmCrb->LocalityState));
+  InternalTpmCrb->LocalityStatus |= PTP_CRB_LOCALITY_STATUS_GRANTED;
+}
+
+/**
+  Cleans the internal CRB putting registers into a known good state
+
+**/
+STATIC
+VOID
+CleanInternalCrb (
+  VOID
+  )
+{
+  /* TODO: If we end up supporting more than Locality0, this will need to clean the correct locality registers */
+  PTP_CRB_REGISTERS_PTR  InternalTpmCrb;
+
+  InternalTpmCrb                      = (PTP_CRB_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmInternalBaseAddress);
+  InternalTpmCrb->LocalityState      &= TPM_LOC_STATE_MASK;
+  InternalTpmCrb->LocalityControl     = 0;
+  InternalTpmCrb->LocalityStatus     &= TPM_LOC_STS_MASK;
+  InternalTpmCrb->InterfaceId         = TPM_INTERFACE_ID_DEFAULT;
+  InternalTpmCrb->CrbControlExtension = 0;
+  InternalTpmCrb->CrbControlRequest   = 0;
+  InternalTpmCrb->CrbControlStatus    = PTP_CRB_CONTROL_AREA_STATUS_TPM_IDLE;
+  InternalTpmCrb->CrbControlCancel    = 0;
+  InternalTpmCrb->CrbControlStart    &= TPM_CTRL_START_MASK;
+  InternalTpmCrb->CrbInterruptEnable  = 0;
+  InternalTpmCrb->CrbInterruptStatus  = 0;
+  /* Remaining registers can be ignored */
+}
+
+/**
+  Handles commands for the TPM service
+
+  @retval TPM_STATUS_OK      Success
+  @retval TPM_STATUS_INVARG  Invalid parameter
+  @retval TPM_STATUS_DENIED  Access denied
+  @retval TPM_STATUS_NOMEM   Insufficient memory
+
+**/
+STATIC
+TpmStatus
+HandleCommand (
+  VOID
+  )
+{
+  PTP_CRB_REGISTERS_PTR  InternalTpmCrb;
+
+  DEBUG ((DEBUG_INFO, "Handle TPM Command\n"));
+  InternalTpmCrb = (PTP_CRB_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmInternalBaseAddress);
+
+  /* Make sure the internal CRB was set to start a command */
+  if (InternalTpmCrb->CrbControlStart != 1) {
+    return TPM2_FFA_ERROR_DENIED;
+  }
+
+  /* Set the status to ready (i.e. not idle) */
+  InternalTpmCrb->CrbControlStatus = 0;
+
+  /* Submit the command to the TPM */
+  EFI_STATUS  Status = Tpm2SubmitCommand (
+                         InternalTpmCrb->CrbControlCommandSize,
+                         InternalTpmCrb->CrbDataBuffer,
+                         &InternalTpmCrb->CrbControlResponseSize,
+                         InternalTpmCrb->CrbDataBuffer
+                         );
+
+  /* Clear the internal CRB start register to indicate successful completion and response ready */
+  if (Status == EFI_SUCCESS) {
+    InternalTpmCrb->CrbControlStart = 0;
+  } else {
+    DEBUG ((DEBUG_ERROR, "Command Failed w/ Status: %x\n", Status));
+  }
+
+  /* Set the status to idle */
+  InternalTpmCrb->CrbControlStatus = PTP_CRB_CONTROL_AREA_STATUS_TPM_IDLE;
+
+  return ConvertEfiToTpmStatus (Status);
+}
+
+/**
+  Handles locality requests for the TPM service
+
+  @retval TPM_STATUS_OK      Success
+  @retval TPM_STATUS_INVARG  Invalid parameter
+  @retval TPM_STATUS_DENIED  Access denied
+  @retval TPM_STATUS_NOMEM   Insufficient memory
+
+**/
+STATIC
+TpmStatus
+HandleLocalityRequest (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  DEBUG ((DEBUG_INFO, "Handle TPM Locality Request\n"));
+
+  /* Request to use the TPM */
+  Status = Tpm2RequestUseTpm ();
+
+  /* Update the internal TPM CRB */
+  if (Status == EFI_SUCCESS) {
+    UpdateInternalCrb ();
+  } else {
+    DEBUG ((DEBUG_ERROR, "Locality Request Failed w/ Status: %x\n", Status));
+  }
+
+  return ConvertEfiToTpmStatus (Status);
+}
+
+/**
+  Handler for TPM service GetInterfaceVersion command
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+  @retval TPM_STATUS_OK Success
+
+**/
+STATIC
+TpmStatus
+GetInterfaceVersionHandler (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  TpmStatus  ReturnVal;
+
+  ReturnVal      = TPM2_FFA_SUCCESS_OK;
+  Response->Arg0 = TPM2_FFA_SUCCESS_OK_RESULTS_RETURNED;
+  Response->Arg1 = (TPM_MAJOR_VER << 16) | TPM_MINOR_VER;
+  return ReturnVal;
+}
+
+/**
+  Handler for TPM service GetFeatureInfo command
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+  @retval TPM_STATUS_OK Success
+
+**/
+STATIC
+TpmStatus
+GetFeatureInfoHandler (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  TpmStatus  ReturnVal;
+
+  ReturnVal      = TPM2_FFA_SUCCESS_OK;
+  Response->Arg0 = TPM2_FFA_ERROR_NOTSUP;
+  DEBUG ((DEBUG_ERROR, "Unsupported Function\n"));
+  return ReturnVal;
+}
+
+/**
+  Handler for TPM service Start command
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+  @retval TPM_STATUS_OK      Success
+  @retval TPM_STATUS_INVARG  Invalid parameter
+  @retval TPM_STATUS_DENIED  Access denied
+  @retval TPM_STATUS_NOMEM   Insufficient memory
+
+**/
+STATIC
+TpmStatus
+StartHandler (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  TpmStatus  ReturnVal;
+  UINT8      Function;
+  UINT8      Locality;
+
+  ReturnVal = TPM2_FFA_SUCCESS_OK;
+  Function  = Request->Arg1;
+  Locality  = Request->Arg2;
+
+  /* Based on the function we will need to read from the corresponding address
+    * register in the tpm_crb to know where to pull the data from:
+    * NOTE: function = 0, command is ready to be processed
+    *       function = 1, locality request is ready to be processed
+    *       locality = 0...4, the locality where the command or request is located */
+  /* TODO: Currently only Locality0 is available, if this needs to change, we should
+   *       update the PCD base address with the appropriate locality offset. */
+  if (Locality != PTP_CRB_LOCALITY_STATE_ACTIVE_LOCALITY_0) {
+    Response->Arg0 = TPM2_FFA_ERROR_INVARG;
+    DEBUG ((DEBUG_ERROR, "Invalid Locality\n"));
+    return TPM2_FFA_ERROR_INVARG;
+  }
+
+  if (Function == TPM_START_PROCESS_CMD) {
+    ReturnVal = HandleCommand ();
+  } else if (Function == TPM_START_PROCESS_LOC_REQ) {
+    ReturnVal = HandleLocalityRequest ();
+  } else {
+    ReturnVal = TPM2_FFA_ERROR_INVARG;
+    DEBUG ((DEBUG_ERROR, "Invalid Start Function\n"));
+  }
+
+  /* Clean up the internal CRB at the given locality */
+  CleanInternalCrb ();
+
+  Response->Arg0 = ReturnVal;
+  return ReturnVal;
+}
+
+/**
+  Handler for TPM service Register command
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+  @retval TPM_STATUS_OK Success
+
+**/
+STATIC
+TpmStatus
+RegisterHandler (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  TpmStatus  ReturnVal;
+
+  ReturnVal      = TPM2_FFA_SUCCESS_OK;
+  Response->Arg0 = TPM2_FFA_ERROR_NOTSUP;
+  DEBUG ((DEBUG_ERROR, "Unsupported Function\n"));
+  return ReturnVal;
+}
+
+/**
+  Handler for TPM service Unregister command
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+  @retval TPM_STATUS_OK Success
+
+**/
+STATIC
+TpmStatus
+UnregisterHandler (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  TpmStatus  ReturnVal;
+
+  ReturnVal      = TPM2_FFA_SUCCESS_OK;
+  Response->Arg0 = TPM2_FFA_ERROR_NOTSUP;
+  DEBUG ((DEBUG_ERROR, "Unsupported Function\n"));
+  return ReturnVal;
+}
+
+/**
+  Handler for TPM service Finish command
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+  @retval TPM_STATUS_OK Success
+
+**/
+STATIC
+TpmStatus
+FinishHandler (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  TpmStatus  ReturnVal;
+
+  ReturnVal      = TPM2_FFA_SUCCESS_OK;
+  Response->Arg0 = TPM2_FFA_ERROR_NOTSUP;
+  DEBUG ((DEBUG_ERROR, "Unsupported Function\n"));
+  return ReturnVal;
+}
+
+/**
+  Initializes the TPM service
+
+**/
+VOID
+TpmServiceInit (
+  VOID
+  )
+{
+  InitInternalCrb ();
+}
+
+/**
+  Deinitializes the TPM service
+
+**/
+VOID
+TpmServiceDeInit (
+  VOID
+  )
+{
+  /* Nothing to DeInit */
+}
+
+/**
+  Handler for TPM service commands
+
+  @param  Request   The incoming message
+  @param  Response  The outgoing message
+
+**/
+VOID
+TpmServiceHandle (
+  DIRECT_MSG_ARGS_EX  *Request,
+  DIRECT_MSG_ARGS_EX  *Response
+  )
+{
+  UINT64  Opcode;
+
+  /* Validate the input parameters before attempting to dereference or pass them along */
+  if ((Request == NULL) || (Response == NULL)) {
+    return;
+  }
+
+  Opcode = Request->Arg0;
+
+  switch (Opcode) {
+    case TPM2_FFA_GET_INTERFACE_VERSION:
+      GetInterfaceVersionHandler (Request, Response);
+      break;
+
+    case TPM2_FFA_GET_FEATURE_INFO:
+      GetFeatureInfoHandler (Request, Response);
+      break;
+
+    case TPM2_FFA_START:
+      StartHandler (Request, Response);
+      break;
+
+    case TPM2_FFA_REGISTER_FOR_NOTIFICATION:
+      RegisterHandler (Request, Response);
+      break;
+
+    case TPM2_FFA_UNREGISTER_FROM_NOTIFICATION:
+      UnregisterHandler (Request, Response);
+      break;
+
+    case TPM2_FFA_FINISH_NOTIFIED:
+      FinishHandler (Request, Response);
+      break;
+
+    default:
+      Response->Arg0 = TPM2_FFA_ERROR_NOFUNC;
+      DEBUG ((DEBUG_ERROR, "Invalid TPM Service Opcode\n"));
+      break;
+  }
+}

--- a/ArmPkg/Library/TpmServiceLib/TpmServiceLib.inf
+++ b/ArmPkg/Library/TpmServiceLib/TpmServiceLib.inf
@@ -1,0 +1,39 @@
+#/** @file
+#
+#  Component description file for the TPM Service
+#
+#  Copyright (c), Microsoft Corporation.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = TpmServiceLib
+  FILE_GUID                      = 84002883-0ef6-4c50-908d-f6408386b8fe
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = TpmServiceLib
+
+[Sources.common]
+  TpmServiceLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  ArmPkg/ArmPkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  PlatformFfaInterruptLib
+  ArmSvcLib
+  ArmSmcLib
+  ArmFfaLib
+  ArmFfaLibEx
+  Tpm2DeviceLib
+
+[Pcd]
+  gArmTokenSpaceGuid.PcdFfaLibConduitSmc                   ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress          ## SOMETIMES_CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInternalBaseAddress  ## CONSUMES


### PR DESCRIPTION
## Description

All services from Trusted Services have been ported to UEFI style and are running in a secure partition generated our UEFI style as well. The services have been ported as libraries that secure partitions can include if they would like to utilize them. Added an ArmArchTimer library for the secure partition to support the TPM library for the TPM service. SEL0 SP's do not have access to timer registers so we needed a work-around.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Verified service functionality through the FfaPartitionTestApp with the TPM service being tested through building with the TPM defines set in the build_conf file. Secure partition is being dispatched and all services are being exercised. 

## Integration Instructions

N/A
