### PR TITLE
[FF-A][TPM] CRB Response Buffer Size Overwrite

### DIFF
--- a/ArmPkg/Library/TpmServiceLib/TpmServiceLib.c
+++ b/ArmPkg/Library/TpmServiceLib/TpmServiceLib.c
@@ -32,9 +32,6 @@
 
 typedef UINTN TpmStatus;
 
-/* TPM Service Variables */
-UINT8  TpmCommandBuffer[0xF80]; // Value comes from TpmPtp.h -> CrbDataBuffer
-
 /**
   Converts the passed in EFI_STATUS to a TPM_STATUS
 
@@ -175,6 +172,7 @@ HandleCommand (
   InternalTpmCrb->CrbControlStatus = 0;
 
   /* Copy the command data to the static buffer */
+  UINT8   TpmCommandBuffer[sizeof (InternalTpmCrb->CrbDataBuffer)];
   UINT32  ResponseDataLen = InternalTpmCrb->CrbControlResponseSize;
   UINT32  CommandDataLen  = InternalTpmCrb->CrbControlCommandSize;
 

--- a/ArmPkg/Library/TpmServiceLib/TpmServiceLib.c
+++ b/ArmPkg/Library/TpmServiceLib/TpmServiceLib.c
@@ -26,11 +26,14 @@
 #define TPM_CTRL_START_MASK  (0x01)
 
 // Default Value - tpmEstablished
-#define TPM_LOC_STATE_DEFAULT     (0x01)
+#define TPM_LOC_STATE_DEFAULT  (0x01)
 // Default Value - CRB Interface Selected, Only Locality0 Supported
-#define TPM_INTERFACE_ID_DEFAULT  (0x4011) 
+#define TPM_INTERFACE_ID_DEFAULT  (0x4011)
 
 typedef UINTN TpmStatus;
+
+/* TPM Service Variables */
+UINT8  TpmCommandBuffer[0xF80]; // Value comes from TpmPtp.h -> CrbDataBuffer
 
 /**
   Converts the passed in EFI_STATUS to a TPM_STATUS
@@ -89,7 +92,7 @@ InitInternalCrb (
   DEBUG ((DEBUG_INFO, "PcdTpmInternalBaseAddress: %lx\n", PcdGet64 (PcdTpmInternalBaseAddress)));
   SetMem ((void *)InternalTpmCrb, sizeof (PTP_CRB_REGISTERS), 0x00);
   InternalTpmCrb->LocalityState = TPM_LOC_STATE_DEFAULT;
-  InternalTpmCrb->InterfaceId   = TPM_INTERFACE_ID_DEFAULT; 
+  InternalTpmCrb->InterfaceId   = TPM_INTERFACE_ID_DEFAULT;
 }
 
 /**
@@ -171,13 +174,22 @@ HandleCommand (
   /* Set the status to ready (i.e. not idle) */
   InternalTpmCrb->CrbControlStatus = 0;
 
+  /* Copy the command data to the static buffer */
+  UINT32  ResponseDataLen = InternalTpmCrb->CrbControlResponseSize;
+  UINT32  CommandDataLen  = InternalTpmCrb->CrbControlCommandSize;
+
+  CopyMem (TpmCommandBuffer, InternalTpmCrb->CrbDataBuffer, CommandDataLen);
+
   /* Submit the command to the TPM */
   EFI_STATUS  Status = Tpm2SubmitCommand (
-                         InternalTpmCrb->CrbControlCommandSize,
-                         InternalTpmCrb->CrbDataBuffer,
-                         &InternalTpmCrb->CrbControlResponseSize,
-                         InternalTpmCrb->CrbDataBuffer
+                         CommandDataLen,
+                         TpmCommandBuffer,
+                         &ResponseDataLen,
+                         TpmCommandBuffer
                          );
+
+  /* Copy the response data from the static buffer */
+  CopyMem (InternalTpmCrb->CrbDataBuffer, TpmCommandBuffer, ResponseDataLen);
 
   /* Clear the internal CRB start register to indicate successful completion and response ready */
   if (Status == EFI_SUCCESS) {


### PR DESCRIPTION
## Description

Updated the TPM service to use a local static buffer rather than the CRB buffer for transfers to the TPM. This was to resolve an issue where the CRB buffer response length was getting adjusted by the TPM library.

Fixes: https://github.com/microsoft/mu_tiano_platforms/issues/1093

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Ran the build with TPM enabled.

## Integration Instructions

N/A
