### PR TITLE
[FF-A][TPM] Internal CRB Request Register Set to 0x2

### DIFF
--- a/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2Ptp.c
+++ b/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2Ptp.c
@@ -212,7 +212,7 @@ PtpCrbTpmCommand (
              0
              );
   if (EFI_ERROR (Status)) {
-    goto GoIdle_Exit;
+    goto Exit;
   }
 
   //
@@ -237,7 +237,7 @@ PtpCrbTpmCommand (
   if (SwapBytes16 (Data16) == TPM_ST_RSP_COMMAND) {
     DEBUG ((DEBUG_ERROR, "TPM2: TPM_ST_RSP error - %x\n", TPM_ST_RSP_COMMAND));
     Status = EFI_UNSUPPORTED;
-    goto GoIdle_Exit;
+    goto Exit;
   }
 
   CopyMem (&Data32, (BufferOut + 2), sizeof (UINT32));
@@ -247,7 +247,7 @@ PtpCrbTpmCommand (
     // Command completed, but buffer is not enough
     //
     Status = EFI_BUFFER_TOO_SMALL;
-    goto GoIdle_Exit;
+    goto Exit;
   }
 
   *SizeOut = TpmOutSize;
@@ -262,7 +262,7 @@ PtpCrbTpmCommand (
   DumpTpmOutputBlock (TpmOutSize, BufferOut);
   DEBUG_CODE_END ();
 
-GoIdle_Exit:
+Exit:
 
   return Status;
 }

--- a/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2Ptp.c
+++ b/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2Ptp.c
@@ -262,16 +262,7 @@ PtpCrbTpmCommand (
   DumpTpmOutputBlock (TpmOutSize, BufferOut);
   DEBUG_CODE_END ();
 
-  //
-  // Do not wait for state transition for TIMEOUT_C
-  // This function will try to wait 2 TIMEOUT_C at the beginning in next call.
-  //
 GoIdle_Exit:
-
-  //
-  //  Return to Idle state by setting TPM_CRB_CTRL_STS_x.Status.goIdle to 1.
-  //
-  MmioWrite32 ((UINTN)&CrbReg->CrbControlRequest, PTP_CRB_CONTROL_AREA_REQUEST_GO_IDLE);
 
   return Status;
 }


### PR DESCRIPTION
## Description

Fixed an issue where the FF-A library for the TPM was setting the internal CRB buffer request register to go idle. This will cause the register to remain with that bit set as the register only ever gets cleared when an FF-A command is sent to the TPM service.

Fixes: https://github.com/microsoft/mu_tiano_platforms/issues/1094

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Built and ran the TPM build.

## Integration Instructions

N/A
