### PR TITLE
Add RMR support for IORT and SmmuDxe IoMmu mappings

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -109,6 +109,7 @@ UpdateMapping (
   UINT32      Index;
   PAGE_TABLE  *Current;
   UINT64      Entry;
+  UINT32      SmmuIndex;
 
   // Flags must be 12 bits or less
   if ((Root == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (PhysicalAddress == 0)) {
@@ -153,7 +154,7 @@ UpdateMapping (
       if (Valid) {
         Entry = (PhysicalAddress & ~PAGE_TABLE_BLOCK_OFFSET); // Assign PA
         // validate entry and set leaf level flags
-        Entry                  |= PAGE_TABLE_ACCESS_FLAG | PAGE_TABLE_DESCRIPTOR | PAGE_TABLE_ENTRY_VALID_BIT;
+        Entry                  |= Flags | PAGE_TABLE_ACCESS_FLAG | PAGE_TABLE_DESCRIPTOR | PAGE_TABLE_ENTRY_VALID_BIT;
         Current->Entries[Index] =  Entry;
       } else {
         Current->Entries[Index] = Current->Entries[Index] & ~PAGE_TABLE_ENTRY_VALID_BIT; // only invalidate leaf entry
@@ -166,7 +167,24 @@ UpdateMapping (
     }
   }
 
-  ArmDataSynchronizationBarrier ();
+  // Invalidate TLBI Command.
+  // Current implementation of IoMmu protocol doesnt distinguish between stream id's or Smmu's.
+  // As a result we have to invalidate TLB for all SMMU's for the given virtual address to make
+  // sure that the correct smmu's streamid's page table's TLB is invalidated.
+  // To workaround the limitations of the IoMmu protocol, we globally set the page table root
+  // for all SMMU's and stream id's to be the same.
+  // Todo: Update the IoMmu protocol to support multiple SMMU's and stream id's so we don't have to
+  // invalidate all SMMU's TLB for a given virtual address, just the one that was updated.
+  if (!Valid) {
+    for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+      Status = SmmuV3TLBInvalidateAddress (&mIoMmu->SmmuInfo[SmmuIndex], VirtualAddress);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB\n", __func__));
+        goto End;
+      }
+    }
+  }
+
   SpeculationBarrier ();
 
 End:
@@ -188,7 +206,6 @@ End:
   @retval EFI_INVALID_PARAMETER  Invalid parameter.
   @retval EFI_OUT_OF_RESOURCES   Out of resources.
 **/
-STATIC
 EFI_STATUS
 UpdatePageTable (
   IN PAGE_TABLE  *Root,
@@ -202,7 +219,6 @@ UpdatePageTable (
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  PhysicalAddressEnd;
   EFI_PHYSICAL_ADDRESS  CurPhysicalAddress;
-  UINT32                SmmuIndex;
 
   if ((Root == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (PhysicalAddress == 0) || (Bytes == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
@@ -221,17 +237,6 @@ UpdatePageTable (
     }
 
     CurPhysicalAddress += EFI_PAGE_SIZE;
-  }
-
-  // Invalidate TLBI Command
-  if (!Valid) {
-    for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-      Status = SmmuV3TLBInvalidateAll (&mIoMmu->SmmuInfo[SmmuIndex]);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB.\n", __func__));
-        goto End;
-      }
-    }
   }
 
 End:

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -497,7 +497,7 @@ IoMmuSetAttribute (
              mIoMmu->SmmuInfo->PageTableRoot,
              MapInfo->PhysicalAddress,
              MapInfo->NumberOfBytes,
-             PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS (IoMmuAccess),
+             PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS ((EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)), // TODO: https://github.com/microsoft/mu_silicon_arm_tiano/issues/375 debug issue on physical platform and revert the permissions
              FALSE,
              TRUE
              );

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.h
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.h
@@ -23,6 +23,39 @@
 #define PAGE_TABLE_DESCRIPTOR       (0x1 << 1)
 #define PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS(IoMmuAccess)  (IoMmuAccess << 6)
 
+typedef UINT64 PAGE_TABLE_ENTRY;
+
+#define PAGE_TABLE_SIZE  (EFI_PAGE_SIZE / sizeof(PAGE_TABLE_ENTRY))  // Number of entries in a page table
+
+// Page Table Structure used by SMMU
+typedef struct _PAGE_TABLE {
+  PAGE_TABLE_ENTRY    Entries[PAGE_TABLE_SIZE];
+} PAGE_TABLE;
+
+/**
+  Update the page table mapping with the given physical address and flags.
+
+  @param [in]  Root                       Pointer to the root page table.
+  @param [in]  PhysicalAddress            Physical address to map.
+  @param [in]  Bytes                      Number of bytes to map.
+  @param [in]  Flags                      Flags to set for the mapping. 12 bits or less.
+  @param [in]  Valid                      Boolean to indicate if the entry is valid.
+  @param [in]  SetReadWriteFlagsOnly      Boolean to indicate if only R/W flags should be set.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_INVALID_PARAMETER  Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES   Out of resources.
+**/
+EFI_STATUS
+UpdatePageTable (
+  IN PAGE_TABLE  *Root,
+  IN UINT64      PhysicalAddress,
+  IN UINT64      Bytes,
+  IN UINT16      Flags,
+  IN BOOLEAN     Valid,
+  IN BOOLEAN     SetReadWriteFlagsOnly
+  );
+
 /**
   Installs the IOMMU Protocol on this SMMU instance.
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -327,18 +327,21 @@ SmmuV3BuildStreamTableEntry (
   OUT SMMUV3_STREAM_TABLE_ENTRY  *StreamEntry
   )
 {
-  EFI_STATUS   Status;
-  UINT32       InputSize;
-  SMMUV3_IDR0  Idr0;
-  SMMUV3_IDR1  Idr1;
-  SMMUV3_IDR5  Idr5;
-  UINT8        IortCohac;
-  UINT32       CCA;
-  UINT8        CPM;
-  UINT8        DACS;
-  UINT64       S2Sl0;
+  EFI_STATUS                                Status;
+  UINT32                                    InputSize;
+  SMMUV3_IDR0                               Idr0;
+  SMMUV3_IDR1                               Idr1;
+  SMMUV3_IDR5                               Idr5;
+  UINT8                                     IortCohac;
+  UINT32                                    CCA;
+  UINT8                                     CPM;
+  UINT8                                     DACS;
+  UINT64                                    S2Sl0;
+  EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE        *RmrNode;
+  EFI_ACPI_6_0_IO_REMAPPING_MEM_RANGE_DESC  *IortMemRangeDesc;
+  UINT32                                    NumMemRangeDesc;
 
-  if ((SmmuInfo == NULL) || (SmmuInfo->StreamEntryConfig == NULL) || (StreamEntry == NULL)) {
+  if ((SmmuInfo == NULL) || (SmmuInfo->StreamEntryConfig == NULL) || (StreamEntry == NULL) || (StreamId > SmmuInfo->StreamTableEntryMax)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
@@ -349,6 +352,29 @@ SmmuV3BuildStreamTableEntry (
 
   // Device attributes are Cacheable and Inner-Shareable
   DACS = (SmmuInfo->StreamEntryConfig[StreamId].MemoryAccessFlags & SMMUV3_STREAM_TABLE_ENTRY_DACS) >> 1;      // Shift by 1 to isolate DACS bit.
+
+  RmrNode = SmmuInfo->StreamEntryConfig[StreamId].RmrNode;
+
+  // Process memory range descriptors
+  if (RmrNode != NULL) {
+    for (NumMemRangeDesc = 0; NumMemRangeDesc < RmrNode->NumMemRangeDesc; NumMemRangeDesc++) {
+      IortMemRangeDesc = (EFI_ACPI_6_0_IO_REMAPPING_MEM_RANGE_DESC *)((UINT8 *)RmrNode + RmrNode->MemRangeDescRef);
+      if ((IortMemRangeDesc[NumMemRangeDesc].Base > 0) && (IortMemRangeDesc[NumMemRangeDesc].Length > 0)) {
+        Status = UpdatePageTable (
+                   SmmuInfo->PageTableRoot,
+                   IortMemRangeDesc[NumMemRangeDesc].Base,
+                   IortMemRangeDesc[NumMemRangeDesc].Length,
+                   PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS ((EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)),
+                   TRUE,
+                   FALSE
+                   );
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "%a: Failed to update RMR mapping.\n", __func__));
+          return Status;
+        }
+      }
+    }
+  }
 
   ZeroMem ((VOID *)StreamEntry, sizeof (SMMUV3_STREAM_TABLE_ENTRY));
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -15,6 +15,7 @@
 #include <Register/SmmuV3Registers.h>
 #include <Uefi/UefiBaseType.h>
 #include <IndustryStandard/IoRemappingTable.h>
+#include "IoMmu.h"
 
 // Number of levels in the page table
 #define PAGE_TABLE_DEPTH  4
@@ -142,10 +143,6 @@
 #define SMMUV3_CR0_VMW_DISABLED             0                // Disable VMID wildcard matching
 #define SMMUV3_CR0_ATS_CHK_DISABLE          1                // Disable bypass for ATS translated traffic
 
-typedef UINT64 PAGE_TABLE_ENTRY;
-
-#define PAGE_TABLE_SIZE  EFI_PAGE_SIZE / sizeof(PAGE_TABLE_ENTRY)  // Number of entries in a page table
-
 typedef enum _SMMU_ADDRESS_SIZE_TYPE {
   SmmuAddressSize32Bit = 0,
   SmmuAddressSize36Bit = 1,
@@ -156,14 +153,10 @@ typedef enum _SMMU_ADDRESS_SIZE_TYPE {
   SmmuAddressSize52Bit = 6,
 } SMMU_ADDRESS_SIZE_TYPE;
 
-// Page Table Structure used by SMMU
-typedef struct _PAGE_TABLE {
-  PAGE_TABLE_ENTRY    Entries[PAGE_TABLE_SIZE];
-} PAGE_TABLE;
-
 typedef struct _SMMU_STREAM_ENTRY_CONFIG {
-  UINT32    CacheCoherentAttribute;
-  UINT32    MemoryAccessFlags;
+  UINT32                                CacheCoherentAttribute;
+  UINT32                                MemoryAccessFlags;
+  EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE    *RmrNode;
 } SMMU_STREAM_ENTRY_CONFIG;
 
 // General SMMU Information for a SMMU instance
@@ -410,6 +403,23 @@ SmmuV3ConsumeEventQueueForErrors (
   );
 
 /**
+  Dump the page table entries for a given virtual address.
+  Dumps PTE's for all levels regardless of the starting level chosen for translation.
+
+  @param [in]  SmmuInfo        Pointer to the SMMU_INFO structure.
+  @param [in]  VirtualAddress  The virtual address to dump.
+  @param [in]  Root            Pointer to the root page table.
+
+  @retval None.
+**/
+VOID
+SmmuV3DumpPageTableEntries (
+  IN SMMU_INFO   *SmmuInfo,
+  IN UINT64      VirtualAddress,
+  IN PAGE_TABLE  *Root
+  );
+
+/**
   Log the errors if found from the SMMUv3. Prints Event Queue entries and GError register.
   Does nothing if no errors found.
 
@@ -448,6 +458,22 @@ SmmuV3SendCommand (
 EFI_STATUS
 SmmuV3TLBInvalidateAll (
   IN SMMU_INFO  *SmmuInfo
+  );
+
+/**
+  Invalidate TLB entries for specified InputAddress for Stage 2 of SmmuV3.
+
+  @param [in]  SmmuInfo      Pointer to the SMMU_INFO structure.
+  @param [in]  InputAddress  The input address to invalidate.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_TIMEOUT            Timeout.
+  @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+**/
+EFI_STATUS
+SmmuV3TLBInvalidateAddress (
+  IN SMMU_INFO  *SmmuInfo,
+  IN UINT64     InputAddress
   );
 
 /**

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -823,7 +823,6 @@ SmmuV3SendCommand (
 
 /**
   Invalidate all TLB entries in the SMMUv3.
-  TODO: Change to use CMD_TLBI_S2_IPA instead of ALL.
 
   @param [in]  SmmuInfo  Pointer to the SMMU_INFO structure.
 
@@ -853,6 +852,52 @@ SmmuV3TLBInvalidateAll (
   }
 
   SMMUV3_BUILD_CMD_TLBI_EL2_ALL (&Command);
+  Status = SmmuV3SendCommand (SmmuInfo, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_EL2_ALL failed.\n", __func__));
+    return Status;
+  }
+
+  // Issue a CMD_SYNC command to guarantee that any previously issued TLB
+  // invalidations (CMD_TLBI_*) are completed (SMMUv3.2 spec section 4.6.3).
+  SMMUV3_BUILD_CMD_SYNC_NO_INTERRUPT (&Command);
+  Status = SmmuV3SendCommand (SmmuInfo, &Command);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: CMD_SYNC_NO_INTERRUPT failed.\n", __func__));
+    return Status;
+  }
+
+  ArmDataSynchronizationBarrier ();
+
+  return Status;
+}
+
+/**
+  Invalidate TLB entries for specified InputAddress for Stage 2 of SmmuV3.
+
+  @param [in]  SmmuInfo      Pointer to the SMMU_INFO structure.
+  @param [in]  InputAddress  The input address to invalidate.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_TIMEOUT            Timeout.
+  @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+**/
+EFI_STATUS
+SmmuV3TLBInvalidateAddress (
+  IN SMMU_INFO  *SmmuInfo,
+  IN UINT64     InputAddress
+  )
+{
+  SMMUV3_CMD_GENERIC  Command;
+  EFI_STATUS          Status;
+
+  if (SmmuInfo == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Invalidate with TLBI_S2_IPA Commands
+  SMMUV3_BUILD_CMD_TLBI_S2_IPA (&Command, SMMUV3_STREAM_TABLE_ENTRY_S2VMID, InputAddress);
   Status = SmmuV3SendCommand (SmmuInfo, &Command);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_EL2_ALL failed.\n", __func__));
@@ -1120,7 +1165,7 @@ SmmuV3GetStreamIdInfo (
   Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Iort + Iort->NodeOffset);
 
   for (Count = 0; Count < Iort->NumNodes; Count++) {
-    if ((Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) || (Node->Type == EFI_ACPI_IORT_TYPE_NAMED_COMP)) {
+    if ((Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) || (Node->Type == EFI_ACPI_IORT_TYPE_NAMED_COMP) || (Node->Type == EFI_ACPI_IORT_TYPE_RMR)) {
       // Extract Cache Coherent and Memory Access Flags based on node type
       if (Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) {
         RcNode                                   = (EFI_ACPI_6_0_IO_REMAPPING_RC_NODE *)Node;
@@ -1152,7 +1197,12 @@ SmmuV3GetStreamIdInfo (
 
               // Store the Stream ID range information
               for (CurID = StartId; CurID <= EndId; CurID++) {
-                CopyMem (&SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID], &StreamEntryConfig, sizeof (SMMU_STREAM_ENTRY_CONFIG));
+                if (Node->Type == EFI_ACPI_IORT_TYPE_RMR) {
+                  SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID].RmrNode = (EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE *)Node;
+                } else {
+                  SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID].CacheCoherentAttribute = StreamEntryConfig.CacheCoherentAttribute;
+                  SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID].MemoryAccessFlags      = StreamEntryConfig.MemoryAccessFlags;
+                }
               }
 
               DEBUG ((


### PR DESCRIPTION
## Description

Add RMR support for IORT and SmmuDxe IoMmu mappings
Parses IORT for RMR node memory range descriptors
Maps them to the SMMU page tables to be used by the IoMmu protocol

Updates TLIBI operation from TLIBI ALL to TLIBI S2 IPA, now invalidates TLB for InputAddress to Stage 2 SMMU.

Due to an issue seen while testing on a physical arm platform, we see a 0x13 F_PERMISSION fault from the smmu when not setting both r/w bits. For now, temporarily setting both RW bits in  IoMmuSetAttribute
TODO: https://github.com/microsoft/mu_silicon_arm_tiano/issues/375 Debug this issue and revert this commit

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on QEMU SBSA and physical arm platform

## Integration Instructions

N/A
