### PR TITLE
[SQUASH ON REBASE] Support Concatenated Translation Tables

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -117,12 +117,12 @@ UpdateMapping (
     goto End;
   }
 
-  Status = EFI_SUCCESS;
+  Status  = EFI_SUCCESS;
   Current = Root;
 
   // Traverse the page table to the leaf level
   for (Level = mIoMmu->SmmuInfo->TranslationStartingLevel; Level < PAGE_TABLE_DEPTH - 1; Level++) {
-    Index = PAGE_TABLE_INDEX (VirtualAddress, Level);
+    Index = PAGE_TABLE_INDEX (VirtualAddress, Level, mIoMmu->SmmuInfo->OutputAddressWidth, mIoMmu->SmmuInfo->TranslationStartingLevel, mIoMmu->SmmuInfo->PageTableRootConcatenated);
 
     if (Current->Entries[Index] == 0) {
       PAGE_TABLE  *NewPage = (PAGE_TABLE *)AllocatePages (1);
@@ -143,7 +143,7 @@ UpdateMapping (
 
   // leaf level
   if (Current != 0) {
-    Index = PAGE_TABLE_INDEX (VirtualAddress, Level);
+    Index = PAGE_TABLE_INDEX (VirtualAddress, Level, mIoMmu->SmmuInfo->OutputAddressWidth, mIoMmu->SmmuInfo->TranslationStartingLevel, mIoMmu->SmmuInfo->PageTableRootConcatenated);
 
     if (Valid && ((Current->Entries[Index] & PAGE_TABLE_ENTRY_VALID_BIT) != 0)) {
       DEBUG ((DEBUG_VERBOSE, "%a: Page already mapped. VirtualAddress = 0x%llx PhysicalAddress=0x%llx\n", __func__, VirtualAddress, PhysicalAddress));

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -130,6 +130,8 @@ AddIortTable (
   Initialize a page table. Only initializes the root page table.
   UpdateMapping() will allocate entries on the fly as needed.
 
+  To support concatenated page tables, allocate the max amount of pages we are allowed to concatenate, 16.
+
   @retval A pointer to the initialized page table, or NULL on failure.
 **/
 STATIC
@@ -140,13 +142,20 @@ PageTableInit (
 {
   PAGE_TABLE  *PageTable;
 
-  PageTable = (PAGE_TABLE *)AllocatePages (1);
+  // To support concatenated page tables, allocate the max amount of pages we are allowed to concatenate, 16.
+  // Arm DDI0487L_a_a-profile_architecture_reference_manual section D8.2.2 states:
+  // Align the base address of the first translation table to the sum of the size of the memory occupied by the concatenated translation tables.
+  PageTable = (PAGE_TABLE *)AllocateAlignedPages (
+                              PAGE_TABLE_ROOT_CONCATENATED_PAGES_MAX,
+                              EFI_PAGE_SIZE * PAGE_TABLE_ROOT_CONCATENATED_PAGES_MAX
+                              );
+
   if (PageTable == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to allocate page table\n", __func__));
     return NULL;
   }
 
-  ZeroMem (PageTable, EFI_PAGE_SIZE);
+  ZeroMem (PageTable, EFI_PAGE_SIZE * PAGE_TABLE_ROOT_CONCATENATED_PAGES_MAX);
 
   return PageTable;
 }
@@ -165,22 +174,29 @@ PageTableDeInit (
   IN PAGE_TABLE  *PageTable
   )
 {
-  UINTN  Index;
+  UINTN             Index;
+  PAGE_TABLE_ENTRY  Entry;
+  PAGE_TABLE        *PageTableAddress;
 
   if ((Level >= PAGE_TABLE_DEPTH) || (PageTable == NULL)) {
     return;
   }
 
   for (Index = 0; Index < PAGE_TABLE_SIZE; Index++) {
-    PAGE_TABLE_ENTRY  Entry             = PageTable->Entries[Index];
-    PAGE_TABLE        *PageTableAddress = (PAGE_TABLE *)((UINTN)Entry & ~PAGE_TABLE_BLOCK_OFFSET);
+    Entry            = PageTable->Entries[Index];
+    PageTableAddress = (PAGE_TABLE *)((UINTN)Entry & ~PAGE_TABLE_BLOCK_OFFSET);
 
     if (Entry != 0) {
       PageTableDeInit (Level + 1, PageTableAddress);
     }
   }
 
-  FreePages (PageTable, EFI_SIZE_TO_PAGES (sizeof (PAGE_TABLE)));
+  // For root level, use larger size to free for supporting a concatenated page table root.
+  if (Level == 0) {
+    FreePages (PageTable, PAGE_TABLE_ROOT_CONCATENATED_PAGES_MAX);
+  } else {
+    FreePages (PageTable, 1);
+  }
 }
 
 /**
@@ -312,7 +328,6 @@ SmmuV3BuildStreamTableEntry (
   )
 {
   EFI_STATUS   Status;
-  UINT32       OutputAddressWidth;
   UINT32       InputSize;
   SMMUV3_IDR0  Idr0;
   SMMUV3_IDR1  Idr1;
@@ -364,17 +379,17 @@ SmmuV3BuildStreamTableEntry (
   //  Thus the maximum input address width is restricted to 48-bits even if
   //  it is advertised to be larger.
   //
-  OutputAddressWidth = SmmuV3DecodeAddressWidth (Idr5.Oas);
+  SmmuInfo->OutputAddressWidth = SmmuV3DecodeAddressWidth (Idr5.Oas);
 
-  if (OutputAddressWidth < SMMUV3_STREAM_TABLE_ENTRY_OUTPUT_ADDRESS_MAX) {
-    StreamEntry->S2Ps = SmmuV3EncodeAddressWidth (OutputAddressWidth);
+  if (SmmuInfo->OutputAddressWidth < SMMUV3_STREAM_TABLE_ENTRY_OUTPUT_ADDRESS_MAX) {
+    StreamEntry->S2Ps = SmmuV3EncodeAddressWidth (SmmuInfo->OutputAddressWidth);
   } else {
     DEBUG ((DEBUG_INFO, "%a: Advertised OutputAddressWidth >= 48. Capping the width to 48 per the SMMU spec.\n", __func__));
-    StreamEntry->S2Ps  = SmmuV3EncodeAddressWidth (SMMUV3_STREAM_TABLE_ENTRY_OUTPUT_ADDRESS_MAX);
-    OutputAddressWidth = SMMUV3_STREAM_TABLE_ENTRY_OUTPUT_ADDRESS_MAX;
+    StreamEntry->S2Ps            = SmmuV3EncodeAddressWidth (SMMUV3_STREAM_TABLE_ENTRY_OUTPUT_ADDRESS_MAX);
+    SmmuInfo->OutputAddressWidth = SMMUV3_STREAM_TABLE_ENTRY_OUTPUT_ADDRESS_MAX;
   }
 
-  Status = SmmuV3SetTranslationStartingLevel (SmmuInfo, OutputAddressWidth, &S2Sl0);
+  Status = SmmuV3SetTranslationStartingLevel (SmmuInfo, SmmuInfo->OutputAddressWidth, &S2Sl0);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to set translation starting level\n", __func__));
     return Status;
@@ -392,7 +407,7 @@ SmmuV3BuildStreamTableEntry (
   //
   StreamEntry->S2Sl0 = S2Sl0;
 
-  InputSize           = OutputAddressWidth;
+  InputSize           = SmmuInfo->OutputAddressWidth;
   StreamEntry->S2T0Sz = 64 - InputSize;
 
   /**
@@ -602,7 +617,7 @@ SmmuV3Configure (
   }
 
   // Load default STE values
-  for (Index = 0; Index < SmmuInfo->StreamTableEntryMax; Index++) {
+  for (Index = 0; Index <= SmmuInfo->StreamTableEntryMax; Index++) {
     Status = SmmuV3BuildStreamTableEntry (SmmuInfo, Index, &StreamTablePtr[Index]);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Error building stream table\n", __func__));

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -18,10 +18,19 @@
 
 // Number of levels in the page table
 #define PAGE_TABLE_DEPTH  4
-#define PAGE_TABLE_INDEX(VirtualAddress, Level)  (((VirtualAddress) >> (12 + (9 * (PAGE_TABLE_DEPTH - 1 - (Level))))) & 0x1FF)
+// If the starting level is 1, and the address width exceeds 39 bits, then the page table is concatenated
+#define PAGE_TABLE_CONCATENATED_PAGES_BITS_CUTOFF  39
+// Page Table Index macro to calculate the index of the page table entry based on the level and address width, supports concatenated page tables
+#define PAGE_TABLE_INDEX(VirtualAddress, Level, OutputAddressWidth, TranslationStartingLevel, PageTableRootConcatenated) \
+    (PageTableRootConcatenated && (Level == 1) && (TranslationStartingLevel == Level)) ? \
+        (((VirtualAddress) >> (12 + (9 * ((PAGE_TABLE_DEPTH - 1) - (Level))))) & \
+         ((1 << (9 + ((OutputAddressWidth) - PAGE_TABLE_CONCATENATED_PAGES_BITS_CUTOFF))) - 1)) : \
+        (((VirtualAddress) >> (12 + (9 * ((PAGE_TABLE_DEPTH - 1) - (Level))))) & 0x1FF)
+
 #define PAGE_TABLE_4_LEVEL_OUTPUT_ADDRESS_WIDTH_MIN  44
 #define PAGE_TABLE_OUTPUT_ADDRESS_WIDTH_MAX          48
 #define PAGE_TABLE_OUTPUT_ADDRESS_WIDTH_MIN          32
+#define PAGE_TABLE_ROOT_CONCATENATED_PAGES_MAX       16
 
 // Macro to align values down. Alignment is required to be power of 2.
 #define ALIGN_DOWN_BY(length, alignment) \
@@ -164,7 +173,6 @@ typedef struct _SMMU_INFO {
   VOID                        *CommandQueue;
   VOID                        *EventQueue;
   SMMU_STREAM_ENTRY_CONFIG    *StreamEntryConfig;
-  UINT8                       TranslationStartingLevel;
   UINT64                      SmmuBase;
   UINT32                      StreamTableSize;
   UINT32                      StreamTableEntryMax;
@@ -174,6 +182,9 @@ typedef struct _SMMU_INFO {
   UINT32                      StreamTableLog2Size;
   UINT32                      CommandQueueLog2Size;
   UINT32                      EventQueueLog2Size;
+  UINT32                      OutputAddressWidth;
+  UINT8                       TranslationStartingLevel;
+  BOOLEAN                     PageTableRootConcatenated;
 } SMMU_INFO;
 
 // IoMmu configuration structure

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -140,6 +140,8 @@ SmmuV3SetTranslationStartingLevel (
   } else {
     SmmuInfo->TranslationStartingLevel = 1; // 3 level paging
     *S2Sl0                             = 0x1;
+    // If the output address width is greater than PAGE_TABLE_CONCATENATED_PAGES_BITS_CUTOFF, the page table root must be concatenated.
+    SmmuInfo->PageTableRootConcatenated = (OutputAddressWidth > PAGE_TABLE_CONCATENATED_PAGES_BITS_CUTOFF);
   }
 
   return EFI_SUCCESS;
@@ -606,7 +608,7 @@ SmmuV3DumpPageTableEntries (
   Current = Root;
 
   for (Level = SmmuInfo->TranslationStartingLevel; Level < PAGE_TABLE_DEPTH; Level++) {
-    Index = PAGE_TABLE_INDEX (VirtualAddress, Level);
+    Index = PAGE_TABLE_INDEX (VirtualAddress, Level, SmmuInfo->OutputAddressWidth, SmmuInfo->TranslationStartingLevel, SmmuInfo->PageTableRootConcatenated);
     if (Current->Entries[Index] == 0) {
       DEBUG ((DEBUG_ERROR, "%a: Invalid entry at level %d, index %d\n", __func__, Level, Index));
       break;


### PR DESCRIPTION
## Description

Fix alignment for page table root to be aligned to the size of maximum number of allowed concatenated page tables, 16.
For the case where the address width is too large to for the VA bits to fit within a 9-bit width for the root level, we can extend the level index bits.
This corresponds to how many page tables can be concatenated. Up to 4 bits of extension are allowed, meaning a total of 16 concatenated tables.

See: [DDI0487L_a_a-profile_architecture_reference_manual section](https://developer.arm.com/documentation/ddi0487/latest/) Section D8.2.2 on Concatenated Translation Tables

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on QEMU SBSA as well as a physical arm device.

## Integration Instructions

N/A