### PR TITLE
[Cherry-pick][Rebase & FF] Fixes the Stmm without FF-A configuration

### DIFF
--- a/ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.c
+++ b/ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.c
@@ -68,5 +68,22 @@ ArmFfaStandaloneMmLibConstructor (
   IN EFI_MM_SYSTEM_TABLE  *MmSystemTable
   )
 {
-  return ArmFfaLibCommonInit ();
+  EFI_STATUS  Status;
+
+  Status = ArmFfaLibCommonInit ();
+  if (Status == EFI_UNSUPPORTED) {
+    /*
+     * EFI_UNSUPPORTED means FF-A interface isn't available.
+     * However, for Standalone MM modules, FF-A availability is not required.
+     * i.e. Standalone MM could use SpmMm as a legitimate protocol.
+     * Thus, returning EFI_SUCCESS here to avoid the entrypoint to assert.
+     */
+    return EFI_SUCCESS;
+  }
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a failed. Status = %r\n", __func__, Status));
+  }
+
+  return Status;
 }


### PR DESCRIPTION
## Description

The current constructor will return failure and cause the Standalone MM partition to assert if this is built with non-FFA supported platforms. Unsupported is expected and should be taken as an indication of going through normal SMC route.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This was tested on QEMU SBSA platform.

## Integration Instructions

N/A
