### PR TITLE
[Rebase & FF] Add 18 register support for SMC and SVC calls for AArch64 platforms

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -266,6 +266,14 @@
   #
   gArmTokenSpaceGuid.PcdUefiShellDefaultBootEnable|FALSE|BOOLEAN|0x0000052
 
+  # MU_CHANGE [BEGIN]
+  # Whether to use 18 registers for SMC/SVC calls. 0 is to use 8 registers to
+  # be backward compatible with existing legacy SPMC implementations. 1 is to
+  # use 18 registers to support the latest SPMC implementations, such as Hafnium,
+  # which has needs for FF-A v1.2+ capabilities.
+  gArmTokenSpaceGuid.PcdSxcUse18Registers|FALSE|BOOLEAN|0x0000004B
+  # MU_CHANGE [END]
+
 [PcdsFixedAtBuild.common, PcdsPatchableInModule.common]
   gArmTokenSpaceGuid.PcdFdBaseAddress|0|UINT64|0x0000002B
   gArmTokenSpaceGuid.PcdFvBaseAddress|0|UINT64|0x0000002D

--- a/ArmPkg/Include/Library/ArmFfaLib.h
+++ b/ArmPkg/Include/Library/ArmFfaLib.h
@@ -42,8 +42,37 @@ typedef struct DirectMsgArgs {
   /// Implementation define argument 3, this will be set to/from x6(v1) or x7(v2)
   UINTN    Arg3;
 
-  /// Implementation define argument 4, this will be set to/from x7(v1) or ignored (v2)
+  /// Implementation define argument 4, this will be set to/from x7(v1) or x8(v2)
   UINTN    Arg4;
+
+  // MU_CHANGE Starts: Add implementation define arguments 5-13
+  /// Implementation define argument 5, this will be set to/from x9(v2)
+  UINTN    Arg5;
+
+  /// Implementation define argument 6, this will be set to/from x10(v2)
+  UINTN    Arg6;
+
+  /// Implementation define argument 7, this will be set to/from x11(v2)
+  UINTN    Arg7;
+
+  /// Implementation define argument 8, this will be set to/from x12(v2)
+  UINTN    Arg8;
+
+  /// Implementation define argument 9, this will be set to/from x13(v2)
+  UINTN    Arg9;
+
+  /// Implementation define argument 10, this will be set to/from x14(v2)
+  UINTN    Arg10;
+
+  /// Implementation define argument 11, this will be set to/from x15(v2)
+  UINTN    Arg11;
+
+  /// Implementation define argument 12, this will be set to/from x16(v2)
+  UINTN    Arg12;
+
+  /// Implementation define argument 13, this will be set to/from x17(v2)
+  UINTN    Arg13;
+  // MU_CHANGE Ends
 } DIRECT_MSG_ARGS;
 
 /**

--- a/ArmPkg/Include/Library/ArmSmcLib.h
+++ b/ArmPkg/Include/Library/ArmSmcLib.h
@@ -23,6 +23,18 @@ typedef struct {
   UINTN    Arg5;
   UINTN    Arg6;
   UINTN    Arg7;
+  // MU_CHANGE Starts: Support 18 arguments for AArch64
+  UINTN    Arg8;
+  UINTN    Arg9;
+  UINTN    Arg10;
+  UINTN    Arg11;
+  UINTN    Arg12;
+  UINTN    Arg13;
+  UINTN    Arg14;
+  UINTN    Arg15;
+  UINTN    Arg16;
+  UINTN    Arg17;
+  // MU_CHANGE Ends
 } ARM_SMC_ARGS;
 
 /**

--- a/ArmPkg/Include/Library/ArmSvcLib.h
+++ b/ArmPkg/Include/Library/ArmSvcLib.h
@@ -22,6 +22,18 @@ typedef struct {
   UINTN    Arg5;
   UINTN    Arg6;
   UINTN    Arg7;
+  // MU_CHANGE Starts: Support 18 arguments for AArch64
+  UINTN    Arg8;
+  UINTN    Arg9;
+  UINTN    Arg10;
+  UINTN    Arg11;
+  UINTN    Arg12;
+  UINTN    Arg13;
+  UINTN    Arg14;
+  UINTN    Arg15;
+  UINTN    Arg16;
+  UINTN    Arg17;
+  // MU_CHANGE Ends
 } ARM_SVC_ARGS;
 
 /**

--- a/ArmPkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/ArmPkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -712,6 +712,20 @@ ArmFfaLibMsgSendDirectReq2 (
   FfaArgs.Arg5 = ImpDefArgs->Arg1;
   FfaArgs.Arg6 = ImpDefArgs->Arg2;
   FfaArgs.Arg7 = ImpDefArgs->Arg3;
+  // MU_CHANGE Starts: Add implementation define arguments 5-13
+  if (FixedPcdGetBool (PcdSxcUse18Registers)) {
+    FfaArgs.Arg8  = ImpDefArgs->Arg4;
+    FfaArgs.Arg9  = ImpDefArgs->Arg5;
+    FfaArgs.Arg10 = ImpDefArgs->Arg6;
+    FfaArgs.Arg11 = ImpDefArgs->Arg7;
+    FfaArgs.Arg12 = ImpDefArgs->Arg8;
+    FfaArgs.Arg13 = ImpDefArgs->Arg9;
+    FfaArgs.Arg14 = ImpDefArgs->Arg10;
+    FfaArgs.Arg15 = ImpDefArgs->Arg11;
+    FfaArgs.Arg16 = ImpDefArgs->Arg12;
+    FfaArgs.Arg17 = ImpDefArgs->Arg13;
+  }
+  // MU_CHANGE Ends
 
   ArmCallFfa (&FfaArgs);
 
@@ -724,6 +738,20 @@ ArmFfaLibMsgSendDirectReq2 (
   ImpDefArgs->Arg1 = FfaArgs.Arg5;
   ImpDefArgs->Arg2 = FfaArgs.Arg6;
   ImpDefArgs->Arg3 = FfaArgs.Arg7;
+  // MU_CHANGE Starts: Add implementation define arguments 5-13
+  if (FixedPcdGetBool (PcdSxcUse18Registers)) {
+    ImpDefArgs->Arg4  = FfaArgs.Arg8;
+    ImpDefArgs->Arg5  = FfaArgs.Arg9;
+    ImpDefArgs->Arg6  = FfaArgs.Arg10;
+    ImpDefArgs->Arg7  = FfaArgs.Arg11;
+    ImpDefArgs->Arg8  = FfaArgs.Arg12;
+    ImpDefArgs->Arg9  = FfaArgs.Arg13;
+    ImpDefArgs->Arg10 = FfaArgs.Arg14;
+    ImpDefArgs->Arg11 = FfaArgs.Arg15;
+    ImpDefArgs->Arg12 = FfaArgs.Arg16;
+    ImpDefArgs->Arg13 = FfaArgs.Arg17;
+  }
+  // MU_CHANGE Ends
 
   return EFI_SUCCESS;
 }

--- a/ArmPkg/Library/ArmFfaLib/ArmFfaCommon.h
+++ b/ArmPkg/Library/ArmFfaLib/ArmFfaCommon.h
@@ -29,6 +29,18 @@ typedef struct ArmFfaArgs {
   UINTN    Arg5;
   UINTN    Arg6;
   UINTN    Arg7;
+  // MU_CHANGE Starts: Add implementation define arguments 5-13
+  UINTN    Arg8;
+  UINTN    Arg9;
+  UINTN    Arg10;
+  UINTN    Arg11;
+  UINTN    Arg12;
+  UINTN    Arg13;
+  UINTN    Arg14;
+  UINTN    Arg15;
+  UINTN    Arg16;
+  UINTN    Arg17;
+  // MU_CHANGE Ends
 } ARM_FFA_ARGS;
 
 extern BOOLEAN  gFfaSupported;

--- a/ArmPkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
+++ b/ArmPkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
@@ -41,6 +41,9 @@
   gArmTokenSpaceGuid.PcdFfaTxRxPageCount
   gArmTokenSpaceGuid.PcdFfaExitBootEventRegistered
 
+[FixedPcd]
+  gArmTokenSpaceGuid.PcdSxcUse18Registers # MU_CHANGE: Add 18 registers support
+
 [Guids]
   gArmFfaRxTxBufferInfoGuid
   gEfiEventExitBootServicesGuid

--- a/ArmPkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
+++ b/ArmPkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
@@ -41,5 +41,8 @@
   gArmTokenSpaceGuid.PcdFfaTxRxPageCount
   gArmTokenSpaceGuid.PcdFfaExitBootEventRegistered
 
+[FixedPcd]
+  gArmTokenSpaceGuid.PcdSxcUse18Registers # MU_CHANGE: Add 18 registers support
+
 [Guids]
   gArmFfaRxTxBufferInfoGuid

--- a/ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+++ b/ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
@@ -34,3 +34,6 @@
 
 [Pcd]
   gArmTokenSpaceGuid.PcdFfaLibConduitSmc
+
+[FixedPcd]
+  gArmTokenSpaceGuid.PcdSxcUse18Registers # MU_CHANGE: Add 18 registers support

--- a/ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+++ b/ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
@@ -35,3 +35,5 @@
 [Pcd]
   gArmTokenSpaceGuid.PcdFfaLibConduitSmc
 
+[FixedPcd]
+  gArmTokenSpaceGuid.PcdSxcUse18Registers # MU_CHANGE: Add 18 registers support

--- a/ArmPkg/Library/ArmSmcLib/AArch64/ArmSmc.S
+++ b/ArmPkg/Library/ArmSmcLib/AArch64/ArmSmc.S
@@ -8,10 +8,23 @@
 #include <AsmMacroIoLibV8.h>
 
 ASM_FUNC(ArmCallSmc)
-  // Push x0 on the stack - The stack must always be quad-word aligned
+  // Push x0 and x19 on the stack - The stack must always be quad-word aligned
+  // MU_CHANGE: Support 18 arguments for AArch64
+  str   x19, [sp, #-16]!
   str   x0, [sp, #-16]!
 
   // Load the SMC arguments values into the appropriate registers
+  // MU_CHANGE Starts: Support 18 arguments for AArch64
+  mov   x19, FixedPcdGetBool (PcdSxcUse18Registers)
+  cmp   x19, #0
+  beq   1f
+  ldp   x16, x17, [x0, #128]
+  ldp   x14, x15, [x0, #112]
+  ldp   x12, x13, [x0, #96]
+  ldp   x10, x11, [x0, #80]
+  ldp   x8, x9, [x0, #64]
+1:
+  // MU_CHANGE Ends
   ldp   x6, x7, [x0, #48]
   ldp   x4, x5, [x0, #32]
   ldp   x2, x3, [x0, #16]
@@ -19,14 +32,36 @@ ASM_FUNC(ArmCallSmc)
 
   smc   #0
 
-  // Pop the ARM_SMC_ARGS structure address from the stack into x9
-  ldr   x9, [sp], #16
+  // MU_CHANGE Starts: Support 18 arguments for AArch64
+  // Check if we need to use 18 registers
+  cmp   x19, #0
+  beq   2f
+
+  // Pop the ARM_SMC_ARGS structure address from the stack into x19
+  ldr   x19, [sp], #16
 
   // Store the SMC returned values into the ARM_SMC_ARGS structure.
-  // A SMC call can return up to 4 values - we do not need to store back x4-x7.
-  stp   x2, x3, [x9, #16]
-  stp   x0, x1, [x9, #0]
+  // A SMC call can return up to 18 values.
+  stp   x16, x17, [x19, #128]
+  stp   x14, x15, [x19, #112]
+  stp   x12, x13, [x19, #96]
+  stp   x10, x11, [x19, #80]
+  stp   x8, x9, [x19, #64]
+  b     3f
+2:
+  // Pop the ARM_SMC_ARGS structure address from the stack into x19
+  ldr   x19, [sp], #16
 
-  mov   x0, x9
+3:
+  // Store the lower 8 values.
+  // MU_CHANGE Ends
+  stp   x6, x7, [x19, #48]
+  stp   x4, x5, [x19, #32]
+  stp   x2, x3, [x19, #16]
+  stp   x0, x1, [x19, #0]
+
+  mov   x0, x19
+
+  ldr   x19, [sp], #16
 
   ret

--- a/ArmPkg/Library/ArmSmcLib/ArmSmcLib.inf
+++ b/ArmPkg/Library/ArmSmcLib/ArmSmcLib.inf
@@ -23,6 +23,9 @@
 [Sources]
   ArmSmc.c
 
+[FixedPcd]
+  gArmTokenSpaceGuid.PcdSxcUse18Registers # MU_CHANGE - 18 registers
+
 [Packages]
   MdePkg/MdePkg.dec
   ArmPkg/ArmPkg.dec

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
@@ -730,6 +730,20 @@ SetEventCompleteSvcArgs (
           EventCompleteSvcArgs->Arg5 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg1;
           EventCompleteSvcArgs->Arg6 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg2;
           EventCompleteSvcArgs->Arg7 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg3;
+          // MU_CHANGE Starts: Add 18 register support
+          if (FixedPcdGetBool (PcdSxcUse18Registers)) {
+            EventCompleteSvcArgs->Arg8  = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg4;
+            EventCompleteSvcArgs->Arg9  = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg5;
+            EventCompleteSvcArgs->Arg10 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg6;
+            EventCompleteSvcArgs->Arg11 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg7;
+            EventCompleteSvcArgs->Arg12 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg8;
+            EventCompleteSvcArgs->Arg13 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg9;
+            EventCompleteSvcArgs->Arg14 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg10;
+            EventCompleteSvcArgs->Arg15 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg11;
+            EventCompleteSvcArgs->Arg16 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg12;
+            EventCompleteSvcArgs->Arg17 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg13;
+          }
+          // MU_CHANGE Ends
         }
       }
 
@@ -772,6 +786,21 @@ InitializeMiscMmCommunicateBuffer (
   Buffer->DirectMsgArgs.Arg1 = EventSvcArgs->Arg5;
   Buffer->DirectMsgArgs.Arg2 = EventSvcArgs->Arg6;
   Buffer->DirectMsgArgs.Arg3 = EventSvcArgs->Arg7;
+  // MU_CHANGE Starts: Add 18 register support
+  if (FixedPcdGetBool (PcdSxcUse18Registers)) {
+    Buffer->DirectMsgArgs.Arg4  = EventSvcArgs->Arg8;
+    Buffer->DirectMsgArgs.Arg5  = EventSvcArgs->Arg9;
+    Buffer->DirectMsgArgs.Arg6  = EventSvcArgs->Arg10;
+    Buffer->DirectMsgArgs.Arg7  = EventSvcArgs->Arg11;
+    Buffer->DirectMsgArgs.Arg8  = EventSvcArgs->Arg12;
+    Buffer->DirectMsgArgs.Arg9  = EventSvcArgs->Arg13;
+    Buffer->DirectMsgArgs.Arg10 = EventSvcArgs->Arg14;
+    Buffer->DirectMsgArgs.Arg11 = EventSvcArgs->Arg15;
+    Buffer->DirectMsgArgs.Arg12 = EventSvcArgs->Arg16;
+    Buffer->DirectMsgArgs.Arg13 = EventSvcArgs->Arg17;
+  }
+  // MU_CHANGE Ends
+
   CopyGuid (&Buffer->HeaderGuid, ServiceGuid);
 }
 

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
@@ -64,6 +64,9 @@
 [Pcd]
   gArmTokenSpaceGuid.PcdStMmStackSize
 
+[FixedPcd]
+  gArmTokenSpaceGuid.PcdSxcUse18Registers # MU_CHANGE: Add 18 registers support
+
 #
 # This configuration fails for CLANGPDB, which does not support PIE in the GCC
 # sense. Such however is required for ARM family StandaloneMmCore

--- a/ArmPkg/Library/ArmSvcLib/AArch64/ArmSvc.S
+++ b/ArmPkg/Library/ArmSvcLib/AArch64/ArmSvc.S
@@ -12,13 +12,26 @@
 
 ASM_FUNC(ArmCallSvc)
   // Push frame pointer and return address on the stack
-  stp   x29, x30, [sp, #-32]!
+  // MU_CHANGE: Support 18 arguments for AArch64
+  stp   x29, x30, [sp, #-48]!
   mov   x29, sp
 
-  // Push x0 on the stack - The stack must always be quad-word aligned
-  str   x0, [sp, #16]
+  // Push x0 and x19 on the stack - The stack must always be quad-word aligned
+  str   x19, [sp, #16]
+  str   x0, [sp, #32]
 
   // Load the SVC arguments values into the appropriate registers
+  // MU_CHANGE Starts: Support 18 arguments for AArch64
+  mov   x19, FixedPcdGetBool (PcdSxcUse18Registers)
+  cmp   x19, #0
+  beq   1f
+  ldp   x16, x17, [x0, #128]
+  ldp   x14, x15, [x0, #112]
+  ldp   x12, x13, [x0, #96]
+  ldp   x10, x11, [x0, #80]
+  ldp   x8, x9, [x0, #64]
+1:
+  // MU_CHANGE Ends
   ldp   x6, x7, [x0, #48]
   ldp   x4, x5, [x0, #32]
   ldp   x2, x3, [x0, #16]
@@ -29,17 +42,36 @@ ASM_FUNC(ArmCallSvc)
   dsb   nsh
   isb
 
-  // Pop the ARM_SVC_ARGS structure address from the stack into x9
-  ldr   x9, [sp, #16]
+  // MU_CHANGE Starts: Support 18 arguments for AArch64
+  // Check if we need to use 18 registers
+  cmp   x19, #0
+  beq   2f
+
+  // Pop the ARM_SVC_ARGS structure address from the stack into x19
+  ldr   x19, [sp, #32]
 
   // Store the SVC returned values into the ARM_SVC_ARGS structure.
-  // A SVC call can return up to 8 values
-  stp   x0, x1, [x9, #0]
-  stp   x2, x3, [x9, #16]
-  stp   x4, x5, [x9, #32]
-  stp   x6, x7, [x9, #48]
+  // A SVC call can return up to 18 values
+  stp   x16, x17, [x19, #128]
+  stp   x14, x15, [x19, #112]
+  stp   x12, x13, [x19, #96]
+  stp   x10, x11, [x19, #80]
+  stp   x8, x9, [x19, #64]
+  b     3f
+2:
+  // Pop the ARM_SVC_ARGS structure address from the stack into x19
+  ldr   x19, [sp, #32]
 
-  mov   x0, x9
+3:
+  // MU_CHANGE Ends
+  stp   x6, x7, [x19, #48]
+  stp   x4, x5, [x19, #32]
+  stp   x2, x3, [x19, #16]
+  stp   x0, x1, [x19, #0]
 
-  ldp   x29, x30, [sp], #32
+  mov   x0, x19
+
+  ldr   x19, [sp, #16]
+
+  ldp   x29, x30, [sp], #48
   ret

--- a/ArmPkg/Library/ArmSvcLib/ArmSvcLib.inf
+++ b/ArmPkg/Library/ArmSvcLib/ArmSvcLib.inf
@@ -19,6 +19,9 @@
 [Sources.AARCH64]
   AArch64/ArmSvc.S
 
+[FixedPcd]
+  gArmTokenSpaceGuid.PcdSxcUse18Registers # MU_CHANGE - 18 registers
+
 [Packages]
   ArmPkg/ArmPkg.dec
   MdePkg/MdePkg.dec


### PR DESCRIPTION
## Description

Current SMC and SVC only supports up to 8 registers.

However, the FF-A spec has definition for FFA direct request 2 which could use up to 18 registers.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This was tested on proprietary hardware and QEMU SBSA virtual platform.

## Integration Instructions

For platforms needing to use 18-registers, add `gArmTokenSpaceGuid.PcdSxcUse18Registers|TRUE` to the platform build dsc file.
