### PR TITLE
PSCI warm reset fix

### DIFF
--- a/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
+++ b/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
@@ -16,6 +16,7 @@
 #include <IndustryStandard/ArmStdSmc.h>
 
 #include <Library/ArmMonitorLib.h>
+#include <Library/BaseMemoryLib.h> // MU_CHANGE
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/ResetSystemLib.h>
@@ -51,6 +52,7 @@ ResetCold (
 {
   ARM_MONITOR_ARGS  Args;
 
+  ZeroMem (&Args, sizeof (ARM_MONITOR_ARGS)); // MU_CHANGE
   // Send a PSCI 0.2 SYSTEM_RESET command
   Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET;
 
@@ -71,12 +73,15 @@ ResetWarm (
 {
   ARM_MONITOR_ARGS  Args;
 
+  ZeroMem (&Args, sizeof (ARM_MONITOR_ARGS)); // MU_CHANGE
+
   Args.Arg0 = ARM_SMC_ID_PSCI_FEATURES;              // MU_CHANGE
   Args.Arg1 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64; // MU_CHANGE
   // Is SYSTEM_RESET2 supported?
   ArmMonitorCall (&Args);
   if (Args.Arg0 == ARM_SMC_PSCI_RET_SUCCESS) {
     // Send PSCI SYSTEM_RESET2 command
+    ZeroMem (&Args, sizeof (ARM_MONITOR_ARGS)); // MU_CHANGE
     Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
 
     ArmMonitorCall (&Args);
@@ -104,6 +109,7 @@ ResetShutdown (
 {
   ARM_MONITOR_ARGS  Args;
 
+  ZeroMem (&Args, sizeof (ARM_MONITOR_ARGS)); // MU_CHANGE
   // Send a PSCI 0.2 SYSTEM_RESET command
   Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_OFF;
 

--- a/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
+++ b/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
@@ -71,8 +71,8 @@ ResetWarm (
 {
   ARM_MONITOR_ARGS  Args;
 
-  Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
-
+  Args.Arg0 = ARM_SMC_ID_PSCI_FEATURES;              // MU_CHANGE
+  Args.Arg1 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64; // MU_CHANGE
   // Is SYSTEM_RESET2 supported?
   ArmMonitorCall (&Args);
   if (Args.Arg0 == ARM_SMC_PSCI_RET_SUCCESS) {

--- a/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.inf
+++ b/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.inf
@@ -28,5 +28,6 @@
 
 [LibraryClasses]
   ArmMonitorLib
+  BaseMemoryLib # MU_CHANGE
   BaseLib
   DebugLib


### PR DESCRIPTION
## Description

This resolves an issue in the ResetWarm() routine where the warm reset was being attempted twice instead of querying for PSCI SYSTEM_RESET2 support. In addition, it ensures that the monitor args are zero'd prior to monitor calls. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested warm reset flow with this change, confirmed that SYSTEM_RESET2 works as expected.

## Integration Instructions

N/A
