### PR TITLE
Adding a PartitionId PCD for FF-A TPM service

### DIFF
--- a/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.inf
+++ b/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.inf
@@ -45,3 +45,4 @@
 [Pcd.common]
   gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress            ## CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType    ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmServiceFfaPartitionId  ## SOMETIMES_PRODUCES

--- a/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2ServiceFfaRaw.c
+++ b/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2ServiceFfaRaw.c
@@ -230,6 +230,14 @@ GetTpmServicePartitionId (
     goto Exit;
   }
 
+  if (PcdGet16 (PcdTpmServiceFfaPartitionId) != 0) {
+    mFfaTpm2PartitionId = PcdGet16 (PcdTpmServiceFfaPartitionId);
+    *PartitionId        = mFfaTpm2PartitionId;
+    Status              = EFI_SUCCESS;
+
+    goto Exit;
+  }
+
   CopyMem (&TpmServiceGuid, &gEfiTpm2ServiceFfaGuid, sizeof (EFI_GUID));
 
   ZeroMem (&FfaConduitArgs, sizeof (FFA_CONDUIT_ARGS));
@@ -257,7 +265,7 @@ GetTpmServicePartitionId (
   mFfaTpm2PartitionId = TpmPartInfo->PartitionId;
   *PartitionId        = mFfaTpm2PartitionId;
 
-  Status = EFI_SUCCESS;
+  Status = PcdSet16S (PcdTpmServiceFfaPartitionId, mFfaTpm2PartitionId);
 
 Exit:
   return Status;


### PR DESCRIPTION
## Description

This change adds a PCD for FF-A TPM service.

The TPM library will be used to produce this PCD if the platform did not set it to non-zero.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This was tested on QEMU SBSA platform with Hafnium integrated.

## Integration Instructions

N/A
