### PR TITLE
[REBASE & FF] ArmPkg: Add changes required for AARCH64 MSVC

### DIFF
--- a/ArmPkg/Drivers/ArmGicDxe/ArmGicDxe.inf
+++ b/ArmPkg/Drivers/ArmGicDxe/ArmGicDxe.inf
@@ -29,6 +29,7 @@
 
 [Sources.AARCH64]
   GicV3/AArch64/ArmGicV3.S
+  GicV3/AArch64/ArmGicV3.masm  | MSFT
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/ArmPkg/Drivers/ArmGicDxe/ArmGicV3Dxe.inf
+++ b/ArmPkg/Drivers/ArmGicDxe/ArmGicV3Dxe.inf
@@ -27,6 +27,7 @@
 
 [Sources.AARCH64]
   GicV3/AArch64/ArmGicV3.S
+  GicV3/AArch64/ArmGicV3.masm  | MSFT
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/ArmPkg/Drivers/ArmGicDxe/GicV3/AArch64/ArmGicV3.masm
+++ b/ArmPkg/Drivers/ArmGicDxe/GicV3/AArch64/ArmGicV3.masm
@@ -23,6 +23,8 @@
     EXPORT ArmGicV3AcknowledgeInterrupt
     EXPORT ArmGicV3SetPriorityMask
     EXPORT ArmGicV3SetBinaryPointer
+    EXPORT ArmGicV3SetControlRegister
+    EXPORT ArmGicV3GetControlRegister
 
 //UINT32
 //EFIAPI
@@ -118,5 +120,25 @@ ArmGicV3SetBinaryPointer PROC
         msr     ICC_BPR1_EL1, x0
         ret
 ArmGicV3SetBinaryPointer ENDP
+
+//UINTN
+//EFIAPI
+//ArmGicV3GetControlRegister (
+//  VOID
+//  );
+ArmGicV3GetControlRegister PROC
+        mrs     x0, ICC_CTLR_EL1
+        ret
+ArmGicV3GetControlRegister ENDP
+
+//VOID
+//EFIAPI
+//ArmGicV3SetControlRegister (
+//  IN UINTN         Value
+//  );
+ArmGicV3SetControlRegister PROC
+        msr     ICC_CTLR_EL1, x0
+        ret
+ArmGicV3SetControlRegister ENDP
 
     END

--- a/ArmPkg/Drivers/ArmGicDxe/GicV3/ArmGicV3Dxe.c
+++ b/ArmPkg/Drivers/ArmGicDxe/GicV3/ArmGicV3Dxe.c
@@ -605,6 +605,7 @@ GicV3DxeInitialize (
   UINT64      MpId;
   UINT64      CpuTarget;
   UINT64      RegValue;
+  UINT32      ControlSystemRegValue; // MU_CHANGE - Add ControlSystemRegValue
 
   // Make sure the Interrupt Controller Protocol is not already installed in
   // the system.
@@ -626,9 +627,11 @@ GicV3DxeInitialize (
   mGicRedistributorBase = GicGetCpuRedistributorBase (PcdGet64 (PcdGicRedistributorsBase));
   mGicNumInterrupts     = ArmGicGetMaxNumInterrupts (mGicDistributorBase);
 
-  RegValue = ArmGicV3GetControlSystemRegisterEnable ();
-  if ((RegValue & ICC_SRE_EL2_SRE) == 0) {
-    ArmGicV3SetControlSystemRegisterEnable (RegValue | ICC_SRE_EL2_SRE);
+  // MU_CHANGE [BEGIN] - Add ControlSystemRegValue
+  ControlSystemRegValue = ArmGicV3GetControlSystemRegisterEnable ();
+  if ((ControlSystemRegValue & ICC_SRE_EL2_SRE) == 0) {
+    ArmGicV3SetControlSystemRegisterEnable (ControlSystemRegValue | ICC_SRE_EL2_SRE);
+    // MU_CHANGE [END] - Add ControlSystemRegValue
     ASSERT ((ArmGicV3GetControlSystemRegisterEnable () & ICC_SRE_EL2_SRE) != 0);
   }
 

--- a/ArmPkg/Drivers/CpuDxe/PageTableMemoryAllocation.c
+++ b/ArmPkg/Drivers/CpuDxe/PageTableMemoryAllocation.c
@@ -104,6 +104,7 @@ FindPoolToAllocateFrom (
   @retval A pointer to the allocated page table memory or NULL if the
           allocation failed.
 **/
+STATIC
 VOID *
 AllocatePageTableMemory (
   IN UINTN  Pages
@@ -152,7 +153,7 @@ AllocatePageTableMemory (
   return Buffer;
 }
 
-PAGE_TABLE_MEM_ALLOC_PROTOCOL  mPageTableMemAllocProtocol = {
+STATIC PAGE_TABLE_MEM_ALLOC_PROTOCOL  mPageTableMemAllocProtocol = {
   AllocatePageTableMemory
 };
 

--- a/ArmPkg/Library/ArmMonitorLib/AArch64/ArmMonitorLib.masm
+++ b/ArmPkg/Library/ArmMonitorLib/AArch64/ArmMonitorLib.masm
@@ -6,8 +6,7 @@
 //
 //
 
-    AREA |.text|, CODE, READONLY
-    ALIGN 3
+    AREA |.text|,ALIGN=3,CODE, READONLY
 
     EXPORT ArmMonitorCall
 

--- a/ArmPkg/Library/ArmSmcLib/AArch64/ArmSmc.masm
+++ b/ArmPkg/Library/ArmSmcLib/AArch64/ArmSmc.masm
@@ -5,7 +5,7 @@
 //
 //------------------------------------------------------------------------------
 
-    AREA    |.text|,ALIGN=8,CODE,READONLY
+    AREA    |.text|,ALIGN=3,CODE,READONLY
 
     EXPORT ArmCallSmc
 


### PR DESCRIPTION
`##` Description

Add changes required for AARCH64 MSVC (Moved from old PR: https://github.com/microsoft/mu_silicon_arm_tiano/pull/355)
- Add missing functions in ArmGicV3.masm and include the .masm file in ArmGicDxe infs. 
- ArmMonitorLib.masm: change ALIGN value to fix compiler error `Compiler #2070 improper alignment value 3; expected [1,2,4,8...32768]`
- Add UINT32 ControlSystemRegValue to fix compiler type conversion warning. Previously, RegValue was being used for two values, one UINT32 and one UINT64.
- Make AllocatePageTableMemory static in CpuDxe. This fixes linker and compiler errors with ArmMmuLibPageTableAlloc. The MSVC errors were LNK2005, LNK1169, and Compiler #4744

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Built in project consuming ArmGicV3Dxe and ArmMonitorLib

## Integration Instructions

N/A
