### PR TITLE
[SQUASH ON REBASE] Add support for N SMMU's and dynamically parse any IORT config

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -120,7 +120,7 @@ UpdateMapping (
   Current = Root;
 
   // Traverse the page table to the leaf level
-  for (Level = mSmmu->TranslationStartingLevel; Level < PAGE_TABLE_DEPTH - 1; Level++) {
+  for (Level = mIoMmu->SmmuInfo->TranslationStartingLevel; Level < PAGE_TABLE_DEPTH - 1; Level++) {
     Index = PAGE_TABLE_INDEX (VirtualAddress, Level);
 
     if (Current->Entries[Index] == 0) {
@@ -202,6 +202,7 @@ UpdatePageTable (
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  PhysicalAddressEnd;
   EFI_PHYSICAL_ADDRESS  CurPhysicalAddress;
+  UINT32                SmmuIndex;
 
   if ((Root == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (PhysicalAddress == 0) || (Bytes == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
@@ -223,10 +224,12 @@ UpdatePageTable (
   }
 
   // Invalidate TLBI Command
-  Status = SmmuV3TLBInvalidateAll (mSmmu);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
-    goto Error;
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    Status = SmmuV3TLBInvalidateAll (&mIoMmu->SmmuInfo[SmmuIndex]);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
+      goto Error;
+    }
   }
 
   return Status;
@@ -265,6 +268,7 @@ IoMmuMap (
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  PhysicalAddress;
   IOMMU_MAP_INFO        *MapInfo;
+  UINT32                SmmuIndex;
 
   if ((This == NULL) ||
       (HostAddress == NULL) ||
@@ -279,7 +283,7 @@ IoMmuMap (
   }
 
   PhysicalAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
-  Status          = UpdatePageTable (mSmmu->PageTableRoot, PhysicalAddress, *NumberOfBytes, 0, TRUE, FALSE);
+  Status          = UpdatePageTable (mIoMmu->SmmuInfo->PageTableRoot, PhysicalAddress, *NumberOfBytes, 0, TRUE, FALSE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to update page table.\n", __func__));
     goto Error;
@@ -295,11 +299,17 @@ IoMmuMap (
   *Mapping                 = MapInfo;
 
   // Only prints errors if Event Queue is not empty and GError != 0
-  SmmuV3LogErrors (mSmmu);
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+  }
+
   return Status;
 
 Error:
-  SmmuV3LogErrors (mSmmu);
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+  }
+
   ASSERT_EFI_ERROR (Status);
   return Status;
 }
@@ -324,6 +334,7 @@ IoMmuUnmap (
 {
   EFI_STATUS      Status;
   IOMMU_MAP_INFO  *MapInfo;
+  UINT32          SmmuIndex;
 
   if ((This == NULL) || (Mapping == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
@@ -333,7 +344,7 @@ IoMmuUnmap (
 
   MapInfo = (IOMMU_MAP_INFO *)Mapping;
 
-  Status = UpdatePageTable (mSmmu->PageTableRoot, MapInfo->PhysicalAddress, MapInfo->NumberOfBytes, 0, FALSE, FALSE);
+  Status = UpdatePageTable (mIoMmu->SmmuInfo->PageTableRoot, MapInfo->PhysicalAddress, MapInfo->NumberOfBytes, 0, FALSE, FALSE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to update page table.\n", __func__));
     goto Error;
@@ -345,11 +356,17 @@ IoMmuUnmap (
   }
 
   // Only prints errors if Event Queue is not empty and GError != 0
-  SmmuV3LogErrors (mSmmu);
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+  }
+
   return Status;
 
 Error:
-  SmmuV3LogErrors (mSmmu);
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+  }
+
   ASSERT_EFI_ERROR (Status);
   return Status;
 }
@@ -477,6 +494,7 @@ IoMmuSetAttribute (
 {
   EFI_STATUS      Status;
   IOMMU_MAP_INFO  *MapInfo;
+  UINT32          SmmuIndex;
 
   if ((This == NULL) || (Mapping == NULL) || ((IoMmuAccess & ~(EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)) != 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
@@ -487,7 +505,7 @@ IoMmuSetAttribute (
   MapInfo = (IOMMU_MAP_INFO *)Mapping;
 
   Status = UpdatePageTable (
-             mSmmu->PageTableRoot,
+             mIoMmu->SmmuInfo->PageTableRoot,
              MapInfo->PhysicalAddress,
              MapInfo->NumberOfBytes,
              PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS (IoMmuAccess),
@@ -500,11 +518,17 @@ IoMmuSetAttribute (
   }
 
   // Only prints errors if Event Queue is not empty and GError != 0
-  SmmuV3LogErrors (mSmmu);
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+  }
+
   return Status;
 
 Error:
-  SmmuV3LogErrors (mSmmu);
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+  }
+
   ASSERT_EFI_ERROR (Status);
   return Status;
 }

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -114,7 +114,7 @@ UpdateMapping (
   if ((Root == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (PhysicalAddress == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter.\n", __func__));
     Status = EFI_INVALID_PARAMETER;
-    goto Error;
+    goto End;
   }
 
   Status = EFI_SUCCESS;
@@ -129,7 +129,7 @@ UpdateMapping (
       if (NewPage == NULL) {
         DEBUG ((DEBUG_ERROR, "%a: Failed allocating page.\n", __func__));
         Status = EFI_OUT_OF_RESOURCES;
-        goto Error;
+        goto End;
       }
 
       ZeroMem ((VOID *)NewPage, EFI_PAGE_SIZE);
@@ -161,16 +161,15 @@ UpdateMapping (
     } else {
       Status = UpdateReadWriteFlags (Current, Flags, Index);
       if (EFI_ERROR (Status)) {
-        goto Error;
+        goto End;
       }
     }
   }
 
   ArmDataSynchronizationBarrier ();
   SpeculationBarrier ();
-  return Status;
 
-Error:
+End:
   ASSERT_EFI_ERROR (Status);
   return Status;
 }
@@ -208,7 +207,7 @@ UpdatePageTable (
   if ((Root == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (PhysicalAddress == 0) || (Bytes == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
     Status = EFI_INVALID_PARAMETER;
-    goto Error;
+    goto End;
   }
 
   CurPhysicalAddress = PhysicalAddress;
@@ -218,7 +217,7 @@ UpdatePageTable (
     Status = UpdateMapping (Root, CurPhysicalAddress, CurPhysicalAddress, Flags, Valid, SetReadWriteFlagsOnly);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to update page table mapping\n", __func__));
-      goto Error;
+      goto End;
     }
 
     CurPhysicalAddress += EFI_PAGE_SIZE;
@@ -230,14 +229,12 @@ UpdatePageTable (
       Status = SmmuV3TLBInvalidateAll (&mIoMmu->SmmuInfo[SmmuIndex]);
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
-        goto Error;
+        goto End;
       }
     }
   }
 
-  return Status;
-
-Error:
+End:
   ASSERT_EFI_ERROR (Status);
   return Status;
 }
@@ -282,14 +279,14 @@ IoMmuMap (
   {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
     Status = EFI_INVALID_PARAMETER;
-    goto Error;
+    goto End;
   }
 
   PhysicalAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
   Status          = UpdatePageTable (mIoMmu->SmmuInfo->PageTableRoot, PhysicalAddress, *NumberOfBytes, 0, TRUE, FALSE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to update page table.\n", __func__));
-    goto Error;
+    goto End;
   }
 
   // Allocate and fill the IOMMU_MAP_INFO structure with mapped information
@@ -301,14 +298,8 @@ IoMmuMap (
   MapInfo->PhysicalAddress = PhysicalAddress;
   *Mapping                 = MapInfo;
 
+End:
   // Only prints errors if Event Queue is not empty and GError != 0
-  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
-  }
-
-  return Status;
-
-Error:
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
     SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
   }
@@ -342,7 +333,7 @@ IoMmuUnmap (
   if ((This == NULL) || (Mapping == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
     Status = EFI_INVALID_PARAMETER;
-    goto Error;
+    goto End;
   }
 
   MapInfo = (IOMMU_MAP_INFO *)Mapping;
@@ -350,7 +341,7 @@ IoMmuUnmap (
   Status = UpdatePageTable (mIoMmu->SmmuInfo->PageTableRoot, MapInfo->PhysicalAddress, MapInfo->NumberOfBytes, 0, FALSE, FALSE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to update page table.\n", __func__));
-    goto Error;
+    goto End;
   }
 
   // Free the mapping structure allocated in IoMmuMap
@@ -358,14 +349,8 @@ IoMmuUnmap (
     FreePool (MapInfo);
   }
 
+End:
   // Only prints errors if Event Queue is not empty and GError != 0
-  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
-  }
-
-  return Status;
-
-Error:
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
     SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
   }
@@ -398,18 +383,16 @@ IoMmuFreeBuffer (
   if ((This == NULL) || (HostAddress == NULL) || (Pages == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
     Status = EFI_INVALID_PARAMETER;
-    goto Error;
+    goto End;
   }
 
   Status = gBS->FreePages ((EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress, Pages);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to free pages\n", __func__));
-    goto Error;
+    goto End;
   }
 
-  return Status;
-
-Error:
+End:
   ASSERT_EFI_ERROR (Status);
   return Status;
 }
@@ -451,7 +434,7 @@ IoMmuAllocateBuffer (
   if ((This == NULL) || (Pages == 0) || (HostAddress == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
     Status = EFI_INVALID_PARAMETER;
-    goto Error;
+    goto End;
   }
 
   Status = gBS->AllocatePages (
@@ -462,14 +445,12 @@ IoMmuAllocateBuffer (
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to allocate pages\n", __func__));
-    goto Error;
+    goto End;
   }
 
   *HostAddress = (VOID *)(UINTN)PhysicalAddress;
 
-  return Status;
-
-Error:
+End:
   ASSERT_EFI_ERROR (Status);
   return Status;
 }
@@ -502,7 +483,7 @@ IoMmuSetAttribute (
   if ((This == NULL) || (Mapping == NULL) || ((IoMmuAccess & ~(EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)) != 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
     Status = EFI_INVALID_PARAMETER;
-    goto Error;
+    goto End;
   }
 
   MapInfo = (IOMMU_MAP_INFO *)Mapping;
@@ -517,17 +498,11 @@ IoMmuSetAttribute (
              );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to update page table.\n", __func__));
-    goto Error;
+    goto End;
   }
 
+End:
   // Only prints errors if Event Queue is not empty and GError != 0
-  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
-  }
-
-  return Status;
-
-Error:
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
     SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
   }

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -117,6 +117,7 @@ UpdateMapping (
     goto Error;
   }
 
+  Status = EFI_SUCCESS;
   Current = Root;
 
   // Traverse the page table to the leaf level
@@ -224,11 +225,13 @@ UpdatePageTable (
   }
 
   // Invalidate TLBI Command
-  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-    Status = SmmuV3TLBInvalidateAll (&mIoMmu->SmmuInfo[SmmuIndex]);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
-      goto Error;
+  if (!Valid) {
+    for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+      Status = SmmuV3TLBInvalidateAll (&mIoMmu->SmmuInfo[SmmuIndex]);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
+        goto Error;
+      }
     }
   }
 

--- a/ArmPkg/Drivers/SmmuDxe/README.md
+++ b/ArmPkg/Drivers/SmmuDxe/README.md
@@ -21,7 +21,7 @@ PCI I/O Protocol
       ↓
 IOMMU Protocol
       ↓
-SMMU Hardware  
+SMMU Hardware
 ```
 
 ## IOMMU Protocol Integration
@@ -33,16 +33,16 @@ SMMU Hardware
 2. **IOMMU Protocol Setup**:
    - Implements the IOMMU protocol:
 
-      ```c
-      struct _EDKII_IOMMU_PROTOCOL {
-        UINT64                         Revision;
-        EDKII_IOMMU_SET_ATTRIBUTE      SetAttribute;
-        EDKII_IOMMU_MAP                Map;
-        EDKII_IOMMU_UNMAP              Unmap;
-        EDKII_IOMMU_ALLOCATE_BUFFER    AllocateBuffer;
-        EDKII_IOMMU_FREE_BUFFER        FreeBuffer;
-      };
-      ```
+     ```c
+     struct _EDKII_IOMMU_PROTOCOL {
+       UINT64                         Revision;
+       EDKII_IOMMU_SET_ATTRIBUTE      SetAttribute;
+       EDKII_IOMMU_MAP                Map;
+       EDKII_IOMMU_UNMAP              Unmap;
+       EDKII_IOMMU_ALLOCATE_BUFFER    AllocateBuffer;
+       EDKII_IOMMU_FREE_BUFFER        FreeBuffer;
+     };
+     ```
 
    - Configures IOMMU page tables with PageTableInit()
 
@@ -53,18 +53,18 @@ SMMU Hardware
 
 1. **IoMmu Map**:
 
-    ```c
-    EFI_STATUS
-    EFIAPI
-    IoMmuMap (
-      IN     EDKII_IOMMU_PROTOCOL   *This,
-      IN     EDKII_IOMMU_OPERATION  Operation,
-      IN     VOID                   *HostAddress,
-      IN OUT UINTN                  *NumberOfBytes,
-      OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
-      OUT    VOID                   **Mapping
-      );
-    ```
+   ```c
+   EFI_STATUS
+   EFIAPI
+   IoMmuMap (
+     IN     EDKII_IOMMU_PROTOCOL   *This,
+     IN     EDKII_IOMMU_OPERATION  Operation,
+     IN     VOID                   *HostAddress,
+     IN OUT UINTN                  *NumberOfBytes,
+     OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
+     OUT    VOID                   **Mapping
+     );
+   ```
 
 - Sets access permissions based on operation type:
   - BusMasterRead: READ access
@@ -83,14 +83,14 @@ SMMU Hardware
 
 2. **IoMmu Unmap**:
 
-    ```c
-    EFI_STATUS
-    EFIAPI
-    IoMmuUnmap (
-      IN  EDKII_IOMMU_PROTOCOL  *This,
-      IN  VOID                  *Mapping
-      );
-    ```
+   ```c
+   EFI_STATUS
+   EFIAPI
+   IoMmuUnmap (
+     IN  EDKII_IOMMU_PROTOCOL  *This,
+     IN  VOID                  *Mapping
+     );
+   ```
 
    - Invalidates mapping in Page Table
    - Invalidates TLB entries
@@ -236,16 +236,27 @@ Potential improvements:
 - Intel IOMMU for DMA protection in UEFI <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-whitepaper-using-iommu-for-dma-protection-in-uefi.pdf>
 - IORT documentation <https://developer.arm.com/documentation/den0049/latest/>
 
-## Integration Instructions
+## Platform Integration Instructions
 
-Integration with Qemu:
+Generic Platform Integration:
 
-- SMMU is supported on Qemu but on v9.1.50+ <https://gitlab.com/qemu-project/qemu>
+- The Platform will construct a SMMU config HOB and publish for SmmuDxe to consume:
+- Append the IORT structure to this struct and update the fields accordingly.
 
-Platform Integration:
+  ```c
+  typedef struct _SMMU_CONFIG {
+    UINT32    VersionMajor;
+    UINT32    VersionMinor;
+    UINT32    IortSize;
+    UINT32    IortOffset;
+  } SMMU_CONFIG;
+  ```
 
-- The Platform will construct a SMMU config HOB in PEI:
 - Essentialy the same as IORT we want to publish
 - The SMMU expects the entire IORT data to be passed into a HOB gSmmuConfigHobGuid.
 - The platform must create the IORT structure and create gSmmuConfigHobGuid with that data using BuildGuidDataHob.
 - This structure is consumed by SmmuDxe to configure the SMMU hardware
+
+Integration with Qemu:
+
+- SMMU is supported on Qemu but on v9.1.50+ <https://gitlab.com/qemu-project/qemu>

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -993,6 +993,7 @@ InitializeSmmuDxe (
 {
   EFI_STATUS               Status;
   EFI_EVENT                Event;
+  UINT32                   SmmuIndex;
   EFI_ACPI_TABLE_PROTOCOL  *AcpiTable;
   SMMU_CONFIG              *SmmuConfig;
   PAGE_TABLE               *PageTableRoot;
@@ -1069,8 +1070,8 @@ InitializeSmmuDxe (
   }
 
   // Configure SMMUv3 hardware
-  for (UINT32 i = 0; i < mIoMmu->SmmuCount; i++) {
-    Status = SmmuV3Configure (&mIoMmu->SmmuInfo[i], PageTableRoot);
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    Status = SmmuV3Configure (&mIoMmu->SmmuInfo[SmmuIndex], PageTableRoot);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to configure SMMUv3 hardware\n", __func__));
       goto Error;

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -29,8 +29,8 @@
 #include "IoMmu.h"
 #include "SmmuV3.h"
 
-// Global SMMU instance
-SMMU_INFO  *mSmmu;
+// Global IOMMU/SMMU instance
+IOMMU_CONFIG  *mIoMmu;
 
 /**
   Calculate and update the checksum of an ACPI table.
@@ -69,7 +69,8 @@ AcpiPlatformChecksum (
   Add the IORT ACPI table.
 
   @param [in]  AcpiTableProtocol    Pointer to the ACPI Table Protocol.
-  @param [in]  SmmuConfig           Pointer to the SMMU configuration.
+  @param [in]  IortData             Pointer to the IORT.
+  @param [in]  IortSize             Size of the IORT table.
 
   @retval EFI_SUCCESS               Success.
   @retval EFI_OUT_OF_RESOURCES      Out of resources.
@@ -79,30 +80,23 @@ STATIC
 EFI_STATUS
 AddIortTable (
   IN EFI_ACPI_TABLE_PROTOCOL  *AcpiTable,
-  IN SMMU_CONFIG              *SmmuConfig
+  IN VOID                     *IortData,
+  IN UINT32                   IortSize
   )
 {
   EFI_STATUS            Status;
   UINTN                 TableHandle;
-  UINT32                TableSize;
   EFI_PHYSICAL_ADDRESS  PageAddress;
-  UINT8                 *New;
 
-  if ((AcpiTable == NULL) || (SmmuConfig == NULL)) {
+  if ((AcpiTable == NULL) || (IortData == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
-  // Calculate the new table size based on the number of nodes in SMMU_CONFIG struct
-  TableSize = sizeof (SmmuConfig->Config.Iort) +
-              sizeof (SmmuConfig->Config.ItsNode) +
-              sizeof (SmmuConfig->Config.SmmuNode) +
-              sizeof (SmmuConfig->Config.RcNode);
-
   Status = gBS->AllocatePages (
                   AllocateAnyPages,
                   EfiACPIReclaimMemory,
-                  EFI_SIZE_TO_PAGES (TableSize),
+                  EFI_SIZE_TO_PAGES (IortSize),
                   &PageAddress
                   );
   if (EFI_ERROR (Status)) {
@@ -110,27 +104,10 @@ AddIortTable (
     return EFI_OUT_OF_RESOURCES;
   }
 
-  New = (UINT8 *)(UINTN)PageAddress;
-  ZeroMem (New, TableSize);
+  ZeroMem ((VOID *)(UINTN)PageAddress, EFI_SIZE_TO_PAGES (IortSize) * EFI_PAGE_SIZE);
+  CopyMem ((VOID *)(UINTN)PageAddress, IortData, IortSize);
 
-  // Add the ACPI Description table header
-  CopyMem (New, &SmmuConfig->Config.Iort, sizeof (SmmuConfig->Config.Iort));
-  ((EFI_ACPI_DESCRIPTION_HEADER *)New)->Length = TableSize;
-  New                                         += sizeof (SmmuConfig->Config.Iort);
-
-  // ITS Node
-  CopyMem (New, &SmmuConfig->Config.ItsNode, sizeof (SmmuConfig->Config.ItsNode));
-  New += sizeof (SmmuConfig->Config.ItsNode);
-
-  // SMMUv3 Node
-  CopyMem (New, &SmmuConfig->Config.SmmuNode, sizeof (SmmuConfig->Config.SmmuNode));
-  New += sizeof (SmmuConfig->Config.SmmuNode);
-
-  // RC Node
-  CopyMem (New, &SmmuConfig->Config.RcNode, sizeof (SmmuConfig->Config.RcNode));
-  New += sizeof (SmmuConfig->Config.RcNode);
-
-  Status = AcpiPlatformChecksum ((UINT8 *)(UINTN)PageAddress, TableSize);
+  Status = AcpiPlatformChecksum ((UINT8 *)(UINTN)PageAddress, IortSize);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to calculate checksum for IORT table\n", __func__));
     return Status;
@@ -139,7 +116,7 @@ AddIortTable (
   Status = AcpiTable->InstallAcpiTable (
                         AcpiTable,
                         (EFI_ACPI_COMMON_HEADER *)(UINTN)PageAddress,
-                        TableSize,
+                        IortSize,
                         &TableHandle
                         );
   if (EFI_ERROR (Status)) {
@@ -320,7 +297,7 @@ SmmuV3FreeQueue (
   Build the stream table for SMMUv3.
 
   @param [in]  SmmuInfo       Pointer to the SMMU_INFO structure.
-  @param [in]  SmmuConfig     Pointer to the SMMU configuration.
+  @param [in]  StreamId       Stream ID.
   @param [out] StreamEntry    Pointer to the stream table entry.
 
   @retval EFI_SUCCESS         Success.
@@ -328,9 +305,9 @@ SmmuV3FreeQueue (
 **/
 STATIC
 EFI_STATUS
-SmmuV3BuildStreamTable (
+SmmuV3BuildStreamTableEntry (
   IN SMMU_INFO                   *SmmuInfo,
-  IN SMMU_CONFIG                 *SmmuConfig,
+  IN UINT32                      StreamId,
   OUT SMMUV3_STREAM_TABLE_ENTRY  *StreamEntry
   )
 {
@@ -346,17 +323,17 @@ SmmuV3BuildStreamTable (
   UINT8        DACS;
   UINT64       S2Sl0;
 
-  if ((SmmuInfo == NULL) || (SmmuConfig == NULL) || (StreamEntry == NULL)) {
+  if ((SmmuInfo == NULL) || (SmmuInfo->StreamEntryConfig == NULL) || (StreamEntry == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
-  IortCohac = SmmuConfig->Config.SmmuNode.SmmuNode.Flags & EFI_ACPI_IORT_SMMUv3_FLAG_COHAC_OVERRIDE; // Cohac override flag
-  CCA       = SmmuConfig->Config.RcNode.RcNode.CacheCoherent;                                        // Cache Coherent Attribute
-  CPM       = SmmuConfig->Config.RcNode.RcNode.MemoryAccessFlags & SMMUV3_STREAM_TABLE_ENTRY_CPM;    // Coherent Path to Memory
+  IortCohac = SmmuInfo->Flags & EFI_ACPI_IORT_SMMUv3_FLAG_COHAC_OVERRIDE;                              // Cohac override flag
+  CCA       = SmmuInfo->StreamEntryConfig[StreamId].CacheCoherentAttribute;                            // Cache Coherent Attribute
+  CPM       = SmmuInfo->StreamEntryConfig[StreamId].MemoryAccessFlags & SMMUV3_STREAM_TABLE_ENTRY_CPM; // Coherent Path to Memory
 
   // Device attributes are Cacheable and Inner-Shareable
-  DACS = (SmmuConfig->Config.RcNode.RcNode.MemoryAccessFlags & SMMUV3_STREAM_TABLE_ENTRY_DACS) >> 1;      // Shift by 1 to isolate DACS bit.
+  DACS = (SmmuInfo->StreamEntryConfig[StreamId].MemoryAccessFlags & SMMUV3_STREAM_TABLE_ENTRY_DACS) >> 1;      // Shift by 1 to isolate DACS bit.
 
   ZeroMem ((VOID *)StreamEntry, sizeof (SMMUV3_STREAM_TABLE_ENTRY));
 
@@ -471,7 +448,6 @@ SmmuV3BuildStreamTable (
   This function uses the linear stream table.
 
   @param [in]  SmmuInfo       Pointer to the SMMU_INFO structure.
-  @param [in]  SmmuConfig     Pointer to the SMMU configuration.
   @param [out] Log2Size       Pointer to store the log2 size of the stream table.
   @param [out] Size           Pointer to store the size of the stream table.
 
@@ -480,10 +456,9 @@ SmmuV3BuildStreamTable (
 STATIC
 SMMUV3_STREAM_TABLE_ENTRY *
 SmmuV3AllocateStreamTable (
-  IN SMMU_INFO    *SmmuInfo,
-  IN SMMU_CONFIG  *SmmuConfig,
-  OUT UINT32      *Log2Size,
-  OUT UINT32      *Size
+  IN SMMU_INFO  *SmmuInfo,
+  OUT UINT32    *Log2Size,
+  OUT UINT32    *Size
   )
 {
   UINT32  MaxStreamId;
@@ -492,13 +467,13 @@ SmmuV3AllocateStreamTable (
   UINTN   Pages;
   VOID    *AllocatedAddress;
 
-  if ((SmmuInfo == NULL) || (SmmuConfig == NULL) || (Log2Size == NULL) || (Size == NULL)) {
+  if ((SmmuInfo == NULL) || (Log2Size == NULL) || (Size == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
     return NULL;
   }
 
   // The max stream id is calculated as the output base + the number of stream ids
-  MaxStreamId      = SmmuConfig->Config.RcNode.RcIdMap.OutputBase + SmmuConfig->Config.RcNode.RcIdMap.NumIds;
+  MaxStreamId      = SmmuInfo->StreamTableEntryMax;
   SidMsb           = HighBitSet32 (MaxStreamId);
   *Log2Size        = SidMsb + 1;
   *Size            = SMMUV3_LINEAR_STREAM_TABLE_SIZE_FROM_LOG2 (*Log2Size);
@@ -543,8 +518,8 @@ SmmuV3FreeStreamTable (
   <https://developer.arm.com/documentation/109242/0100/Programming-the-SMMU/Minimum-configuration>
   <https://developer.arm.com/documentation/ihi0070/latest/>
 
-  @param [in] SmmuInfo    Pointer to the SMMU_INFO structure.
-  @param [in] SmmuConfig  Pointer to the SMMU configuration.
+  @param [in] SmmuInfo        Pointer to the SMMU_INFO structure.
+  @param [in] PageTableRoot   Pointer to the page table root.
 
   @retval EFI_SUCCESS            Success.
   @retval EFI_INVALID_PARAMETER  Invalid parameter.
@@ -556,8 +531,8 @@ SmmuV3FreeStreamTable (
 STATIC
 EFI_STATUS
 SmmuV3Configure (
-  IN SMMU_INFO    *SmmuInfo,
-  IN SMMU_CONFIG  *SmmuConfig
+  IN SMMU_INFO   *SmmuInfo,
+  IN PAGE_TABLE  *PageTableRoot
   )
 {
   EFI_STATUS                 Status;
@@ -572,7 +547,6 @@ SmmuV3Configure (
   SMMUV3_STREAM_TABLE_ENTRY  *StreamTablePtr;
   SMMUV3_CMDQ_BASE           CommandQueueBase;
   SMMUV3_EVENTQ_BASE         EventQueueBase;
-  SMMUV3_STREAM_TABLE_ENTRY  TemplateStreamEntry;
   SMMUV3_CR0                 Cr0;
   SMMUV3_CR1                 Cr1;
   SMMUV3_CR2                 Cr2;
@@ -582,14 +556,14 @@ SmmuV3Configure (
   VOID                       *CommandQueue;
   VOID                       *EventQueue;
 
-  if ((SmmuInfo == NULL) || (SmmuConfig == NULL)) {
+  if ((SmmuInfo == NULL) || (PageTableRoot == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
   // Set ReadWriteAllocationHint based on the COHAC_OVERRIDE flag.
   // These hints are applied to the allocated Stream Table, Command Queue, and Event Queue.
-  if ((SmmuConfig->Config.SmmuNode.SmmuNode.Flags & EFI_ACPI_IORT_SMMUv3_FLAG_COHAC_OVERRIDE) != 0) {
+  if ((SmmuInfo->Flags & EFI_ACPI_IORT_SMMUv3_FLAG_COHAC_OVERRIDE) != 0) {
     ReadWriteAllocationHint = 0x1;
   } else {
     ReadWriteAllocationHint = 0x0;
@@ -609,7 +583,7 @@ SmmuV3Configure (
   }
 
   // Allocate Linear Stream Table
-  StreamTablePtr = SmmuV3AllocateStreamTable (SmmuInfo, SmmuConfig, &StreamTableLog2Size, &StreamTableSize);
+  StreamTablePtr = SmmuV3AllocateStreamTable (SmmuInfo, &StreamTableLog2Size, &StreamTableSize);
   if (StreamTablePtr == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Error allocating stream table\n", __func__));
     Status = EFI_OUT_OF_RESOURCES;
@@ -620,23 +594,20 @@ SmmuV3Configure (
   SmmuInfo->StreamTableSize     = StreamTableSize;
   SmmuInfo->StreamTableLog2Size = StreamTableLog2Size;
 
-  SmmuInfo->PageTableRoot = PageTableInit ();
+  SmmuInfo->PageTableRoot = PageTableRoot;
   if (SmmuInfo->PageTableRoot == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Error initializing Page Table\n", __func__));
     Status = EFI_OUT_OF_RESOURCES;
     goto End;
   }
 
-  // Build default STE template
-  Status = SmmuV3BuildStreamTable (SmmuInfo, SmmuConfig, &TemplateStreamEntry);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Error building stream table\n", __func__));
-    goto End;
-  }
-
   // Load default STE values
-  for (Index = 0; Index < SMMUV3_COUNT_FROM_LOG2 (StreamTableLog2Size); Index++) {
-    CopyMem (&StreamTablePtr[Index], &TemplateStreamEntry, sizeof (SMMUV3_STREAM_TABLE_ENTRY));
+  for (Index = 0; Index < SmmuInfo->StreamTableEntryMax; Index++) {
+    Status = SmmuV3BuildStreamTableEntry (SmmuInfo, Index, &StreamTablePtr[Index]);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Error building stream table\n", __func__));
+      goto End;
+    }
   }
 
   Status = SmmuV3AllocateCommandQueue (SmmuInfo, &CommandQueueLog2Size, &CommandQueue);
@@ -696,7 +667,7 @@ SmmuV3Configure (
   // Configure CR1
   Cr1.AsUINT32  = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_CR1);
   Cr1.AsUINT32 &= ~SMMUV3_CR1_VALID_MASK;
-  if ((SmmuConfig->Config.SmmuNode.SmmuNode.Flags & EFI_ACPI_IORT_SMMUv3_FLAG_COHAC_OVERRIDE) != 0) {
+  if ((SmmuInfo->Flags & EFI_ACPI_IORT_SMMUv3_FLAG_COHAC_OVERRIDE) != 0) {
     Cr1.QueueIc = ARM64_RGNCACHEATTR_WRITEBACK_WRITEALLOCATE; // WBC
     Cr1.QueueOc = ARM64_RGNCACHEATTR_WRITEBACK_WRITEALLOCATE; // WBC
     Cr1.QueueSh = ARM64_SHATTR_INNER_SHAREABLE;               // Inner-shareable
@@ -865,28 +836,23 @@ CheckSmmuConfigVersion (
 }
 
 /**
-  Initialize the SMMU_INFO structure.
+  Initialize the IOMMU_CONFIG structure.
 
-  @param [in] SmmuBase The base address of the SMMU.
 
-  @retval Pointer to the allocated SMMU_INFO structure, or NULL on failure.
+  @retval Pointer to the allocated IOMMU_CONFIG structure, or NULL on failure.
 **/
-STATIC
-SMMU_INFO *
-SmmuInit (
-  IN UINT64  SmmuBase
+EFI_STATUS
+IoMmuConfigInit (
+  OUT IOMMU_CONFIG  **IoMmu
   )
 {
-  SMMU_INFO  *SmmuInfo;
-
-  if (SmmuBase == 0) {
-    DEBUG ((DEBUG_ERROR, "%a: Invalid SMMU base address\n", __func__));
-    return NULL;
+  *IoMmu = (IOMMU_CONFIG *)AllocateZeroPool (sizeof (IOMMU_CONFIG));
+  if (*IoMmu == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate IOMMU_CONFIG structure\n", __func__));
+    return EFI_OUT_OF_RESOURCES;
   }
 
-  SmmuInfo           = (SMMU_INFO *)AllocateZeroPool (sizeof (SMMU_INFO));
-  SmmuInfo->SmmuBase = SmmuBase;
-  return SmmuInfo;
+  return EFI_SUCCESS;
 }
 
 /**
@@ -897,48 +863,57 @@ SmmuInit (
 **/
 STATIC
 VOID
-SmmuDeInit (
-  IN SMMU_INFO  *SmmuInfo
+IoMmuDeInit (
+  IN IOMMU_CONFIG  *IoMmu
   )
 {
   EFI_STATUS  Status;
+  UINT32      SmmuIndex;
 
-  if (SmmuInfo == NULL) {
+  if (IoMmu == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: SMMU_INFO structure is NULL\n", __func__));
     return;
   }
 
-  Status = SmmuV3DisableTranslation (SmmuInfo->SmmuBase);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to disable SMMUv3 translation\n", __func__));
+  for (SmmuIndex = 0; SmmuIndex < IoMmu->SmmuCount; SmmuIndex++) {
+    Status = SmmuV3DisableTranslation (IoMmu->SmmuInfo[SmmuIndex].SmmuBase);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to disable SMMUv3 translation 0x%llx\n", __func__, IoMmu->SmmuInfo[SmmuIndex].SmmuBase));
+    }
+
+    Status = SmmuV3GlobalAbort (IoMmu->SmmuInfo[SmmuIndex].SmmuBase);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to global abort SMMUv3 0x%llx\n", __func__, IoMmu->SmmuInfo[SmmuIndex].SmmuBase));
+    }
+
+    if (IoMmu->SmmuInfo[SmmuIndex].PageTableRoot != NULL) {
+      PageTableDeInit (0, IoMmu->SmmuInfo[SmmuIndex].PageTableRoot);
+      IoMmu->SmmuInfo->PageTableRoot = NULL;
+    }
+
+    if (IoMmu->SmmuInfo[SmmuIndex].StreamEntryConfig != NULL) {
+      FreePool (IoMmu->SmmuInfo[SmmuIndex].StreamEntryConfig);
+      IoMmu->SmmuInfo[SmmuIndex].StreamEntryConfig = NULL;
+    }
+
+    if (IoMmu->SmmuInfo[SmmuIndex].StreamTable != NULL) {
+      SmmuV3FreeStreamTable (IoMmu->SmmuInfo[SmmuIndex].StreamTable, IoMmu->SmmuInfo[SmmuIndex].StreamTableSize);
+      IoMmu->SmmuInfo[SmmuIndex].StreamTable = NULL;
+    }
+
+    if (IoMmu->SmmuInfo[SmmuIndex].CommandQueue != NULL) {
+      SmmuV3FreeQueue (IoMmu->SmmuInfo[SmmuIndex].CommandQueue, IoMmu->SmmuInfo[SmmuIndex].CommandQueueLog2Size);
+      IoMmu->SmmuInfo[SmmuIndex].CommandQueue = NULL;
+    }
+
+    if (IoMmu->SmmuInfo[SmmuIndex].EventQueue != NULL) {
+      SmmuV3FreeQueue (IoMmu->SmmuInfo[SmmuIndex].EventQueue, IoMmu->SmmuInfo[SmmuIndex].EventQueueLog2Size);
+      IoMmu->SmmuInfo[SmmuIndex].EventQueue = NULL;
+    }
   }
 
-  Status = SmmuV3GlobalAbort (SmmuInfo->SmmuBase);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to global abort SMMUv3\n", __func__));
-  }
-
-  if (SmmuInfo->PageTableRoot != NULL) {
-    PageTableDeInit (0, SmmuInfo->PageTableRoot);
-    SmmuInfo->PageTableRoot = NULL;
-  }
-
-  if (SmmuInfo->StreamTable != NULL) {
-    SmmuV3FreeStreamTable (SmmuInfo->StreamTable, SmmuInfo->StreamTableSize);
-    SmmuInfo->StreamTable = NULL;
-  }
-
-  if (SmmuInfo->CommandQueue != NULL) {
-    SmmuV3FreeQueue (SmmuInfo->CommandQueue, SmmuInfo->CommandQueueLog2Size);
-    SmmuInfo->CommandQueue = NULL;
-  }
-
-  if (SmmuInfo->EventQueue != NULL) {
-    SmmuV3FreeQueue (SmmuInfo->EventQueue, SmmuInfo->EventQueueLog2Size);
-    SmmuInfo->EventQueue = NULL;
-  }
-
-  FreePool (SmmuInfo);
+  FreePool (IoMmu->SmmuInfo);
+  FreePool (IoMmu);
 }
 
 /**
@@ -956,6 +931,7 @@ SmmuV3ExitBootServices (
 {
   EFI_STATUS  Status;
   EFI_TPL     OldTpl;
+  UINT32      SmmuIndex;
 
   if (Event == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Event\n", __func__));
@@ -963,24 +939,27 @@ SmmuV3ExitBootServices (
     return;
   }
 
-  if (mSmmu == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: SMMU_INFO structure is NULL\n", __func__));
-    ASSERT (mSmmu != NULL);
+  if ((mIoMmu == NULL) || (mIoMmu->SmmuInfo == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: IOMMU_CONFIG/SMMU_INFO structure is NULL\n", __func__));
+    ASSERT (mIoMmu != NULL);
+    ASSERT (mIoMmu->SmmuInfo != NULL);
     return;
   }
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
-  Status = SmmuV3DisableTranslation (mSmmu->SmmuBase);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to disable smmu translation.\n", __func__));
-    ASSERT_EFI_ERROR (Status);
-  }
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    Status = SmmuV3DisableTranslation (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to disable smmu translation.\n", __func__));
+      ASSERT_EFI_ERROR (Status);
+    }
 
-  Status = SmmuV3SetGlobalBypass (mSmmu->SmmuBase);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to set global bypass.\n", __func__));
-    ASSERT_EFI_ERROR (Status);
+    Status = SmmuV3SetGlobalBypass (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to set global bypass.\n", __func__));
+      ASSERT_EFI_ERROR (Status);
+    }
   }
 
   gBS->RestoreTPL (OldTpl);
@@ -1016,6 +995,8 @@ InitializeSmmuDxe (
   EFI_EVENT                Event;
   EFI_ACPI_TABLE_PROTOCOL  *AcpiTable;
   SMMU_CONFIG              *SmmuConfig;
+  PAGE_TABLE               *PageTableRoot;
+  VOID                     *IortData;
 
   // Get SMMU configuration data from HOB
   SmmuConfig = GetSmmuConfigHobData ();
@@ -1056,25 +1037,44 @@ InitializeSmmuDxe (
     return Status;
   }
 
-  // Get SMMUv3 base address from Smmu Config HOB
-  mSmmu = SmmuInit (SmmuConfig->Config.SmmuNode.SmmuNode.Base);
-  if (mSmmu == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate SMMU_INFO structure\n", __func__));
-    return EFI_OUT_OF_RESOURCES;
+  Status = IoMmuConfigInit (&mIoMmu);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to initialize IoMmu Config\n", __func__));
+    return Status;
   }
 
+  IortData = (VOID *)((UINT8 *)SmmuConfig + SmmuConfig->IortOffset);
+
+  Status = SmmuV3ParseIort (IortData, &mIoMmu->SmmuInfo, &mIoMmu->SmmuCount);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to parse IORT for SMMU\n", __func__));
+    return EFI_NOT_FOUND;
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "%a: Found %u SMMUs\n", __func__, mIoMmu->SmmuCount));
+
   // Add IORT Table
-  Status = AddIortTable (AcpiTable, SmmuConfig);
+  Status = AddIortTable (AcpiTable, IortData, SmmuConfig->IortSize);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to add IORT table\n", __func__));
     goto Error;
   }
 
-  // Configure SMMUv3 hardware
-  Status = SmmuV3Configure (mSmmu, SmmuConfig);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to configure SMMUV3 hardware\n", __func__));
+  // Global Page Table until TODO: IoMmu Protocol V2 is implemented
+  PageTableRoot = PageTableInit ();
+  if (PageTableRoot == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to initialize Page Table\n", __func__));
+    Status = EFI_OUT_OF_RESOURCES;
     goto Error;
+  }
+
+  // Configure SMMUv3 hardware
+  for (UINT32 i = 0; i < mIoMmu->SmmuCount; i++) {
+    Status = SmmuV3Configure (&mIoMmu->SmmuInfo[i], PageTableRoot);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to configure SMMUv3 hardware\n", __func__));
+      goto Error;
+    }
   }
 
   // Initialize IoMmu Protocol
@@ -1089,7 +1089,7 @@ InitializeSmmuDxe (
   return Status;
 
 Error:
-  SmmuDeInit (mSmmu);
-  mSmmu = NULL;
+  IoMmuDeInit (mIoMmu);
+  mIoMmu = NULL;
   return Status;
 }

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -1049,7 +1049,7 @@ InitializeSmmuDxe (
   Status = SmmuV3ParseIort (IortData, &mIoMmu->SmmuInfo, &mIoMmu->SmmuCount);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to parse IORT for SMMU\n", __func__));
-    return EFI_NOT_FOUND;
+    return Status;
   }
 
   DEBUG ((DEBUG_VERBOSE, "%a: Found %u SMMUs\n", __func__, mIoMmu->SmmuCount));

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -14,6 +14,7 @@
 
 #include <Register/SmmuV3Registers.h>
 #include <Uefi/UefiBaseType.h>
+#include <IndustryStandard/IoRemappingTable.h>
 
 // Number of levels in the page table
 #define PAGE_TABLE_DEPTH  4
@@ -151,24 +152,38 @@ typedef struct _PAGE_TABLE {
   PAGE_TABLE_ENTRY    Entries[PAGE_TABLE_SIZE];
 } PAGE_TABLE;
 
+typedef struct _SMMU_STREAM_ENTRY_CONFIG {
+  UINT32    CacheCoherentAttribute;
+  UINT32    MemoryAccessFlags;
+} SMMU_STREAM_ENTRY_CONFIG;
+
 // General SMMU Information for a SMMU instance
 typedef struct _SMMU_INFO {
-  PAGE_TABLE    *PageTableRoot;
-  VOID          *StreamTable;
-  VOID          *CommandQueue;
-  VOID          *EventQueue;
-  UINT8         TranslationStartingLevel;
-  UINT64        SmmuBase;
-  UINT32        StreamTableSize;
-  UINT32        CommandQueueSize;
-  UINT32        EventQueueSize;
-  UINT32        StreamTableLog2Size;
-  UINT32        CommandQueueLog2Size;
-  UINT32        EventQueueLog2Size;
+  PAGE_TABLE                  *PageTableRoot;
+  VOID                        *StreamTable;
+  VOID                        *CommandQueue;
+  VOID                        *EventQueue;
+  SMMU_STREAM_ENTRY_CONFIG    *StreamEntryConfig;
+  UINT8                       TranslationStartingLevel;
+  UINT64                      SmmuBase;
+  UINT32                      StreamTableSize;
+  UINT32                      StreamTableEntryMax;
+  UINT32                      Flags;
+  UINT32                      CommandQueueSize;
+  UINT32                      EventQueueSize;
+  UINT32                      StreamTableLog2Size;
+  UINT32                      CommandQueueLog2Size;
+  UINT32                      EventQueueLog2Size;
 } SMMU_INFO;
 
-// SMMU instance
-extern SMMU_INFO  *mSmmu;
+// IoMmu configuration structure
+typedef struct _IOMMU_CONFIG {
+  UINT32       SmmuCount;
+  SMMU_INFO    *SmmuInfo;
+} IOMMU_CONFIG;
+
+// IOMMU/SMMU instance
+extern IOMMU_CONFIG  *mIoMmu;
 
 /**
   Decode the address width from the given address size type.
@@ -422,6 +437,22 @@ SmmuV3SendCommand (
 EFI_STATUS
 SmmuV3TLBInvalidateAll (
   IN SMMU_INFO  *SmmuInfo
+  );
+
+/**
+ * Parse IORT table and extract SMMU information
+ *
+ * @param[in]  IortTable    Pointer to the IORT table
+ * @param[out] SmmuInfo     Pointer to store the array of SMMU_INFO structures
+ * @param[out] SmmuCount    Pointer to store the number of SMMU nodes found
+ *
+ * @return EFI_SUCCESS on success, or an error status code on failure
+ */
+EFI_STATUS
+SmmuV3ParseIort (
+  IN  VOID       *IortTable,
+  OUT SMMU_INFO  **SmmuInfo,
+  OUT UINT32     *SmmuCount
   );
 
 #endif

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -446,7 +446,11 @@ SmmuV3TLBInvalidateAll (
  * @param[out] SmmuInfo     Pointer to store the array of SMMU_INFO structures
  * @param[out] SmmuCount    Pointer to store the number of SMMU nodes found
  *
- * @return EFI_SUCCESS on success, or an error status code on failure
+ * @return EFI_SUCCESS on success
+ * @return EFI_INVALID_PARAMETER if any parameter is NULL
+ * @return EFI_OUT_OF_RESOURCES if memory allocation fails
+ * @return EFI_NOT_FOUND if no SMMU nodes are found
+ * @return EFI_UNSUPPORTED if the IORT table is not supported
  */
 EFI_STATUS
 SmmuV3ParseIort (

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -1209,6 +1209,9 @@ SmmuV3ParseIort (
     return EFI_INVALID_PARAMETER;
   }
 
+  SmmuInfoArray = NULL;
+  SmmuNodePtrs  = NULL;
+
   // Cast the void* to the IORT structure
   Iort = (EFI_ACPI_6_0_IO_REMAPPING_TABLE *)IortTable;
 
@@ -1254,15 +1257,16 @@ SmmuV3ParseIort (
   SmmuInfoArray = AllocateZeroPool (SmmuNodeCount * sizeof (SMMU_INFO));
   if (SmmuInfoArray == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to allocate memory for SMMU info array\n", __func__));
-    return EFI_OUT_OF_RESOURCES;
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Error;
   }
 
   // Allocate memory for SMMU node pointers (for output reference lookup)
   SmmuNodePtrs = AllocateZeroPool (SmmuNodeCount * sizeof (VOID *));
   if (SmmuNodePtrs == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to allocate memory for SMMU node pointers\n", __func__));
-    FreePool (SmmuInfoArray);
-    return EFI_OUT_OF_RESOURCES;
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Error;
   }
 
   // Second pass: collect SMMU information
@@ -1306,7 +1310,19 @@ SmmuV3ParseIort (
   return Status;
 
 Error:
-  FreePool (SmmuInfoArray);
-  FreePool (SmmuNodePtrs);
+  if (SmmuInfoArray != NULL) {
+    for (SmmuIndex = 0; SmmuIndex < SmmuNodeCount; SmmuIndex++) {
+      if (SmmuInfoArray[SmmuIndex].StreamEntryConfig != NULL) {
+        FreePool (SmmuInfoArray[SmmuIndex].StreamEntryConfig);
+      }
+    }
+
+    FreePool (SmmuInfoArray);
+  }
+
+  if (SmmuNodePtrs != NULL) {
+    FreePool (SmmuNodePtrs);
+  }
+
   return Status;
 }

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -13,6 +13,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/IoLib.h>
+#include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiDriverEntryPoint.h>
@@ -867,5 +868,445 @@ SmmuV3TLBInvalidateAll (
 
   ArmDataSynchronizationBarrier ();
 
+  return Status;
+}
+
+/**
+ * Get SMMUV3 node information from the IORT table.
+ *
+ * @param [in]  IortTable      Pointer to the IORT table.
+ * @param [out] SmmuInfoArray  Pointer to the array of SMMU_INFO structures.
+ * @param [out] SmmuNodePtrs   Pointer to the array of SMMU node pointers.
+ *
+ * @retval EFI_SUCCESS            Success.
+ * @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+ *
+ */
+EFI_STATUS
+SmmuV3GetNodeInfo (
+  IN  VOID       *IortTable,
+  OUT SMMU_INFO  *SmmuInfoArray,
+  OUT VOID       **SmmuNodePtrs
+  )
+{
+  EFI_ACPI_6_0_IO_REMAPPING_TABLE       *Iort;
+  EFI_ACPI_6_0_IO_REMAPPING_NODE        *Node;
+  EFI_ACPI_6_0_IO_REMAPPING_SMMU3_NODE  *SmmuNode;
+  UINT32                                SmmuIndex;
+  UINT32                                Count;
+
+  if ((IortTable == NULL) || (SmmuInfoArray == NULL) || (SmmuNodePtrs == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid parameters\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Iort      = (EFI_ACPI_6_0_IO_REMAPPING_TABLE *)IortTable;
+  Node      = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Iort + Iort->NodeOffset);
+  SmmuIndex = 0;
+
+  for (Count = 0; Count < Iort->NumNodes; Count++) {
+    if (Node->Type == EFI_ACPI_IORT_TYPE_SMMUv3) {
+      SmmuNode                                     = (EFI_ACPI_6_0_IO_REMAPPING_SMMU3_NODE *)Node;
+      SmmuInfoArray[SmmuIndex].SmmuBase            = SmmuNode->Base;
+      SmmuInfoArray[SmmuIndex].Flags               = SmmuNode->Flags;
+      SmmuInfoArray[SmmuIndex].StreamTableEntryMax = 0;  // Initialize max stream ID to 0
+      SmmuInfoArray[SmmuIndex].StreamEntryConfig   = NULL;
+      SmmuNodePtrs[SmmuIndex]                      = (VOID *)SmmuNode;
+      SmmuIndex++;
+    }
+
+    // Move to the next node
+    Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Node + Node->Length);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+ * Get the number of SMMUV3 nodes in the IORT table.
+ *
+ * @param [in]  IortTable      Pointer to the IORT table.
+ * @param [out] SmmuNodeCount  Pointer to store the number of SMMU nodes found.
+ *
+ * @retval EFI_SUCCESS            Success.
+ * @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+ */
+EFI_STATUS
+SmmuV3NodeCount (
+  IN  VOID    *IortTable,
+  OUT UINT32  *SmmuNodeCount
+  )
+{
+  EFI_ACPI_6_0_IO_REMAPPING_TABLE  *Iort;
+  EFI_ACPI_6_0_IO_REMAPPING_NODE   *Node;
+  UINT32                           Counter;
+
+  if ((IortTable == NULL) || (SmmuNodeCount == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid parameters\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Cast the void* to the proper IORT structure
+  Iort = (EFI_ACPI_6_0_IO_REMAPPING_TABLE *)IortTable;
+  if (Iort == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: NULL IORT table\n", __func__));
+    return EFI_NOT_FOUND;
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "%a: IORT contains %d nodes\n", __func__, Iort->NumNodes));
+
+  // First pass: count SMMU nodes
+  *SmmuNodeCount = 0;
+  Node           = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Iort + Iort->NodeOffset);
+
+  for (Counter = 0; Counter < Iort->NumNodes; Counter++) {
+    if (Node->Type == EFI_ACPI_IORT_TYPE_SMMUv3) {
+      (*SmmuNodeCount)++;
+    }
+
+    // Move to the next node
+    Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Node + Node->Length);
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "%a: Found %d SMMU nodes\n", __func__, *SmmuNodeCount));
+
+  return EFI_SUCCESS;
+}
+
+/*
+* Get the max stream ID for each SMMU.
+*
+* @param [in]  IortTable      Pointer to the IORT table.
+*/
+EFI_STATUS
+SmmuV3GetMaxStreamIds (
+  IN  VOID       *IortTable,
+  IN  VOID       **SmmuNodePtrs,
+  IN  UINT32     SmmuNodeCount,
+  OUT SMMU_INFO  *SmmuInfoArray
+  )
+{
+  EFI_ACPI_6_0_IO_REMAPPING_TABLE     *Iort;
+  EFI_ACPI_6_0_IO_REMAPPING_NODE      *Node;
+  EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE  *IdMapping;
+  VOID                                *OutputNode;
+  UINT32                              ByteOffset;
+  BOOLEAN                             Found;
+  UINT32                              Count;
+  UINT32                              IdMappingIndex;
+  UINT32                              SmmuIndex;
+  UINT32                              CurMaxMappingStreamId;
+
+  if ((IortTable == NULL) || (SmmuNodePtrs == NULL) || (SmmuInfoArray == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid parameters\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Iort = (EFI_ACPI_6_0_IO_REMAPPING_TABLE *)IortTable;
+  Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Iort + Iort->NodeOffset);
+
+  for (Count = 0; Count < Iort->NumNodes; Count++) {
+    if ((Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) || (Node->Type == EFI_ACPI_IORT_TYPE_NAMED_COMP)) {
+      if (Node->NumIdMappings > 0) {
+        // Get the ID mapping array
+        IdMapping = (EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE *)((UINT8 *)Node + Node->IdReference);
+
+        for (IdMappingIndex = 0; IdMappingIndex < Node->NumIdMappings; IdMappingIndex++) {
+          // Calculate the absolute offset of the output reference
+          ByteOffset = IdMapping[IdMappingIndex].OutputReference;
+          OutputNode = (VOID *)((UINT8 *)Iort + ByteOffset);
+
+          // Check if the output reference points to an SMMU node
+          Found = FALSE;
+          for (SmmuIndex = 0; SmmuIndex < SmmuNodeCount; SmmuIndex++) {
+            if (OutputNode == SmmuNodePtrs[SmmuIndex]) {
+              // This ID mapping references an SMMU node
+              // Calculate the max Stream ID for this mapping: OutputBase + NumIds
+              CurMaxMappingStreamId = IdMapping[IdMappingIndex].OutputBase + IdMapping[IdMappingIndex].NumIds;
+
+              // Update MaxStreamId if this mapping has a higher value
+              if (CurMaxMappingStreamId > SmmuInfoArray[SmmuIndex].StreamTableEntryMax) {
+                SmmuInfoArray[SmmuIndex].StreamTableEntryMax = CurMaxMappingStreamId;
+                DEBUG ((
+                  DEBUG_VERBOSE,
+                  "%a: Updated MaxStreamId for SMMU[0x%llx] to 0x%x (from mapping: InputBase=0x%x, NumIds=0x%x, OutputBase=0x%x)\n",
+                  __func__,
+                  SmmuInfoArray[SmmuIndex].SmmuBase,
+                  SmmuInfoArray[SmmuIndex].StreamTableEntryMax,
+                  IdMapping[IdMappingIndex].InputBase,
+                  IdMapping[IdMappingIndex].NumIds,
+                  IdMapping[IdMappingIndex].OutputBase
+                  ));
+              }
+
+              Found = TRUE;
+              break;
+            }
+          }
+
+          if (!Found) {
+            DEBUG ((
+              DEBUG_ERROR,
+              "%a: ID mapping references a non-SMMU node (offset: 0x%x)\n",
+              __func__,
+              ByteOffset
+              ));
+            return EFI_NOT_FOUND;
+          }
+        }
+      }
+    }
+
+    // Move to the next node
+    Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Node + Node->Length);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+ * Collect Stream ID specific information for each SMMU.
+ *
+ * @param [in]  IortTable      Pointer to the IORT table.
+ * @param [in]  SmmuNodePtrs   Pointer to the array of SMMU node pointers.
+ * @param [in]  SmmuNodeCount  Number of SMMU nodes.
+ * @param [out] SmmuInfoArray  Pointer to the array of SMMU_INFO structures.
+ *
+ * @retval EFI_SUCCESS            Success.
+ * @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+ *
+ */
+EFI_STATUS
+SmmuV3GetStreamIdInfo (
+  IN  VOID       *IortTable,
+  IN  VOID       **SmmuNodePtrs,
+  IN  UINT32     SmmuNodeCount,
+  OUT SMMU_INFO  *SmmuInfoArray
+  )
+{
+  EFI_ACPI_6_0_IO_REMAPPING_TABLE            *Iort;
+  EFI_ACPI_6_0_IO_REMAPPING_NODE             *Node;
+  EFI_ACPI_6_0_IO_REMAPPING_RC_NODE          *RcNode;
+  EFI_ACPI_6_0_IO_REMAPPING_NAMED_COMP_NODE  *NamedCompNode;
+  EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE         *IdMapping;
+  VOID                                       *OutputNode;
+  SMMU_STREAM_ENTRY_CONFIG                   StreamEntryConfig;
+  UINT32                                     ByteOffset;
+  UINT32                                     SmmuIndex;
+  UINT32                                     IdMappingIndex;
+  UINT32                                     Count;
+  BOOLEAN                                    Found;
+  UINT32                                     StartId;
+  UINT32                                     EndId;
+  UINT32                                     CurID;
+
+  if ((IortTable == NULL) || (SmmuNodePtrs == NULL) || (SmmuInfoArray == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid parameters\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Iort = (EFI_ACPI_6_0_IO_REMAPPING_TABLE *)IortTable;
+  Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Iort + Iort->NodeOffset);
+
+  for (Count = 0; Count < Iort->NumNodes; Count++) {
+    if ((Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) || (Node->Type == EFI_ACPI_IORT_TYPE_NAMED_COMP)) {
+      ZeroMem (&StreamEntryConfig, sizeof (SMMU_STREAM_ENTRY_CONFIG));
+      // Extract Cache Coherent and Memory Access Flags based on node type
+      if (Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) {
+        RcNode                                   = (EFI_ACPI_6_0_IO_REMAPPING_RC_NODE *)Node;
+        StreamEntryConfig.CacheCoherentAttribute = RcNode->CacheCoherent;
+        StreamEntryConfig.MemoryAccessFlags      = RcNode->MemoryAccessFlags;
+      } else if (Node->Type == EFI_ACPI_IORT_TYPE_NAMED_COMP) {
+        NamedCompNode                            = (EFI_ACPI_6_0_IO_REMAPPING_NAMED_COMP_NODE *)Node;
+        StreamEntryConfig.CacheCoherentAttribute = NamedCompNode->CacheCoherent;
+        StreamEntryConfig.MemoryAccessFlags      = NamedCompNode->MemoryAccessFlags;
+      }
+
+      if (Node->NumIdMappings > 0) {
+        // Get the ID mapping array
+        IdMapping = (EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE *)((UINT8 *)Node + Node->IdReference);
+
+        for (IdMappingIndex = 0; IdMappingIndex < Node->NumIdMappings; IdMappingIndex++) {
+          // Calculate the absolute offset of the output reference
+          ByteOffset = IdMapping[IdMappingIndex].OutputReference;
+          OutputNode = (VOID *)((UINT8 *)Iort + ByteOffset);
+
+          // Check if the output reference points to an SMMU node
+          Found = FALSE;
+          for (SmmuIndex = 0; SmmuIndex < SmmuNodeCount; SmmuIndex++) {
+            if (OutputNode == SmmuNodePtrs[SmmuIndex]) {
+              // This ID mapping references an SMMU node
+              // Calculate the Stream ID range
+              StartId = IdMapping[IdMappingIndex].OutputBase;
+              EndId   = StartId + IdMapping[IdMappingIndex].NumIds;
+
+              // Store the Stream ID range information
+              for (CurID = StartId; CurID <= EndId; CurID++) {
+                // SmmuInfoArray[k].StreamEntryConfig[CurID].CacheCoherentAttribute = StreamEntryConfig.CacheCoherentAttribute;
+                // SmmuInfoArray[k].StreamEntryConfig[CurID].MemoryAccessFlags = StreamEntryConfig.MemoryAccessFlags;
+                CopyMem (&SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID], &StreamEntryConfig, sizeof (SMMU_STREAM_ENTRY_CONFIG));
+              }
+
+              DEBUG ((
+                DEBUG_VERBOSE,
+                "%a: Added Stream ID range for SMMU[0x%llx]: StartId=0x%x, EndId=0x%x\n",
+                __func__,
+                SmmuInfoArray[SmmuIndex].SmmuBase,
+                StartId,
+                EndId
+                ));
+
+              Found = TRUE;
+              break;
+            }
+          }
+
+          if (!Found) {
+            DEBUG ((
+              DEBUG_ERROR,
+              "%a: ID mapping references a non-SMMU node (offset: 0x%x)\n",
+              __func__,
+              ByteOffset
+              ));
+            return EFI_NOT_FOUND;
+          }
+        }
+      }
+    }
+
+    // Move to the next node
+    Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Node + Node->Length);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+ * Parse IORT table and extract SMMU information
+ *
+ * @param[in]  IortTable    Pointer to the IORT table
+ * @param[out] SmmuInfo     Pointer to store the array of SMMU_INFO structures
+ * @param[out] SmmuCount    Pointer to store the number of SMMU nodes found
+ *
+ * @return EFI_SUCCESS on success, or an error status code on failure
+ */
+EFI_STATUS
+SmmuV3ParseIort (
+  IN  VOID       *IortTable,
+  OUT SMMU_INFO  **SmmuInfo,
+  OUT UINT32     *SmmuCount
+  )
+{
+  EFI_STATUS                       Status;
+  EFI_ACPI_6_0_IO_REMAPPING_TABLE  *Iort;
+  SMMU_INFO                        *SmmuInfoArray;
+  VOID                             **SmmuNodePtrs;
+  UINT32                           SmmuNodeCount;
+  UINT32                           SmmuIndex;
+
+  if ((IortTable == NULL) || (SmmuInfo == NULL) || (SmmuCount == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid parameters\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Cast the void* to the IORT structure
+  Iort = (EFI_ACPI_6_0_IO_REMAPPING_TABLE *)IortTable;
+
+  // Verify IORT signature
+  // TODO add revision check
+  if (Iort->Header.Signature != EFI_ACPI_6_0_IO_REMAPPING_TABLE_SIGNATURE) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Invalid IORT signature: 0x%08X, expected: 0x%08X\n",
+      __func__,
+      Iort->Header.Signature,
+      EFI_ACPI_6_0_IO_REMAPPING_TABLE_SIGNATURE
+      ));
+    return EFI_UNSUPPORTED;
+  }
+
+  if ((Iort->Header.Revision != EFI_ACPI_IO_REMAPPING_TABLE_REVISION_00) && (Iort->Header.Revision != EFI_ACPI_IO_REMAPPING_TABLE_REVISION_06)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Unsupported IORT revision: %d, expected: [%d, %d]\n",
+      __func__,
+      Iort->Header.Revision,
+      EFI_ACPI_IO_REMAPPING_TABLE_REVISION_00,
+      EFI_ACPI_IO_REMAPPING_TABLE_REVISION_06
+      ));
+    return EFI_UNSUPPORTED;
+  }
+
+  // First pass: get the number of SMMU nodes
+  Status = SmmuV3NodeCount (IortTable, &SmmuNodeCount);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get IORT node count\n", __func__));
+    return Status;
+  }
+
+  if (SmmuNodeCount == 0) {
+    *SmmuCount = 0;
+    *SmmuInfo  = NULL;
+    return EFI_NOT_FOUND;
+  }
+
+  // Allocate memory for SMMU info array
+  SmmuInfoArray = AllocateZeroPool (SmmuNodeCount * sizeof (SMMU_INFO));
+  if (SmmuInfoArray == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate memory for SMMU info array\n", __func__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // Allocate memory for SMMU node pointers (for output reference lookup)
+  SmmuNodePtrs = AllocateZeroPool (SmmuNodeCount * sizeof (VOID *));
+  if (SmmuNodePtrs == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate memory for SMMU node pointers\n", __func__));
+    FreePool (SmmuInfoArray);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // Second pass: collect SMMU information
+  Status = SmmuV3GetNodeInfo (IortTable, SmmuInfoArray, SmmuNodePtrs);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get SMMU node info\n", __func__));
+    goto Error;
+  }
+
+  // Third pass: calculate max Stream ID for each SMMU node
+  Status = SmmuV3GetMaxStreamIds (IortTable, SmmuNodePtrs, SmmuNodeCount, SmmuInfoArray);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get max Stream ID for SMMU nodes\n", __func__));
+    goto Error;
+  }
+
+  // Allocate memory for Stream ID ranges after knowing the maximum Stream ID
+  for (SmmuIndex = 0; SmmuIndex < SmmuNodeCount; SmmuIndex++) {
+    if (SmmuInfoArray[SmmuIndex].StreamTableEntryMax > 0) {
+      // Allocate space for StreamIdRanges based on MaxStreamId
+      // One entry for each possible StreamId (0 to MaxStreamId inclusive)
+      SmmuInfoArray[SmmuIndex].StreamEntryConfig = AllocateZeroPool ((SmmuInfoArray[SmmuIndex].StreamTableEntryMax + 1) * sizeof (SMMU_STREAM_ENTRY_CONFIG));
+      if (SmmuInfoArray[SmmuIndex].StreamEntryConfig == NULL) {
+        DEBUG ((DEBUG_ERROR, "%a: Failed to allocate Stream ID ranges for SMMU[%d]\n", __func__, SmmuInfoArray[SmmuIndex].SmmuBase));
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Error;
+      }
+    }
+  }
+
+  // Fourth pass: collect per Stream ID range info like CCA, CPM, DACS for each RC/NamedComp node
+  Status = SmmuV3GetStreamIdInfo (IortTable, SmmuNodePtrs, SmmuNodeCount, SmmuInfoArray);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get Stream ID info for SMMU nodes\n", __func__));
+    goto Error;
+  }
+
+  FreePool (SmmuNodePtrs);
+  *SmmuInfo  = SmmuInfoArray;
+  *SmmuCount = SmmuNodeCount;
+  return Status;
+
+Error:
+  FreePool (SmmuInfoArray);
+  FreePool (SmmuNodePtrs);
   return Status;
 }

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -930,6 +930,7 @@ SmmuV3GetNodeInfo (
  *
  * @retval EFI_SUCCESS            Success.
  * @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+ * @retval EFI_NOT_FOUND          IORT table not found.
  */
 EFI_STATUS
 SmmuV3NodeCount (
@@ -1014,53 +1015,51 @@ SmmuV3GetMaxStreamIds (
   Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Iort + Iort->NodeOffset);
 
   for (Count = 0; Count < Iort->NumNodes; Count++) {
-    if ((Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) || (Node->Type == EFI_ACPI_IORT_TYPE_NAMED_COMP)) {
-      if (Node->NumIdMappings > 0) {
-        // Get the ID mapping array
-        IdMapping = (EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE *)((UINT8 *)Node + Node->IdReference);
+    if (((Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) || (Node->Type == EFI_ACPI_IORT_TYPE_NAMED_COMP)) && (Node->NumIdMappings > 0)) {
+      // Get the ID mapping array
+      IdMapping = (EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE *)((UINT8 *)Node + Node->IdReference);
 
-        for (IdMappingIndex = 0; IdMappingIndex < Node->NumIdMappings; IdMappingIndex++) {
-          // Calculate the absolute offset of the output reference
-          ByteOffset = IdMapping[IdMappingIndex].OutputReference;
-          OutputNode = (VOID *)((UINT8 *)Iort + ByteOffset);
+      for (IdMappingIndex = 0; IdMappingIndex < Node->NumIdMappings; IdMappingIndex++) {
+        // Calculate the absolute offset of the output reference
+        ByteOffset = IdMapping[IdMappingIndex].OutputReference;
+        OutputNode = (VOID *)((UINT8 *)Iort + ByteOffset);
 
-          // Check if the output reference points to an SMMU node
-          Found = FALSE;
-          for (SmmuIndex = 0; SmmuIndex < SmmuNodeCount; SmmuIndex++) {
-            if (OutputNode == SmmuNodePtrs[SmmuIndex]) {
-              // This ID mapping references an SMMU node
-              // Calculate the max Stream ID for this mapping: OutputBase + NumIds
-              CurMaxMappingStreamId = IdMapping[IdMappingIndex].OutputBase + IdMapping[IdMappingIndex].NumIds;
+        // Check if the output reference points to an SMMU node
+        Found = FALSE;
+        for (SmmuIndex = 0; SmmuIndex < SmmuNodeCount; SmmuIndex++) {
+          if (OutputNode == SmmuNodePtrs[SmmuIndex]) {
+            // This ID mapping references an SMMU node
+            // Calculate the max Stream ID for this mapping: OutputBase + NumIds
+            CurMaxMappingStreamId = IdMapping[IdMappingIndex].OutputBase + IdMapping[IdMappingIndex].NumIds;
 
-              // Update MaxStreamId if this mapping has a higher value
-              if (CurMaxMappingStreamId > SmmuInfoArray[SmmuIndex].StreamTableEntryMax) {
-                SmmuInfoArray[SmmuIndex].StreamTableEntryMax = CurMaxMappingStreamId;
-                DEBUG ((
-                  DEBUG_VERBOSE,
-                  "%a: Updated MaxStreamId for SMMU[0x%llx] to 0x%x (from mapping: InputBase=0x%x, NumIds=0x%x, OutputBase=0x%x)\n",
-                  __func__,
-                  SmmuInfoArray[SmmuIndex].SmmuBase,
-                  SmmuInfoArray[SmmuIndex].StreamTableEntryMax,
-                  IdMapping[IdMappingIndex].InputBase,
-                  IdMapping[IdMappingIndex].NumIds,
-                  IdMapping[IdMappingIndex].OutputBase
-                  ));
-              }
-
-              Found = TRUE;
-              break;
+            // Update MaxStreamId if this mapping has a higher value
+            if (CurMaxMappingStreamId > SmmuInfoArray[SmmuIndex].StreamTableEntryMax) {
+              SmmuInfoArray[SmmuIndex].StreamTableEntryMax = CurMaxMappingStreamId;
+              DEBUG ((
+                DEBUG_VERBOSE,
+                "%a: Updated MaxStreamId for SMMU[0x%llx] to 0x%x (from mapping: InputBase=0x%x, NumIds=0x%x, OutputBase=0x%x)\n",
+                __func__,
+                SmmuInfoArray[SmmuIndex].SmmuBase,
+                SmmuInfoArray[SmmuIndex].StreamTableEntryMax,
+                IdMapping[IdMappingIndex].InputBase,
+                IdMapping[IdMappingIndex].NumIds,
+                IdMapping[IdMappingIndex].OutputBase
+                ));
             }
-          }
 
-          if (!Found) {
-            DEBUG ((
-              DEBUG_ERROR,
-              "%a: ID mapping references a non-SMMU node (offset: 0x%x)\n",
-              __func__,
-              ByteOffset
-              ));
-            return EFI_NOT_FOUND;
+            Found = TRUE;
+            break;
           }
+        }
+
+        if (!Found) {
+          DEBUG ((
+            DEBUG_ERROR,
+            "%a: ID mapping references a non-SMMU node (offset: 0x%x)\n",
+            __func__,
+            ByteOffset
+            ));
+          return EFI_NOT_FOUND;
         }
       }
     }
@@ -1082,6 +1081,7 @@ SmmuV3GetMaxStreamIds (
  *
  * @retval EFI_SUCCESS            Success.
  * @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+ * @retval EFI_NOT_FOUND          SMMU node not found.
  */
 EFI_STATUS
 SmmuV3GetStreamIdInfo (
@@ -1112,12 +1112,13 @@ SmmuV3GetStreamIdInfo (
     return EFI_INVALID_PARAMETER;
   }
 
+  ZeroMem (&StreamEntryConfig, sizeof (SMMU_STREAM_ENTRY_CONFIG));
+
   Iort = (EFI_ACPI_6_0_IO_REMAPPING_TABLE *)IortTable;
   Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Iort + Iort->NodeOffset);
 
   for (Count = 0; Count < Iort->NumNodes; Count++) {
     if ((Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) || (Node->Type == EFI_ACPI_IORT_TYPE_NAMED_COMP)) {
-      ZeroMem (&StreamEntryConfig, sizeof (SMMU_STREAM_ENTRY_CONFIG));
       // Extract Cache Coherent and Memory Access Flags based on node type
       if (Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) {
         RcNode                                   = (EFI_ACPI_6_0_IO_REMAPPING_RC_NODE *)Node;

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -977,6 +977,14 @@ SmmuV3NodeCount (
 * Get the max stream ID for each SMMU.
 *
 * @param [in]  IortTable      Pointer to the IORT table.
+* @param [in]  SmmuNodePtrs   Pointer to the array of SMMU node pointers.
+* @param [in]  SmmuNodeCount  Number of SMMU nodes.
+* @param [out] SmmuInfoArray  Pointer to the array of SMMU_INFO structures.
+*
+*
+* @retval EFI_SUCCESS            Success.
+* @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+* @retval EFI_NOT_FOUND          SMMU node not found.
 */
 EFI_STATUS
 SmmuV3GetMaxStreamIds (
@@ -1074,7 +1082,6 @@ SmmuV3GetMaxStreamIds (
  *
  * @retval EFI_SUCCESS            Success.
  * @retval EFI_INVALID_PARAMETER  Invalid Parameters.
- *
  */
 EFI_STATUS
 SmmuV3GetStreamIdInfo (
@@ -1142,8 +1149,6 @@ SmmuV3GetStreamIdInfo (
 
               // Store the Stream ID range information
               for (CurID = StartId; CurID <= EndId; CurID++) {
-                // SmmuInfoArray[k].StreamEntryConfig[CurID].CacheCoherentAttribute = StreamEntryConfig.CacheCoherentAttribute;
-                // SmmuInfoArray[k].StreamEntryConfig[CurID].MemoryAccessFlags = StreamEntryConfig.MemoryAccessFlags;
                 CopyMem (&SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID], &StreamEntryConfig, sizeof (SMMU_STREAM_ENTRY_CONFIG));
               }
 
@@ -1188,7 +1193,11 @@ SmmuV3GetStreamIdInfo (
  * @param[out] SmmuInfo     Pointer to store the array of SMMU_INFO structures
  * @param[out] SmmuCount    Pointer to store the number of SMMU nodes found
  *
- * @return EFI_SUCCESS on success, or an error status code on failure
+ * @return EFI_SUCCESS on success
+ * @return EFI_INVALID_PARAMETER if any parameter is NULL
+ * @return EFI_OUT_OF_RESOURCES if memory allocation fails
+ * @return EFI_NOT_FOUND if no SMMU nodes are found
+ * @return EFI_UNSUPPORTED if the IORT table is not supported
  */
 EFI_STATUS
 SmmuV3ParseIort (
@@ -1216,7 +1225,6 @@ SmmuV3ParseIort (
   Iort = (EFI_ACPI_6_0_IO_REMAPPING_TABLE *)IortTable;
 
   // Verify IORT signature
-  // TODO add revision check
   if (Iort->Header.Signature != EFI_ACPI_6_0_IO_REMAPPING_TABLE_SIGNATURE) {
     DEBUG ((
       DEBUG_ERROR,

--- a/ArmPkg/Include/Guid/SmmuConfig.h
+++ b/ArmPkg/Include/Guid/SmmuConfig.h
@@ -18,8 +18,6 @@
 #ifndef SMMU_CONFIG_GUID_H_
 #define SMMU_CONFIG_GUID_H_
 
-#include <IndustryStandard/IoRemappingTable.h>
-
 /*
   The needs/requirements of the SMMU and ACPI/IORT node configuration may vary between new and existing platforms, modify the SMMU_CONFIG structure as needed.
   Increment SMMU_CONFIG version when the structure changes.
@@ -28,44 +26,16 @@
   SmmuDxe driver will check and enforce the version of the SMMU_CONFIG structure to this current version set here.
 */
 #define CURRENT_SMMU_CONFIG_VERSION_MAJOR  0
-#define CURRENT_SMMU_CONFIG_VERSION_MINOR  7
-
-/*
-  See <https://developer.arm.com/documentation/den0049/latest/> for IORT spec for
-  information on the IORT ACPI node structure. Platform must populate all the below
-  ACPI structures to pass the SMMU configuration data to the SMMU driver.
-  See IoRemappingTable.h for definitions of the below sub-structures.
-*/
+#define CURRENT_SMMU_CONFIG_VERSION_MINOR  8
 
 #pragma pack(push, 1)
 
-typedef struct _PLATFORM_ACPI_6_0_IO_REMAPPING_ITS_NODE {
-  EFI_ACPI_6_0_IO_REMAPPING_ITS_NODE    Node;        // ITS Node
-  UINT32                                Identifiers; // ITS Node identifiers
-} PLATFORM_ACPI_6_0_IO_REMAPPING_ITS_NODE;
-
-typedef struct _PLATFORM_ACPI_6_0_IO_REMAPPING_SMMU3_NODE {
-  EFI_ACPI_6_0_IO_REMAPPING_SMMU3_NODE    SmmuNode;  // SMMUV3 Node
-  EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE      SmmuIdMap; // SMMUV3 ID Mapping
-} PLATFORM_ACPI_6_0_IO_REMAPPING_SMMU3_NODE;
-
-typedef struct _PLATFORM_ACPI_6_0_IO_REMAPPING_RC_NODE {
-  EFI_ACPI_6_0_IO_REMAPPING_RC_NODE     RcNode;  // Root Complex Node
-  EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE    RcIdMap; // Root Complex ID Mapping
-} PLATFORM_ACPI_6_0_IO_REMAPPING_RC_NODE;
-
-typedef struct _PLATFORM_IO_REMAPPING_STRUCTURE {
-  EFI_ACPI_6_0_IO_REMAPPING_TABLE              Iort;     // IORT table header
-  PLATFORM_ACPI_6_0_IO_REMAPPING_ITS_NODE      ItsNode;  // ITS Node platform wrapper
-  PLATFORM_ACPI_6_0_IO_REMAPPING_SMMU3_NODE    SmmuNode; // Smmu Node platform wrapper
-  PLATFORM_ACPI_6_0_IO_REMAPPING_RC_NODE       RcNode;   // Root Complex Node platform wrapper
-} PLATFORM_IO_REMAPPING_STRUCTURE;
-
 // SMMU_CONFIG structure to pass the SMMU configuration data from the platform to the SMMU driver.
 typedef struct _SMMU_CONFIG {
-  UINT32                             VersionMajor;
-  UINT32                             VersionMinor;
-  PLATFORM_IO_REMAPPING_STRUCTURE    Config;
+  UINT32    VersionMajor;
+  UINT32    VersionMinor;
+  UINT32    IortSize;
+  UINT32    IortOffset;
 } SMMU_CONFIG;
 
 #pragma pack(pop)


### PR DESCRIPTION
## Description

Supports N number of SMMU's
Dynamically parses any generic IORT structure and configures the SMMU's accordingly

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on an ARM surface platform and QEMU SBSA.

See https://github.com/microsoft/mu_tiano_platforms/pull/1085 for platform side changes.

## Integration Instructions

N/A
