### PR TITLE
[SQUASH ON REBASE] SmmuDxe updates and bug fixes

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -56,14 +56,12 @@ UpdateFlags (
   IN UINT32      Index
   )
 {
-  EFI_STATUS  Status;
-  UINT64      Entry;
+  UINT64  Entry;
 
   if ((Table == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (Index >= PAGE_TABLE_SIZE)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter.\n", __func__));
-    Status = EFI_INVALID_PARAMETER;
-    ASSERT_EFI_ERROR (Status);
-    return Status;
+    ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
+    return EFI_INVALID_PARAMETER;
   }
 
   // Allows clearing the R/W bits without affecting the other bits in the entry.
@@ -266,7 +264,6 @@ IoMmuMap (
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  PhysicalAddress;
   IOMMU_MAP_INFO        *MapInfo;
-  SMMUV3_CMD_GENERIC    Command;
 
   if ((This == NULL) ||
       (HostAddress == NULL) ||
@@ -288,30 +285,11 @@ IoMmuMap (
   }
 
   // Invalidate TLBI Command
-  SMMUV3_BUILD_CMD_TLBI_NSNH_ALL (&Command);
-  Status = SmmuV3SendCommand (mSmmu, &Command);
+  Status = SmmuV3TLBInvalidateAll (mSmmu);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_NSNH_ALL failed.\n", __func__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
     goto Error;
   }
-
-  SMMUV3_BUILD_CMD_TLBI_EL2_ALL (&Command);
-  Status = SmmuV3SendCommand (mSmmu, &Command);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_EL2_ALL failed.\n", __func__));
-    goto Error;
-  }
-
-  // Issue a CMD_SYNC command to guarantee that any previously issued TLB
-  // invalidations (CMD_TLBI_*) are completed (SMMUv3.2 spec section 4.6.3).
-  SMMUV3_BUILD_CMD_SYNC_NO_INTERRUPT (&Command);
-  Status = SmmuV3SendCommand (mSmmu, &Command);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_SYNC_NO_INTERRUPT failed.\n", __func__));
-    goto Error;
-  }
-
-  ArmDataSynchronizationBarrier ();
 
   // Allocate and fill the IOMMU_MAP_INFO structure with mapped information
   *DeviceAddress = PhysicalAddress; // Identity mapping
@@ -350,9 +328,8 @@ IoMmuUnmap (
   IN  VOID                  *Mapping
   )
 {
-  EFI_STATUS          Status;
-  SMMUV3_CMD_GENERIC  Command;
-  IOMMU_MAP_INFO      *MapInfo;
+  EFI_STATUS      Status;
+  IOMMU_MAP_INFO  *MapInfo;
 
   if ((This == NULL) || (Mapping == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
@@ -369,30 +346,11 @@ IoMmuUnmap (
   }
 
   // Invalidate TLBI Command
-  SMMUV3_BUILD_CMD_TLBI_NSNH_ALL (&Command);
-  Status = SmmuV3SendCommand (mSmmu, &Command);
+  Status = SmmuV3TLBInvalidateAll (mSmmu);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_NSNH_ALL failed.\n", __func__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
     goto Error;
   }
-
-  SMMUV3_BUILD_CMD_TLBI_EL2_ALL (&Command);
-  Status = SmmuV3SendCommand (mSmmu, &Command);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_EL2_ALL failed.\n", __func__));
-    goto Error;
-  }
-
-  // Issue a CMD_SYNC command to guarantee that any previously issued TLB
-  // invalidations (CMD_TLBI_*) are completed (SMMUv3.2 spec section 4.6.3).
-  SMMUV3_BUILD_CMD_SYNC_NO_INTERRUPT (&Command);
-  Status = SmmuV3SendCommand (mSmmu, &Command);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_SYNC_NO_INTERRUPT failed.\n", __func__));
-    goto Error;
-  }
-
-  ArmDataSynchronizationBarrier ();
 
   // Free the mapping structure allocated in IoMmuMap
   if (MapInfo != NULL) {
@@ -530,9 +488,8 @@ IoMmuSetAttribute (
   IN UINT64                IoMmuAccess
   )
 {
-  EFI_STATUS          Status;
-  IOMMU_MAP_INFO      *MapInfo;
-  SMMUV3_CMD_GENERIC  Command;
+  EFI_STATUS      Status;
+  IOMMU_MAP_INFO  *MapInfo;
 
   if ((This == NULL) || (Mapping == NULL) || ((IoMmuAccess & ~(EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)) != 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
@@ -556,30 +513,11 @@ IoMmuSetAttribute (
   }
 
   // Invalidate TLBI Command
-  SMMUV3_BUILD_CMD_TLBI_NSNH_ALL (&Command);
-  Status = SmmuV3SendCommand (mSmmu, &Command);
+  Status = SmmuV3TLBInvalidateAll (mSmmu);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_NSNH_ALL failed.\n", __func__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
     goto Error;
   }
-
-  SMMUV3_BUILD_CMD_TLBI_EL2_ALL (&Command);
-  Status = SmmuV3SendCommand (mSmmu, &Command);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_EL2_ALL failed.\n", __func__));
-    goto Error;
-  }
-
-  // Issue a CMD_SYNC command to guarantee that any previously issued TLB
-  // invalidations (CMD_TLBI_*) are completed (SMMUv3.2 spec section 4.6.3).
-  SMMUV3_BUILD_CMD_SYNC_NO_INTERRUPT (&Command);
-  Status = SmmuV3SendCommand (mSmmu, &Command);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_SYNC_NO_INTERRUPT failed.\n", __func__));
-    goto Error;
-  }
-
-  ArmDataSynchronizationBarrier ();
 
   // Only prints errors if Event Queue is not empty and GError != 0
   SmmuV3LogErrors (mSmmu);

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -14,7 +14,6 @@
 #include <Library/ArmLib.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/CacheMaintenanceLib.h>
 #include <Library/DebugLib.h>
 #include <Library/IoLib.h>
 #include <Library/MemoryAllocationLib.h>
@@ -36,10 +35,10 @@ typedef struct IOMMU_MAP_INFO {
 } IOMMU_MAP_INFO;
 
 /**
-  Update the flags of a page table entry per Arm Architecture Reference Manual for A profile.
+  Update the RW flags of a page table entry per Arm Architecture Reference Manual for A profile.
   <https://developer.arm.com/documentation/102105/ka-07>
 
-  The bottom 12 bits of a PAGE_TABLE_ENTRY, such as R/W, Access Flags, Valid flags, can be set or cleared. Only allows clearing of R/W bits
+  The bottom 12 bits of a PAGE_TABLE_ENTRY, such as R/W. Only allows setting/clearing of R/W bits
 
   @param [in]  Table                  Pointer to the page table.
   @param [in]  Flags                  Flags such as Read/Write Flags to set or clear. Only allows clearing of R/W bits. 12 bits or less.
@@ -50,7 +49,7 @@ typedef struct IOMMU_MAP_INFO {
 **/
 STATIC
 EFI_STATUS
-UpdateFlags (
+UpdateReadWriteFlags (
   IN PAGE_TABLE  *Table,
   IN UINT16      Flags,
   IN UINT32      Index
@@ -58,21 +57,18 @@ UpdateFlags (
 {
   UINT64  Entry;
 
-  if ((Table == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (Index >= PAGE_TABLE_SIZE)) {
+  if ((Table == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (Index >= PAGE_TABLE_SIZE) ||
+      ((Flags & ~(PAGE_TABLE_READ_BIT | PAGE_TABLE_WRITE_BIT)) != 0))
+  {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter.\n", __func__));
     ASSERT_EFI_ERROR (EFI_INVALID_PARAMETER);
     return EFI_INVALID_PARAMETER;
   }
 
   // Allows clearing the R/W bits without affecting the other bits in the entry.
-  if (Flags != 0) {
-    // Set R/W bits in page table entry
-    Entry = Table->Entries[Index] | Flags;
-  } else {
-    // Clear R/W bits in page table entry
-    Entry = Table->Entries[Index] & ~(PAGE_TABLE_READ_BIT | PAGE_TABLE_WRITE_BIT);
-  }
-
+  Entry = Table->Entries[Index] & ~(PAGE_TABLE_READ_BIT | PAGE_TABLE_WRITE_BIT);
+  // Set R/W bits in page table entry
+  Entry                |= Flags;
   Table->Entries[Index] = Entry;
 
   return EFI_SUCCESS;
@@ -136,7 +132,6 @@ UpdateMapping (
       }
 
       ZeroMem ((VOID *)NewPage, EFI_PAGE_SIZE);
-      WriteBackInvalidateDataCacheRange (NewPage, EFI_PAGE_SIZE);
 
       Entry                   = (PAGE_TABLE_ENTRY)(UINTN)NewPage | PAGE_TABLE_ACCESS_FLAG | PAGE_TABLE_DESCRIPTOR | PAGE_TABLE_ENTRY_VALID_BIT;
       Current->Entries[Index] = Entry; // valid entry
@@ -160,11 +155,10 @@ UpdateMapping (
         Entry                  |= PAGE_TABLE_ACCESS_FLAG | PAGE_TABLE_DESCRIPTOR | PAGE_TABLE_ENTRY_VALID_BIT;
         Current->Entries[Index] =  Entry;
       } else {
-        Entry                   = Current->Entries[Index] & ~PAGE_TABLE_ENTRY_VALID_BIT; // invalidate entry
-        Current->Entries[Index] = Entry;                                                 // only invalidate leaf entry
+        Current->Entries[Index] = Current->Entries[Index] & ~PAGE_TABLE_ENTRY_VALID_BIT; // only invalidate leaf entry
       }
     } else {
-      Status = UpdateFlags (Current, Flags, Index);
+      Status = UpdateReadWriteFlags (Current, Flags, Index);
       if (EFI_ERROR (Status)) {
         goto Error;
       }
@@ -228,6 +222,13 @@ UpdatePageTable (
     CurPhysicalAddress += EFI_PAGE_SIZE;
   }
 
+  // Invalidate TLBI Command
+  Status = SmmuV3TLBInvalidateAll (mSmmu);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
+    goto Error;
+  }
+
   return Status;
 
 Error:
@@ -284,13 +285,6 @@ IoMmuMap (
     goto Error;
   }
 
-  // Invalidate TLBI Command
-  Status = SmmuV3TLBInvalidateAll (mSmmu);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
-    goto Error;
-  }
-
   // Allocate and fill the IOMMU_MAP_INFO structure with mapped information
   *DeviceAddress = PhysicalAddress; // Identity mapping
 
@@ -342,13 +336,6 @@ IoMmuUnmap (
   Status = UpdatePageTable (mSmmu->PageTableRoot, MapInfo->PhysicalAddress, MapInfo->NumberOfBytes, 0, FALSE, FALSE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to update page table.\n", __func__));
-    goto Error;
-  }
-
-  // Invalidate TLBI Command
-  Status = SmmuV3TLBInvalidateAll (mSmmu);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
     goto Error;
   }
 
@@ -509,13 +496,6 @@ IoMmuSetAttribute (
              );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to update page table.\n", __func__));
-    goto Error;
-  }
-
-  // Invalidate TLBI Command
-  Status = SmmuV3TLBInvalidateAll (mSmmu);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
     goto Error;
   }
 

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -12,7 +12,9 @@
 
 #include <Uefi.h>
 #include <Library/ArmLib.h>
+#include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/CacheMaintenanceLib.h>
 #include <Library/DebugLib.h>
 #include <Library/IoLib.h>
 #include <Library/MemoryAllocationLib.h>
@@ -40,7 +42,6 @@ typedef struct IOMMU_MAP_INFO {
   The bottom 12 bits of a PAGE_TABLE_ENTRY, such as R/W, Access Flags, Valid flags, can be set or cleared. Only allows clearing of R/W bits
 
   @param [in]  Table                  Pointer to the page table.
-  @param [in]  SetReadWriteFlagsOnly  Boolean to indicate if only R/W flags should be set.
   @param [in]  Flags                  Flags such as Read/Write Flags to set or clear. Only allows clearing of R/W bits. 12 bits or less.
   @param [in]  Index                  Index of the entry to update. <= PAGE_TABLE_SIZE
 
@@ -51,12 +52,12 @@ STATIC
 EFI_STATUS
 UpdateFlags (
   IN PAGE_TABLE  *Table,
-  IN BOOLEAN     SetReadWriteFlagsOnly,
   IN UINT16      Flags,
   IN UINT32      Index
   )
 {
   EFI_STATUS  Status;
+  UINT64      Entry;
 
   if ((Table == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (Index >= PAGE_TABLE_SIZE)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter.\n", __func__));
@@ -65,24 +66,18 @@ UpdateFlags (
     return Status;
   }
 
-  Status = EFI_SUCCESS;
-
-  // This boolean is used to explicity update the R/W bits in the page table entry.
   // Allows clearing the R/W bits without affecting the other bits in the entry.
-  if (SetReadWriteFlagsOnly) {
-    if (Flags != 0) {
-      // Set R/W bits in page table entry
-      Table->Entries[Index] |= Flags;
-    } else {
-      // Clear R/W bits in page table entry
-      Table->Entries[Index] &= ~(PAGE_TABLE_READ_BIT | PAGE_TABLE_WRITE_BIT);
-    }
-  } else {
+  if (Flags != 0) {
     // Set R/W bits in page table entry
-    Table->Entries[Index] |= Flags;
+    Entry = Table->Entries[Index] | Flags;
+  } else {
+    // Clear R/W bits in page table entry
+    Entry = Table->Entries[Index] & ~(PAGE_TABLE_READ_BIT | PAGE_TABLE_WRITE_BIT);
   }
 
-  return Status;
+  Table->Entries[Index] = Entry;
+
+  return EFI_SUCCESS;
 }
 
 /**
@@ -119,6 +114,7 @@ UpdateMapping (
   UINT8       Level;
   UINT32      Index;
   PAGE_TABLE  *Current;
+  UINT64      Entry;
 
   // Flags must be 12 bits or less
   if ((Root == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (PhysicalAddress == 0)) {
@@ -130,7 +126,7 @@ UpdateMapping (
   Current = Root;
 
   // Traverse the page table to the leaf level
-  for (Level = 0; Level < PAGE_TABLE_DEPTH - 1; Level++) {
+  for (Level = mSmmu->TranslationStartingLevel; Level < PAGE_TABLE_DEPTH - 1; Level++) {
     Index = PAGE_TABLE_INDEX (VirtualAddress, Level);
 
     if (Current->Entries[Index] == 0) {
@@ -142,19 +138,10 @@ UpdateMapping (
       }
 
       ZeroMem ((VOID *)NewPage, EFI_PAGE_SIZE);
+      WriteBackInvalidateDataCacheRange (NewPage, EFI_PAGE_SIZE);
 
-      Current->Entries[Index] = (PAGE_TABLE_ENTRY)(UINTN)NewPage;
-    }
-
-    if (!SetReadWriteFlagsOnly) {
-      if (Valid) {
-        Current->Entries[Index] |= PAGE_TABLE_ENTRY_VALID_BIT; // valid entry
-      }
-    }
-
-    Status = UpdateFlags (Current, SetReadWriteFlagsOnly, Flags, Index);
-    if (EFI_ERROR (Status)) {
-      goto FlagError;
+      Entry                   = (PAGE_TABLE_ENTRY)(UINTN)NewPage | PAGE_TABLE_ACCESS_FLAG | PAGE_TABLE_DESCRIPTOR | PAGE_TABLE_ENTRY_VALID_BIT;
+      Current->Entries[Index] = Entry; // valid entry
     }
 
     Current = (PAGE_TABLE *)((UINTN)Current->Entries[Index] & ~PAGE_TABLE_BLOCK_OFFSET);
@@ -170,23 +157,26 @@ UpdateMapping (
 
     if (!SetReadWriteFlagsOnly) {
       if (Valid) {
-        Current->Entries[Index]  = (PhysicalAddress & ~PAGE_TABLE_BLOCK_OFFSET); // Assign PA
-        Current->Entries[Index] |= PAGE_TABLE_ENTRY_VALID_BIT;                   // valid entry
+        Entry = (PhysicalAddress & ~PAGE_TABLE_BLOCK_OFFSET); // Assign PA
+        // validate entry and set leaf level flags
+        Entry                  |= PAGE_TABLE_ACCESS_FLAG | PAGE_TABLE_DESCRIPTOR | PAGE_TABLE_ENTRY_VALID_BIT;
+        Current->Entries[Index] =  Entry;
       } else {
-        Current->Entries[Index] &= ~PAGE_TABLE_ENTRY_VALID_BIT; // only invalidate leaf entry
+        Entry                   = Current->Entries[Index] & ~PAGE_TABLE_ENTRY_VALID_BIT; // invalidate entry
+        Current->Entries[Index] = Entry;                                                 // only invalidate leaf entry
       }
-    }
-
-    Status = UpdateFlags (Current, SetReadWriteFlagsOnly, Flags, Index);
-    if (EFI_ERROR (Status)) {
-      goto FlagError;
+    } else {
+      Status = UpdateFlags (Current, Flags, Index);
+      if (EFI_ERROR (Status)) {
+        goto Error;
+      }
     }
   }
 
+  ArmDataSynchronizationBarrier ();
+  SpeculationBarrier ();
   return Status;
 
-FlagError:
-  DEBUG ((DEBUG_ERROR, "%a: Failed to update flags.\n", __func__));
 Error:
   ASSERT_EFI_ERROR (Status);
   return Status;
@@ -276,7 +266,7 @@ IoMmuMap (
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  PhysicalAddress;
   IOMMU_MAP_INFO        *MapInfo;
-  UINT16                Flags;
+  SMMUV3_CMD_GENERIC    Command;
 
   if ((This == NULL) ||
       (HostAddress == NULL) ||
@@ -290,21 +280,42 @@ IoMmuMap (
     goto Error;
   }
 
-  // Arm Architecture Reference Manual Armv8, for Armv8-A architecture profile:
-  // The VMSAv8-64 translation table format descriptors.
-  // Bit #10 AF = 1, Table/Page Descriptors for levels 0-3 so set bit #1 to 0b'1 for each entry
-  Flags = PAGE_TABLE_ACCESS_FLAG | PAGE_TABLE_DESCRIPTOR;
-
   PhysicalAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
-  Status          = UpdatePageTable (mSmmu->PageTableRoot, PhysicalAddress, *NumberOfBytes, Flags, TRUE, FALSE);
+  Status          = UpdatePageTable (mSmmu->PageTableRoot, PhysicalAddress, *NumberOfBytes, 0, TRUE, FALSE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to update page table.\n", __func__));
     goto Error;
   }
 
-  *DeviceAddress = PhysicalAddress; // Identity mapping
+  // Invalidate TLBI Command
+  SMMUV3_BUILD_CMD_TLBI_NSNH_ALL (&Command);
+  Status = SmmuV3SendCommand (mSmmu, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_NSNH_ALL failed.\n", __func__));
+    goto Error;
+  }
+
+  SMMUV3_BUILD_CMD_TLBI_EL2_ALL (&Command);
+  Status = SmmuV3SendCommand (mSmmu, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_EL2_ALL failed.\n", __func__));
+    goto Error;
+  }
+
+  // Issue a CMD_SYNC command to guarantee that any previously issued TLB
+  // invalidations (CMD_TLBI_*) are completed (SMMUv3.2 spec section 4.6.3).
+  SMMUV3_BUILD_CMD_SYNC_NO_INTERRUPT (&Command);
+  Status = SmmuV3SendCommand (mSmmu, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_SYNC_NO_INTERRUPT failed.\n", __func__));
+    goto Error;
+  }
+
+  ArmDataSynchronizationBarrier ();
 
   // Allocate and fill the IOMMU_MAP_INFO structure with mapped information
+  *DeviceAddress = PhysicalAddress; // Identity mapping
+
   MapInfo                  = (IOMMU_MAP_INFO *)AllocateZeroPool (sizeof (IOMMU_MAP_INFO));
   MapInfo->NumberOfBytes   = *NumberOfBytes;
   MapInfo->VirtualAddress  = *DeviceAddress;
@@ -380,6 +391,8 @@ IoMmuUnmap (
     DEBUG ((DEBUG_ERROR, "%a: CMD_SYNC_NO_INTERRUPT failed.\n", __func__));
     goto Error;
   }
+
+  ArmDataSynchronizationBarrier ();
 
   // Free the mapping structure allocated in IoMmuMap
   if (MapInfo != NULL) {
@@ -517,8 +530,9 @@ IoMmuSetAttribute (
   IN UINT64                IoMmuAccess
   )
 {
-  EFI_STATUS      Status;
-  IOMMU_MAP_INFO  *MapInfo;
+  EFI_STATUS          Status;
+  IOMMU_MAP_INFO      *MapInfo;
+  SMMUV3_CMD_GENERIC  Command;
 
   if ((This == NULL) || (Mapping == NULL) || ((IoMmuAccess & ~(EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)) != 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
@@ -540,6 +554,32 @@ IoMmuSetAttribute (
     DEBUG ((DEBUG_ERROR, "%a: Failed to update page table.\n", __func__));
     goto Error;
   }
+
+  // Invalidate TLBI Command
+  SMMUV3_BUILD_CMD_TLBI_NSNH_ALL (&Command);
+  Status = SmmuV3SendCommand (mSmmu, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_NSNH_ALL failed.\n", __func__));
+    goto Error;
+  }
+
+  SMMUV3_BUILD_CMD_TLBI_EL2_ALL (&Command);
+  Status = SmmuV3SendCommand (mSmmu, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_EL2_ALL failed.\n", __func__));
+    goto Error;
+  }
+
+  // Issue a CMD_SYNC command to guarantee that any previously issued TLB
+  // invalidations (CMD_TLBI_*) are completed (SMMUv3.2 spec section 4.6.3).
+  SMMUV3_BUILD_CMD_SYNC_NO_INTERRUPT (&Command);
+  Status = SmmuV3SendCommand (mSmmu, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_SYNC_NO_INTERRUPT failed.\n", __func__));
+    goto Error;
+  }
+
+  ArmDataSynchronizationBarrier ();
 
   // Only prints errors if Event Queue is not empty and GError != 0
   SmmuV3LogErrors (mSmmu);

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.h
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.h
@@ -15,14 +15,12 @@
   <https://developer.arm.com/documentation/102105/ka-07>
   Section D8.3.1 VMSAv8-64 descriptor formats
 **/
-#define PAGE_TABLE_DEPTH            4                           // Number of levels in the page table
 #define PAGE_TABLE_READ_BIT         (0x1 << 6)
 #define PAGE_TABLE_WRITE_BIT        (0x1 << 7)
 #define PAGE_TABLE_ENTRY_VALID_BIT  0x1
 #define PAGE_TABLE_BLOCK_OFFSET     0xFFF
 #define PAGE_TABLE_ACCESS_FLAG      (0x1 << 10)
 #define PAGE_TABLE_DESCRIPTOR       (0x1 << 1)
-#define PAGE_TABLE_INDEX(VirtualAddress, Level)               (((VirtualAddress) >> (12 + (9 * (PAGE_TABLE_DEPTH - 1 - (Level))))) & 0x1FF)
 #define PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS(IoMmuAccess)  (IoMmuAccess << 6)
 
 /**

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -211,34 +211,43 @@ PageTableDeInit (
 
   @param [in]   SmmuInfo       Pointer to the SMMU_INFO structure.
   @param [out]  QueueLog2Size  Pointer to store the log2 size of the queue.
+  @param [out]  EventQueueBase Pointer to store the base address of the allocated event queue.
 
-  @retval Pointer to the allocated event queue, or NULL on failure.
+  @retval EFI_SUCCESS          The event queue was allocated successfully.
+  @retval EFI_INVALID_PARAMETER One or more parameters are invalid.
+  @retval EFI_OUT_OF_RESOURCES  Allocation failed due to insufficient resources.
 **/
 STATIC
-VOID *
+EFI_STATUS
 SmmuV3AllocateEventQueue (
-  IN SMMU_INFO  *SmmuInfo,
-  OUT UINT32    *QueueLog2Size
+  IN  SMMU_INFO  *SmmuInfo,
+  OUT UINT32     *QueueLog2Size,
+  OUT VOID       **EventQueueBase
   )
 {
   UINT32       QueueSize;
   SMMUV3_IDR1  Idr1;
-  VOID         *EventQueueBase;
   UINT32       Pages;
 
-  if ((SmmuInfo == NULL) || (QueueLog2Size == NULL)) {
+  if ((SmmuInfo == NULL) || (QueueLog2Size == NULL) || (EventQueueBase == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
-    return NULL;
+    return EFI_INVALID_PARAMETER;
   }
 
   Idr1.AsUINT32 = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_IDR1);
 
-  *QueueLog2Size = MIN (Idr1.EventQs, SMMUV3_EVENT_QUEUE_LOG2ENTRIES);
-  QueueSize      = SMMUV3_EVENT_QUEUE_SIZE_FROM_LOG2 (*QueueLog2Size);
-  Pages          = EFI_SIZE_TO_PAGES (QueueSize);
-  EventQueueBase = AllocatePages (Pages);
-  ZeroMem (EventQueueBase, EFI_PAGES_TO_SIZE (Pages));
-  return EventQueueBase;
+  *QueueLog2Size  = MIN (Idr1.EventQs, SMMUV3_EVENT_QUEUE_LOG2ENTRIES);
+  QueueSize       = SMMUV3_EVENT_QUEUE_SIZE_FROM_LOG2 (*QueueLog2Size);
+  Pages           = EFI_SIZE_TO_PAGES (QueueSize);
+  *EventQueueBase = AllocatePages (Pages);
+
+  if (*EventQueueBase == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Allocation failed\n", __func__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (*EventQueueBase, EFI_PAGES_TO_SIZE (Pages));
+  return EFI_SUCCESS;
 }
 
 /**
@@ -246,24 +255,27 @@ SmmuV3AllocateEventQueue (
 
   @param [in]   SmmuInfo       Pointer to the SMMU_INFO structure.
   @param [out]  QueueLog2Size  Pointer to store the log2 size of the queue.
+  @param [out]  CmdQueueBase   Pointer to store the base address of the allocated command queue.
 
-  @retval Pointer to the allocated command queue, or NULL on failure.
+  @retval EFI_SUCCESS          The command queue was allocated successfully.
+  @retval EFI_INVALID_PARAMETER One or more parameters are invalid.
+  @retval EFI_OUT_OF_RESOURCES  Allocation failed due to insufficient resources.
 **/
 STATIC
-VOID *
+EFI_STATUS
 SmmuV3AllocateCommandQueue (
   IN  SMMU_INFO  *SmmuInfo,
-  OUT UINT32     *QueueLog2Size
+  OUT UINT32     *QueueLog2Size,
+  OUT VOID       **CmdQueueBase
   )
 {
   UINT32       QueueSize;
   SMMUV3_IDR1  Idr1;
-  VOID         *CmdQueueBase;
   UINT32       Pages;
 
-  if ((SmmuInfo == NULL) || (QueueLog2Size == NULL)) {
+  if ((SmmuInfo == NULL) || (QueueLog2Size == NULL) || (CmdQueueBase == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
-    return NULL;
+    return EFI_INVALID_PARAMETER;
   }
 
   Idr1.AsUINT32 = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_IDR1);
@@ -271,9 +283,15 @@ SmmuV3AllocateCommandQueue (
   *QueueLog2Size = MIN (Idr1.CmdQs, SMMUV3_COMMAND_QUEUE_LOG2ENTRIES);
   QueueSize      = SMMUV3_COMMAND_QUEUE_SIZE_FROM_LOG2 (*QueueLog2Size);
   Pages          = EFI_SIZE_TO_PAGES (QueueSize);
-  CmdQueueBase   = AllocatePages (Pages);
-  ZeroMem (CmdQueueBase, EFI_PAGES_TO_SIZE (Pages));
-  return CmdQueueBase;
+  *CmdQueueBase  = AllocatePages (Pages);
+
+  if (*CmdQueueBase == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Allocation failed\n", __func__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (*CmdQueueBase, EFI_PAGES_TO_SIZE (Pages));
+  return EFI_SUCCESS;
 }
 
 /**
@@ -621,11 +639,15 @@ SmmuV3Configure (
     CopyMem (&StreamTablePtr[Index], &TemplateStreamEntry, sizeof (SMMUV3_STREAM_TABLE_ENTRY));
   }
 
-  CommandQueue = SmmuV3AllocateCommandQueue (SmmuInfo, &CommandQueueLog2Size);
-  EventQueue   = SmmuV3AllocateEventQueue (SmmuInfo, &EventQueueLog2Size);
-  if ((CommandQueue == NULL) || (EventQueue == NULL)) {
-    DEBUG ((DEBUG_ERROR, "%a: Error allocating SMMU Queues\n", __func__));
-    Status = EFI_OUT_OF_RESOURCES;
+  Status = SmmuV3AllocateCommandQueue (SmmuInfo, &CommandQueueLog2Size, &CommandQueue);
+  if (EFI_ERROR (Status) || (CommandQueue == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: Error allocating SMMU Command Queue\n", __func__));
+    goto End;
+  }
+
+  Status = SmmuV3AllocateEventQueue (SmmuInfo, &EventQueueLog2Size, &EventQueue);
+  if (EFI_ERROR (Status) || (EventQueue == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: Error allocating SMMU Event Queue\n", __func__));
     goto End;
   }
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -223,6 +223,8 @@ SmmuV3AllocateEventQueue (
 {
   UINT32       QueueSize;
   SMMUV3_IDR1  Idr1;
+  VOID         *EventQueueBase;
+  UINT32       Pages;
 
   if ((SmmuInfo == NULL) || (QueueLog2Size == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
@@ -233,7 +235,10 @@ SmmuV3AllocateEventQueue (
 
   *QueueLog2Size = MIN (Idr1.EventQs, SMMUV3_EVENT_QUEUE_LOG2ENTRIES);
   QueueSize      = SMMUV3_EVENT_QUEUE_SIZE_FROM_LOG2 (*QueueLog2Size);
-  return AllocateZeroPool (QueueSize);
+  Pages          = EFI_SIZE_TO_PAGES (QueueSize);
+  EventQueueBase = AllocatePages (Pages);
+  ZeroMem (EventQueueBase, EFI_PAGES_TO_SIZE (Pages));
+  return EventQueueBase;
 }
 
 /**
@@ -253,6 +258,8 @@ SmmuV3AllocateCommandQueue (
 {
   UINT32       QueueSize;
   SMMUV3_IDR1  Idr1;
+  VOID         *CmdQueueBase;
+  UINT32       Pages;
 
   if ((SmmuInfo == NULL) || (QueueLog2Size == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
@@ -263,7 +270,10 @@ SmmuV3AllocateCommandQueue (
 
   *QueueLog2Size = MIN (Idr1.CmdQs, SMMUV3_COMMAND_QUEUE_LOG2ENTRIES);
   QueueSize      = SMMUV3_COMMAND_QUEUE_SIZE_FROM_LOG2 (*QueueLog2Size);
-  return AllocateZeroPool (QueueSize);
+  Pages          = EFI_SIZE_TO_PAGES (QueueSize);
+  CmdQueueBase   = AllocatePages (Pages);
+  ZeroMem (CmdQueueBase, EFI_PAGES_TO_SIZE (Pages));
+  return CmdQueueBase;
 }
 
 /**
@@ -274,13 +284,17 @@ SmmuV3AllocateCommandQueue (
 STATIC
 VOID
 SmmuV3FreeQueue (
-  IN VOID  *QueuePtr
+  IN VOID    *QueuePtr,
+  IN UINT32  Log2Size
   )
 {
+  UINT32  Size;
+
   if (QueuePtr == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameters. QueuePtr == NULL\n", __func__));
   } else {
-    FreePool (QueuePtr);
+    Size = SMMUV3_COMMAND_QUEUE_SIZE_FROM_LOG2 (Log2Size);
+    FreePages ((VOID *)QueuePtr, EFI_SIZE_TO_PAGES (Size));
   }
 }
 
@@ -302,6 +316,7 @@ SmmuV3BuildStreamTable (
   OUT SMMUV3_STREAM_TABLE_ENTRY  *StreamEntry
   )
 {
+  EFI_STATUS   Status;
   UINT32       OutputAddressWidth;
   UINT32       InputSize;
   SMMUV3_IDR0  Idr0;
@@ -311,6 +326,7 @@ SmmuV3BuildStreamTable (
   UINT32       CCA;
   UINT8        CPM;
   UINT8        DACS;
+  UINT64       S2Sl0;
 
   if ((SmmuInfo == NULL) || (SmmuConfig == NULL) || (StreamEntry == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
@@ -340,19 +356,6 @@ SmmuV3BuildStreamTable (
     StreamEntry->S2Ptw = SMMUV3_STREAM_TABLE_ENTRY_S2PTW;
   }
 
-  // S2SL0      Meaning
-  // <https://developer.arm.com/documentation/ddi0595/2021-03/AArch64-Registers/VTCR-EL2--Virtualization-Translation-Control-Register?lang=en#fieldset_0-7_6-1>
-  // Starting level of the stage 2 translation lookup, controlled by VTCR_EL2. The meaning of this field depends on the value of VTCR_EL2.TG0.
-  // 0x2:
-  // If VTCR_EL2.TG0 is 0b00 (4KB granule):
-  // If FEAT_LPA2 is not implemented, start at level 0.
-  // If FEAT_LPA2 is implemented and VTCR_EL2.SL2 is 0b0, start at level 0.
-  // If FEAT_LPA2 is implemented, the combination of VTCR_EL2.SL0 == 10 and VTCR_EL2.SL2 == 1 is reserved.
-  // If VTCR_EL2.TG0 is 0b10 (16KB granule) or 0b01 (64KB granule), start at level 1.
-  //
-
-  StreamEntry->S2Sl0 = SMMUV3_STREAM_TABLE_ENTRY_S2SL0; // 0x2: Start at level 0
-
   //
   // Set the maximum output address width. Per SMMUv3.2 spec (sections 5.2 and
   // 3.4.1), the maximum input address width with AArch64 format is given by
@@ -372,8 +375,27 @@ SmmuV3BuildStreamTable (
     StreamEntry->S2Ps = SmmuV3EncodeAddressWidth (OutputAddressWidth);
   } else {
     DEBUG ((DEBUG_INFO, "%a: Advertised OutputAddressWidth >= 48. Capping the width to 48 per the SMMU spec.\n", __func__));
-    StreamEntry->S2Ps = SmmuV3EncodeAddressWidth (SMMUV3_STREAM_TABLE_ENTRY_OUTPUT_ADDRESS_MAX);
+    StreamEntry->S2Ps  = SmmuV3EncodeAddressWidth (SMMUV3_STREAM_TABLE_ENTRY_OUTPUT_ADDRESS_MAX);
+    OutputAddressWidth = SMMUV3_STREAM_TABLE_ENTRY_OUTPUT_ADDRESS_MAX;
   }
+
+  Status = SmmuV3SetTranslationStartingLevel (SmmuInfo, OutputAddressWidth, &S2Sl0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to set translation starting level\n", __func__));
+    return Status;
+  }
+
+  // S2SL0      Meaning
+  // <https://developer.arm.com/documentation/ddi0595/2021-03/AArch64-Registers/VTCR-EL2--Virtualization-Translation-Control-Register?lang=en#fieldset_0-7_6-1>
+  // Starting level of the stage 2 translation lookup, controlled by VTCR_EL2. The meaning of this field depends on the value of VTCR_EL2.TG0.
+  // 0x2:
+  // If VTCR_EL2.TG0 is 0b00 (4KB granule):
+  // If FEAT_LPA2 is not implemented, start at level 0.
+  // If FEAT_LPA2 is implemented and VTCR_EL2.SL2 is 0b0, start at level 0.
+  // If FEAT_LPA2 is implemented, the combination of VTCR_EL2.SL0 == 10 and VTCR_EL2.SL2 == 1 is reserved.
+  // If VTCR_EL2.TG0 is 0b10 (16KB granule) or 0b01 (64KB granule), start at level 1.
+  //
+  StreamEntry->S2Sl0 = S2Sl0;
 
   InputSize           = OutputAddressWidth;
   StreamEntry->S2T0Sz = 64 - InputSize;
@@ -416,7 +438,7 @@ SmmuV3BuildStreamTable (
 
   StreamEntry->Valid = SMMUV3_STREAM_TABLE_ENTRY_VALID;
 
-  return EFI_SUCCESS;
+  return Status;
 }
 
 /**
@@ -885,12 +907,12 @@ SmmuDeInit (
   }
 
   if (SmmuInfo->CommandQueue != NULL) {
-    SmmuV3FreeQueue (SmmuInfo->CommandQueue);
+    SmmuV3FreeQueue (SmmuInfo->CommandQueue, SmmuInfo->CommandQueueLog2Size);
     SmmuInfo->CommandQueue = NULL;
   }
 
   if (SmmuInfo->EventQueue != NULL) {
-    SmmuV3FreeQueue (SmmuInfo->EventQueue);
+    SmmuV3FreeQueue (SmmuInfo->EventQueue, SmmuInfo->EventQueueLog2Size);
     SmmuInfo->EventQueue = NULL;
   }
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.inf
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.inf
@@ -36,6 +36,7 @@
   ArmLib
   BaseLib
   BaseMemoryLib
+  CacheMaintenanceLib
   IoLib
   HobLib
   MemoryAllocationLib

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.inf
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.inf
@@ -36,7 +36,6 @@
   ArmLib
   BaseLib
   BaseMemoryLib
-  CacheMaintenanceLib
   IoLib
   HobLib
   MemoryAllocationLib

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -18,6 +18,9 @@
 // Number of levels in the page table
 #define PAGE_TABLE_DEPTH  4
 #define PAGE_TABLE_INDEX(VirtualAddress, Level)  (((VirtualAddress) >> (12 + (9 * (PAGE_TABLE_DEPTH - 1 - (Level))))) & 0x1FF)
+#define PAGE_TABLE_4_LEVEL_OUTPUT_ADDRESS_WIDTH_MIN  44
+#define PAGE_TABLE_OUTPUT_ADDRESS_WIDTH_MAX          48
+#define PAGE_TABLE_OUTPUT_ADDRESS_WIDTH_MIN          32
 
 // Macro to align values down. Alignment is required to be power of 2.
 #define ALIGN_DOWN_BY(length, alignment) \

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -407,4 +407,18 @@ SmmuV3SendCommand (
   IN SMMUV3_CMD_GENERIC  *Command
   );
 
+/**
+  Invalidate all TLB entries in the SMMUv3.
+
+  @param [in]  SmmuInfo  Pointer to the SMMU_INFO structure.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_TIMEOUT            Timeout.
+  @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+**/
+EFI_STATUS
+SmmuV3TLBInvalidateAll (
+  IN SMMU_INFO  *SmmuInfo
+  );
+
 #endif

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -15,6 +15,10 @@
 #include <Register/SmmuV3Registers.h>
 #include <Uefi/UefiBaseType.h>
 
+// Number of levels in the page table
+#define PAGE_TABLE_DEPTH  4
+#define PAGE_TABLE_INDEX(VirtualAddress, Level)  (((VirtualAddress) >> (12 + (9 * (PAGE_TABLE_DEPTH - 1 - (Level))))) & 0x1FF)
+
 // Macro to align values down. Alignment is required to be power of 2.
 #define ALIGN_DOWN_BY(length, alignment) \
     ((UINT64)(length) & ~((UINT64)(alignment) - 1))
@@ -150,6 +154,7 @@ typedef struct _SMMU_INFO {
   VOID          *StreamTable;
   VOID          *CommandQueue;
   VOID          *EventQueue;
+  UINT8         TranslationStartingLevel;
   UINT64        SmmuBase;
   UINT32        StreamTableSize;
   UINT32        CommandQueueSize;
@@ -184,6 +189,24 @@ SmmuV3DecodeAddressWidth (
 UINT8
 SmmuV3EncodeAddressWidth (
   IN UINT32  AddressWidth
+  );
+
+/**
+  Set the translation starting level for SMMUv3 page tables.
+  Only 3 and 4 level paging are supported.
+
+  @param [in]  SmmuInfo           Pointer to the SMMU_INFO structure.
+  @param [in]  OutputAddressWidth  The output address width.
+  @param [out] S2Sl0              The starting level for stage 2 translation.
+
+  @retval EFI_SUCCESS              Success.
+  @retval EFI_INVALID_PARAMETER    Invalid parameter.
+**/
+EFI_STATUS
+SmmuV3SetTranslationStartingLevel (
+  IN SMMU_INFO  *SmmuInfo,
+  IN UINT32     OutputAddressWidth,
+  OUT UINT64    *S2Sl0
   );
 
 /**

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -109,6 +109,42 @@ SmmuV3EncodeAddressWidth (
 }
 
 /**
+  Set the translation starting level for SMMUv3 page tables.
+  Only 3 and 4 level paging are supported.
+
+  @param [in]  SmmuInfo           Pointer to the SMMU_INFO structure.
+  @param [in]  OutputAddressWidth  The output address width.
+  @param [out] S2Sl0              The starting level for stage 2 translation.
+
+  @retval EFI_SUCCESS              Success.
+  @retval EFI_INVALID_PARAMETER    Invalid parameter.
+**/
+EFI_STATUS
+SmmuV3SetTranslationStartingLevel (
+  IN SMMU_INFO  *SmmuInfo,
+  IN UINT32     OutputAddressWidth,
+  OUT UINT64    *S2Sl0
+  )
+{
+  if ((OutputAddressWidth > 48) || (OutputAddressWidth < 32)) {
+    DEBUG ((DEBUG_ERROR, "%a: OutputAddressWidth not supported.\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Per the Arm ARM VMSA spec, >= 44 bits of address width requires 4 level paging.
+  // Otherwise, 3 level paging is used.
+  if (OutputAddressWidth >= 44) {
+    SmmuInfo->TranslationStartingLevel = 0; // 4 level paging
+    *S2Sl0                             = 0x2;
+  } else {
+    SmmuInfo->TranslationStartingLevel = 1; // 3 level paging
+    *S2Sl0                             = 0x1;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
   Read a 32-bit value from the specified SMMU register.
 
   @param [in]  SmmuBase   The base address of the SMMU.
@@ -526,7 +562,7 @@ SmmuV3ConsumeEventQueueForErrors (
   }
 
   *IsEmpty  = FALSE;
-  NextFault = SmmuInfo->EventQueue + ConsumerIndex;
+  NextFault = (SMMUV3_FAULT_RECORD *)SmmuInfo->EventQueue + ConsumerIndex;
   CopyMem (FaultRecord, NextFault, SMMUV3_EVENT_QUEUE_ENTRY_SIZE);
 
   ConsumerIndex += 1;
@@ -543,6 +579,41 @@ SmmuV3ConsumeEventQueueForErrors (
 
 End:
   return EFI_SUCCESS;
+}
+
+/**
+  Dump the page table entries for a given virtual address.
+  Dumps PTE's for all levels regardless of the starting level chosen for translation.
+
+  @param [in]  SmmuInfo        Pointer to the SMMU_INFO structure.
+  @param [in]  VirtualAddress  The virtual address to dump.
+  @param [in]  Root            Pointer to the root page table.
+
+  @retval None.
+**/
+VOID
+SmmuV3DumpPageTableEntries (
+  IN SMMU_INFO   *SmmuInfo,
+  IN UINT64      VirtualAddress,
+  IN PAGE_TABLE  *Root
+  )
+{
+  UINTN       Index;
+  UINT8       Level;
+  PAGE_TABLE  *Current;
+
+  Current = Root;
+
+  for (Level = SmmuInfo->TranslationStartingLevel; Level < PAGE_TABLE_DEPTH; Level++) {
+    Index = PAGE_TABLE_INDEX (VirtualAddress, Level);
+    if (Current->Entries[Index] == 0) {
+      DEBUG ((DEBUG_ERROR, "%a: Invalid entry at level %d, index %d\n", __func__, Level, Index));
+      break;
+    }
+
+    DEBUG ((DEBUG_INFO, "%a: VirtualAddress = %llx Level = %d Current->Entries[%d] = 0x%llx\n", __func__, VirtualAddress, Level, Index, Current->Entries[Index]));
+    Current = (PAGE_TABLE *)((UINTN)Current->Entries[Index] & ~0xFFF);
+  }
 }
 
 /**
@@ -572,16 +643,23 @@ SmmuV3LogErrors (
     DEBUG ((DEBUG_ERROR, "%a: Error consuming event queue\n", __func__));
   } else {
     if (IsEmpty == FALSE) {
-      DEBUG ((DEBUG_ERROR, "%a: FaultRecord:\n", __func__));
+      DEBUG ((DEBUG_ERROR, "%a: %llx FaultRecord:\n", __func__, SmmuInfo->SmmuBase));
       for (Index = 0; Index < sizeof (FaultRecord.Fault) / sizeof (FaultRecord.Fault[0]); Index++) {
         DEBUG ((DEBUG_ERROR, "0x%llx\n", FaultRecord.Fault[Index]));
+      }
+
+      // Dump PTE's if translation related fault
+      if (((FaultRecord.Fault[0] & 0xFF) == 0x10) || ((FaultRecord.Fault[0] & 0xFF) == 0x11) ||
+          ((FaultRecord.Fault[0] & 0xFF) == 0x12) || ((FaultRecord.Fault[0] & 0xFF) == 0x13))
+      {
+        SmmuV3DumpPageTableEntries (SmmuInfo, FaultRecord.Fault[2], SmmuInfo->PageTableRoot);
       }
     }
   }
 
   GError.AsUINT32 = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_GERROR);
   if (GError.AsUINT32 != 0) {
-    DEBUG ((DEBUG_ERROR, "%a: GError: 0x%lx\n", __func__, GError.AsUINT32));
+    DEBUG ((DEBUG_ERROR, "%a: %llx GError: 0x%lx\n", __func__, SmmuInfo->SmmuBase, GError.AsUINT32));
   }
 }
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -817,3 +817,54 @@ SmmuV3SendCommand (
 
   return Status;
 }
+
+/**
+  Invalidate all TLB entries in the SMMUv3.
+
+  @param [in]  SmmuInfo  Pointer to the SMMU_INFO structure.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_TIMEOUT            Timeout.
+  @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+**/
+EFI_STATUS
+SmmuV3TLBInvalidateAll (
+  IN SMMU_INFO  *SmmuInfo
+  )
+{
+  SMMUV3_CMD_GENERIC  Command;
+  EFI_STATUS          Status;
+
+  if (SmmuInfo == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Invalidate TLBI Commands
+  SMMUV3_BUILD_CMD_TLBI_NSNH_ALL (&Command);
+  Status = SmmuV3SendCommand (SmmuInfo, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_NSNH_ALL failed.\n", __func__));
+    return Status;
+  }
+
+  SMMUV3_BUILD_CMD_TLBI_EL2_ALL (&Command);
+  Status = SmmuV3SendCommand (SmmuInfo, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_EL2_ALL failed.\n", __func__));
+    return Status;
+  }
+
+  // Issue a CMD_SYNC command to guarantee that any previously issued TLB
+  // invalidations (CMD_TLBI_*) are completed (SMMUv3.2 spec section 4.6.3).
+  SMMUV3_BUILD_CMD_SYNC_NO_INTERRUPT (&Command);
+  Status = SmmuV3SendCommand (SmmuInfo, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_SYNC_NO_INTERRUPT failed.\n", __func__));
+    return Status;
+  }
+
+  ArmDataSynchronizationBarrier ();
+
+  return Status;
+}

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -126,14 +126,14 @@ SmmuV3SetTranslationStartingLevel (
   OUT UINT64    *S2Sl0
   )
 {
-  if ((OutputAddressWidth > 48) || (OutputAddressWidth < 32)) {
-    DEBUG ((DEBUG_ERROR, "%a: OutputAddressWidth not supported.\n", __func__));
+  if ((OutputAddressWidth > PAGE_TABLE_OUTPUT_ADDRESS_WIDTH_MAX) || (OutputAddressWidth < PAGE_TABLE_OUTPUT_ADDRESS_WIDTH_MIN)) {
+    DEBUG ((DEBUG_ERROR, "%a: OutputAddressWidth %d not supported.\n", __func__, OutputAddressWidth));
     return EFI_INVALID_PARAMETER;
   }
 
   // Per the Arm ARM VMSA spec, >= 44 bits of address width requires 4 level paging.
   // Otherwise, 3 level paging is used.
-  if (OutputAddressWidth >= 44) {
+  if (OutputAddressWidth >= PAGE_TABLE_4_LEVEL_OUTPUT_ADDRESS_WIDTH_MIN) {
     SmmuInfo->TranslationStartingLevel = 0; // 4 level paging
     *S2Sl0                             = 0x2;
   } else {
@@ -820,6 +820,7 @@ SmmuV3SendCommand (
 
 /**
   Invalidate all TLB entries in the SMMUv3.
+  TODO: Change to use CMD_TLBI_S2_IPA instead of ALL.
 
   @param [in]  SmmuInfo  Pointer to the SMMU_INFO structure.
 


### PR DESCRIPTION
## Description

### [SQUASH ON REBASE] SmmuDxe updates and bug fixes

Bug fix for command queue address not being aligned properly.
Bug fix for event queue consumption.
Dynamically sets starting level of translation for paging from IDR5.OAS on the smmu.
Improve logging on error.
Safety improvements on updating page table entries in the IoMmu protocol.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on QEMU SBSA platform as well as a physical ARM surface platform

## Integration Instructions

N/A
