### PR TITLE
[FF-A][TPM] Remove Setting CRB Command/Response Registers

### DIFF
--- a/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2Ptp.c
+++ b/ArmPkg/Library/Tpm2DeviceLibFfa/Tpm2Ptp.c
@@ -203,13 +203,6 @@ PtpCrbTpmCommand (
     MmioWrite8 ((UINTN)&CrbReg->CrbDataBuffer[Index], BufferIn[Index]);
   }
 
-  MmioWrite32 ((UINTN)&CrbReg->CrbControlCommandAddressHigh, (UINT32)RShiftU64 ((UINTN)CrbReg->CrbDataBuffer, 32));
-  MmioWrite32 ((UINTN)&CrbReg->CrbControlCommandAddressLow, (UINT32)(UINTN)CrbReg->CrbDataBuffer);
-  MmioWrite32 ((UINTN)&CrbReg->CrbControlCommandSize, sizeof (CrbReg->CrbDataBuffer));
-
-  MmioWrite64 ((UINTN)&CrbReg->CrbControlResponseAddrss, (UINTN)CrbReg->CrbDataBuffer);
-  MmioWrite32 ((UINTN)&CrbReg->CrbControlResponseSize, sizeof (CrbReg->CrbDataBuffer));
-
   //
   // STEP 2:
   // Command Execution occurs after receipt of a 1 to Start and the TPM


### PR DESCRIPTION
## Description

Removed setting the CRB command and response buffer address and size registers. This is not required. The TPM service will be in charge of setting these registers to a default value similar to what a normal TPM would.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Verified by enabling TPM support in the QEMU SBSA build.

## Integration Instructions

N/A
