### PR TITLE
[Cherry-Pick] ArmPkg: Add HobLib to ArmStandaloneMmCoreEntryPoint.

### DIFF
--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
@@ -51,6 +51,7 @@
   ArmTransferListLib
   ArmFfaLib
   StackCheckLib
+  HobLib
 
 [Guids]
   gMpInformationHobGuid


### PR DESCRIPTION


## Description

ArmStandaloneMmCoreEntryPoint makes use of GetNextHob which comes from HobLib. The inf does not specify
HobLib has one of its library classes. Specify
HobLib in the LibraryClasses section of the
inf.

(cherry picked from commit 95f1b10aad7928b8f27b13624ae6434f1cfe83a1)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
CI is failing on mu_feature_ffa due to this missing hob.

## Integration Instructions
No integration necessary.