### PR TITLE
[Rebase & FF] Revert UUID mangling change from MU

### DIFF
--- a/ArmPkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/ArmPkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -66,21 +66,12 @@ ConvertEfiGuidToUuid (
   UINT32  *Data32;
   UINT16  *Data16;
 
-  // MU_CHANGE Starts: Update UUID mangling method
-  if ((Guid == NULL) || (Uuid == NULL)) {
-    return;
-  }
-  // MU_CHANGE Ends
-
   CopyGuid ((EFI_GUID *)Uuid, Guid);
-  Data32 = (UINT32 *)Uuid;
-  // Data32[0] = SwapBytes32 (Data32[0]); // MU_CHANGE Starts: Update UUID mangling method
+  Data32    = (UINT32 *)Uuid;
+  Data32[0] = SwapBytes32 (Data32[0]);
   Data16    = (UINT16 *)&Data32[1];
-  Data32[1] = SwapBytes32 (Data32[1]); // MU_CHANGE: Update UUID mangling method
   Data16[0] = SwapBytes16 (Data16[0]);
   Data16[1] = SwapBytes16 (Data16[1]);
-  Data32[2] = SwapBytes32 (Data32[2]); // MU_CHANGE: Update UUID mangling method
-  Data32[3] = SwapBytes32 (Data32[3]); // MU_CHANGE: Update UUID mangling method
 }
 
 /**


### PR DESCRIPTION
## Description

This change reverts the UUID mangling update from an earlier commit: a54476058b916d8f7af0f13bf129cc39ddd9cbca.

The change will align with EDK2 implementation and stick to SMCCC spec.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This was tested on QEMU SBSA virtual platform and proprietary hardware platform.

## Integration Instructions

Platforms need to update the UUIDs carried in their manifest by reversing the endianness.
i.e.
- TPM service: uuid = <0x17b862a4 0x18064faf 0x86b3089a 0x58353861>; to `uuid = <0xa462b817 0xaf4f0618 0x9a08b386 0x61383558>`;
- Stmm service: uuid = <0x378daedc 0xf06b4446 0x831440ab 0x933c87a3>; to `uuid = <0xdcae8d37 0x46446bf0 0xab401483 0xa3873c93>`.