### PR TITLE
[Rebase & FF] Extending FF-A definitions

### DIFF
--- a/ArmPkg/Include/IndustryStandard/ArmFfaSvc.h
+++ b/ArmPkg/Include/IndustryStandard/ArmFfaSvc.h
@@ -196,6 +196,8 @@
 #define ARM_FFA_SET_MEM_ATTR_CODE_PERM_X      0
 #define ARM_FFA_SET_MEM_ATTR_CODE_PERM_XN     1
 
+#define ARM_FFA_MEM_PERM_RESERVED_MASK 0xFFFFFFF8
+
 #define ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST(dataperm, codeperm)  \
     ((((codeperm) & ARM_FFA_SET_MEM_ATTR_CODE_PERM_MASK) <<         \
       ARM_FFA_SET_MEM_ATTR_CODE_PERM_SHIFT) |                       \
@@ -223,5 +225,26 @@
 
 #define IS_FID_FFA_ERROR(fid) \
   (fid == ARM_FID_FFA_ERROR)
+
+#define FFA_NOTIFICATIONS_FLAG_PER_VCPU (0x1 << 0)
+
+/** Flag to delay Schedule Receiver Interrupt. */
+#define FFA_NOTIFICATIONS_FLAG_DELAY_SRI    (0x1 << 1)
+
+#define FFA_NOTIFICATIONS_FLAGS_VCPU_ID(id) ((id & 0xFFFF) << 16)
+
+#define FFA_NOTIFICATIONS_FLAG_BITMAP_SP    (0x1 << 0)
+#define FFA_NOTIFICATIONS_FLAG_BITMAP_VM    (0x1 << 1)
+#define FFA_NOTIFICATIONS_FLAG_BITMAP_SPM   (0x1 << 2)
+#define FFA_NOTIFICATIONS_FLAG_BITMAP_HYP   (0x1 << 3)
+
+/** Query interrupt ID of Notification Pending Interrupt. */
+#define FFA_FEATURE_NPI 0x1U
+
+/** Query interrupt ID of Schedule Receiver Interrupt. */
+#define FFA_FEATURE_SRI 0x2U
+
+/** Query interrupt ID of the Managed Exit Interrupt. */
+#define FFA_FEATURE_MEI 0x3U
 
 #endif // ARM_FFA_SVC_H_


### PR DESCRIPTION
## Description

This change adds a minor extension to existing FF-A definitions. This will allow the UEFI to accept FF-A notification related operations.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This was tested on QEMU SBSA platform with a test application for FF-A notificaiton.

## Integration Instructions

N/A
