### PR TITLE
ArmPkg/ArmStandaloneMmCoreEntryPoint: Fix clang build issues

### DIFF
--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/AArch64/ModuleEntryPoint.S
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/AArch64/ModuleEntryPoint.S
@@ -55,7 +55,8 @@ ASM_FUNC(CheckFfaSupport)
 
   svc #0
 
-  MOV64 (x9, ARM_FFA_RET_NOT_SUPPORTED)
+  // Set x9 as ARM_FFA_RET_NOT_SUPPORTED (-1)   // MU_CHANGE - Fix clang build errors
+  mvn x9, xzr                                   // MU_CHANGE - Fix clang build errors
   cmp x0, x9
   cset x0, ne
   mov x9, xzr

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
@@ -1038,9 +1038,9 @@ CEntryPoint (
     goto finish;
   }
 
-  DEBUG ((DEBUG_INFO, "Start Dump Hob: %lx\n", (unsigned long)HobStart));
+  DEBUG ((DEBUG_INFO, "Start Dump Hob: %p\n", HobStart));   // MU_CHANGE - Fix clang build errors
   DumpPhitHob (HobStart);
-  DEBUG ((DEBUG_INFO, "End Dump Hob: %lx\n", (unsigned long)HobStart));
+  DEBUG ((DEBUG_INFO, "End Dump Hob: %p\n", HobStart));     // MU_CHANGE - Fix clang build errors
 
   FvHob = GetNextHob (EFI_HOB_TYPE_FV, HobStart);
   if (FvHob == NULL) {


### PR DESCRIPTION
## Description

Will upstream to edk2 but need here now to unblock updating QemuSbsaPkg.

---

**Issue 1:**

```
error: immediate must be an integer in range [0, 65535].
movz x9, (-1) >> 48, lsl #48
movk x9, ((-1) >> 32) & 0xffff, lsl #32
movk x9, ((-1) >> 16) & 0xffff, lsl #16
movk x9, (-1) & 0xffff
```

From this code in ModuleEntryPoint.S:

```
  MOV64 (x9, ARM_FFA_RET_NOT_SUPPORTED)
```

The change uses `xzr` with the `mvn` instruction to set the register to `-1`.

---

**Issue 2:**

Pointer cast issues such as:

```
ArmStandaloneMmCoreEntryPoint.c:1041:48: error: cast to smaller
  integer type 'unsigned long' from 'void *'
  [-Werror,-Wvoid-pointer-to-int-cast]

  1041 |   DEBUG ((DEBUG_INFO, "Start Dump Hob: %lx\n",
             (unsigned long)HobStart));
```

The `%p` specifer is now used to print the pointers.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- QemuSbsaPkg CLANGPDB build with the file present
  - `stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py TOOL_CHAIN_TAG=CLANGPDB TARGET=DEBUG`

## Integration Instructions

- N/A