### PR TITLE
[FFA] Update the TPM over FF-A library to honor interface type PCD

### DIFF
--- a/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.c
+++ b/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.c
@@ -195,15 +195,18 @@ Tpm2DeviceLibFfaConstructor (
   }
 
   //
-  // Always cache current active TpmInterfaceType for StandaloneMm implementation
+  // Start by checking the PCD out of the gate and read from the CRB if it is invalid
   //
-  mActiveTpmInterfaceType = Tpm2GetPtpInterface ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+  if (PcdGet8 (PcdActiveTpmInterfaceType) == 0xFF) {
+    mActiveTpmInterfaceType = Tpm2GetPtpInterface ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+    PcdSet8S (PcdActiveTpmInterfaceType, mActiveTpmInterfaceType);
+  }
+
   if (mActiveTpmInterfaceType != Tpm2PtpInterfaceCrb) {
     Status = EFI_UNSUPPORTED;
     goto Exit;
   }
 
-  PcdSet8S (PcdActiveTpmInterfaceType, mActiveTpmInterfaceType);
   DEBUG ((DEBUG_INFO, "Setting Tpm Active Interface Type %d\n", mActiveTpmInterfaceType));
   mCRBIdleByPass = Tpm2GetIdleByPass ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
 

--- a/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.c
+++ b/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceLibFfa.c
@@ -180,7 +180,7 @@ Tpm2DeviceLibFfaConstructor (
 {
   EFI_STATUS  Status;
 
-  mActiveTpmInterfaceType = 0xFF;
+  mActiveTpmInterfaceType = PcdGet8 (PcdActiveTpmInterfaceType);
   mCRBIdleByPass          = 0xFF;
 
   // Check to see if the FF-A is actually supported.
@@ -197,7 +197,7 @@ Tpm2DeviceLibFfaConstructor (
   //
   // Start by checking the PCD out of the gate and read from the CRB if it is invalid
   //
-  if (PcdGet8 (PcdActiveTpmInterfaceType) == 0xFF) {
+  if (mActiveTpmInterfaceType == 0xFF) {
     mActiveTpmInterfaceType = Tpm2GetPtpInterface ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
     PcdSet8S (PcdActiveTpmInterfaceType, mActiveTpmInterfaceType);
   }


### PR DESCRIPTION
## Description

This change is made to ensure the consistent behavior between normal dTPM library and the TPM over FF-A library instance.

With the change, `PcdActiveTpmInterfaceType` will be checked first and bypass the interface querying through CRB reading and directly use the value.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This change is tested on a customized QEMU SBSA platform which supports the TPM backend.

## Integration Instructions

N/A
