### PR TITLE
[Squash on Rebase] DefaultExceptionHandler: Remove MU_CHANGE casting AARCH64 ESR from a …

### DIFF
--- a/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c
+++ b/ArmPkg/Library/DefaultExceptionHandlerLib/AArch64/DefaultExceptionHandler.c
@@ -313,7 +313,7 @@ DefaultExceptionHandler (
 
   DEBUG ((DEBUG_ERROR, "\n ESR : EC 0x%02x  IL 0x%x  ISS 0x%08x\n", (SystemContext.SystemContextAArch64->ESR & 0xFC000000) >> 26, (SystemContext.SystemContextAArch64->ESR >> 25) & 0x1, SystemContext.SystemContextAArch64->ESR & 0x1FFFFFF));
 
-  DescribeExceptionSyndrome ((UINT32)SystemContext.SystemContextAArch64->ESR);   // MU_CHANGE - ARM64 VS change
+  DescribeExceptionSyndrome (SystemContext.SystemContextAArch64->ESR);
 
   DEBUG ((DEBUG_ERROR, "\nStack dump:\n"));
   for (Offset = -256; Offset < 256; Offset += 32) {


### PR DESCRIPTION
## Description
* Remove the MU_CHANGE to cast SystemContext.SystemContextAArch64->ESR to a UINT32 as the function DescribeExceptionSyndrome now takes a UINT64.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
* Verified on Arm based hardware.

## Integration Instructions
* N/A
