### PR TITLE
Update SMMU_CONFIG HOB to use a Smmu disabled list instead.

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/README.md
+++ b/ArmPkg/Drivers/SmmuDxe/README.md
@@ -244,27 +244,21 @@ Generic Platform Integration:
 - Append the IORT structure to this struct and update the fields accordingly.
 
   ```c
-   // SMMU_STATUS structure to hold the status of each SMMU instance.
-   // Contains the base address of the SMMU and whether it is enabled or not.
-   typedef struct _SMMU_STATUS {
-      UINT64     SmmuBase;
-      BOOLEAN    Enabled;
-   } SMMU_STATUS;
-
    // SMMU_CONFIG structure to pass the SMMU configuration data from the platform to the SMMU driver.
    typedef struct _SMMU_CONFIG {
-      UINT32         VersionMajor;
-      UINT32         VersionMinor;
-      UINT32         SmmuCount;
-      SMMU_STATUS    *SmmuStatus;
-      UINT32         IortSize;
-      UINT32         IortOffset;
+      UINT32    VersionMajor;
+      UINT32    VersionMinor;
+      UINT64    SmmuDisabledCount;                // Number of SMMU instances to be disabled.
+      UINT64    SmmuDisabledList[MAX_SMMU_COUNT]; // Array of disabled SMMU stream IDs.
+      UINT32    IortSize;
+      UINT32    IortOffset;      // Offset in bytes to the IORT table from the start of the HOB structure.
    } SMMU_CONFIG;
   ```
 
 - Essentialy the same as IORT we want to publish
 - The SMMU expects the entire IORT data to be passed into a HOB gSmmuConfigHobGuid.
 - The platform must create the IORT structure and create gSmmuConfigHobGuid with that data using BuildGuidDataHob.
+- If the platform needs to disable/bypass any Smmu, they can add the SMMU base address to the SmmuDisabledList in the HOB.
 - This structure is consumed by SmmuDxe to configure the SMMU hardware
 
 Integration with Qemu:

--- a/ArmPkg/Drivers/SmmuDxe/README.md
+++ b/ArmPkg/Drivers/SmmuDxe/README.md
@@ -245,13 +245,15 @@ Generic Platform Integration:
 
   ```c
    // SMMU_CONFIG structure to pass the SMMU configuration data from the platform to the SMMU driver.
+   // Platform will configure SmmuDisabledList size and offset to the SMMU disabled list appropriatley
+   // for any SMMU that needs be disabled in UEFI and set to bypass.
    typedef struct _SMMU_CONFIG {
       UINT32    VersionMajor;
       UINT32    VersionMinor;
-      UINT64    SmmuDisabledCount;                // Number of SMMU instances to be disabled.
-      UINT64    SmmuDisabledList[MAX_SMMU_COUNT]; // Array of disabled SMMU stream IDs.
+      UINT32    SmmuDisabledListSize;   // Size of SmmuDisabledList in bytes.
+      UINT32    SmmuDisabledListOffset; // Offset in bytes to the SmmuDisabledList from the start of the HOB structure.
       UINT32    IortSize;
-      UINT32    IortOffset;      // Offset in bytes to the IORT table from the start of the HOB structure.
+      UINT32    IortOffset;             // Offset in bytes to the IORT table from the start of the HOB structure.
    } SMMU_CONFIG;
   ```
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -851,12 +851,17 @@ GetSmmuConfigHobData (
 **/
 STATIC
 EFI_STATUS
-CheckSmmuConfigVersion (
+CheckSmmuConfigStructure (
   IN SMMU_CONFIG  *SmmuConfig
   )
 {
   if (SmmuConfig == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: SMMU_CONFIG structure is NULL\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((SmmuConfig->SmmuDisabledCount > 0) && (SmmuConfig->SmmuDisabledList == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: SMMU_CONFIG structure has SmmuDisabledCount > 0 but SmmuDisabledList is NULL\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
@@ -1049,7 +1054,7 @@ InitializeSmmuDxe (
   }
 
   // Check SMMU_CONFIG version, return error if incompatible. Backwards compatibility not supported.
-  Status = CheckSmmuConfigVersion (SmmuConfig);
+  Status = CheckSmmuConfigStructure (SmmuConfig);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: SMMU_CONFIG version check failed\n", __func__));
     return Status;
@@ -1086,7 +1091,7 @@ InitializeSmmuDxe (
     return Status;
   }
 
-  IortData = (VOID *)((UINT8 *)SmmuConfig + SmmuConfig->IortOffset);
+  IortData = (VOID *)((UINTN)SmmuConfig + (UINTN)SmmuConfig->IortOffset);
 
   Status = SmmuV3ParseIort (IortData, &mIoMmu->SmmuInfo, &mIoMmu->SmmuCount);
   if (EFI_ERROR (Status)) {
@@ -1111,11 +1116,12 @@ InitializeSmmuDxe (
     goto Error;
   }
 
-  // Set SMMUs' Enabled status based on the SMMU_STATUS in the SMMU_CONFIG HOB structure.
-  for (SmmuStatusIndex = 0; SmmuStatusIndex < SmmuConfig->SmmuCount; SmmuStatusIndex++) {
-    for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-      if (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase == SmmuConfig->SmmuStatus[SmmuStatusIndex].SmmuBase) {
-        mIoMmu->SmmuInfo[SmmuIndex].Enabled = SmmuConfig->SmmuStatus[SmmuStatusIndex].Enabled;
+  // Set SMMUs' Enabled status based on the SmmuDisabledList in the SMMU_CONFIG HOB structure.
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    mIoMmu->SmmuInfo[SmmuIndex].Enabled = TRUE;
+    for (SmmuStatusIndex = 0; SmmuStatusIndex < SmmuConfig->SmmuDisabledCount; SmmuStatusIndex++) {
+      if (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase == SmmuConfig->SmmuDisabledList[SmmuStatusIndex]) {
+        mIoMmu->SmmuInfo[SmmuIndex].Enabled = FALSE;
       }
     }
   }
@@ -1128,6 +1134,8 @@ InitializeSmmuDxe (
         DEBUG ((DEBUG_ERROR, "%a: Failed to configure SMMUv3 hardware\n", __func__));
         goto Error;
       }
+
+      DEBUG ((DEBUG_INFO, "%a: SMMUv3 0x%llx is configured for Stage2 Translation\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
     }
   }
 
@@ -1147,7 +1155,7 @@ InitializeSmmuDxe (
         ASSERT_EFI_ERROR (Status);
       }
 
-      DEBUG ((DEBUG_INFO, "%a: SMMUv3 0x%llx is disabled\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
+      DEBUG ((DEBUG_INFO, "%a: SMMUv3 0x%llx is disabled/global bypass.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
     }
   }
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -860,11 +860,6 @@ CheckSmmuConfigStructure (
     return EFI_INVALID_PARAMETER;
   }
 
-  if ((SmmuConfig->SmmuDisabledCount > 0) && (SmmuConfig->SmmuDisabledList == NULL)) {
-    DEBUG ((DEBUG_ERROR, "%a: SMMU_CONFIG structure has SmmuDisabledCount > 0 but SmmuDisabledList is NULL\n", __func__));
-    return EFI_INVALID_PARAMETER;
-  }
-
   if ((SmmuConfig->VersionMajor == CURRENT_SMMU_CONFIG_VERSION_MAJOR) && (SmmuConfig->VersionMinor == CURRENT_SMMU_CONFIG_VERSION_MINOR)) {
     return EFI_SUCCESS;
   }
@@ -1041,6 +1036,8 @@ InitializeSmmuDxe (
   EFI_EVENT                Event;
   UINT32                   SmmuIndex;
   UINT32                   SmmuStatusIndex;
+  UINT32                   SmmuDisabledCount;
+  UINT64                   *SmmuDisabledList;
   EFI_ACPI_TABLE_PROTOCOL  *AcpiTable;
   SMMU_CONFIG              *SmmuConfig;
   PAGE_TABLE               *PageTableRoot;
@@ -1117,10 +1114,13 @@ InitializeSmmuDxe (
   }
 
   // Set SMMUs' Enabled status based on the SmmuDisabledList in the SMMU_CONFIG HOB structure.
+  SmmuDisabledCount = SmmuConfig->SmmuDisabledListSize / sizeof (UINT64);
+  SmmuDisabledList  = (UINT64 *)((UINTN)SmmuConfig + (UINTN)SmmuConfig->SmmuDisabledListOffset);
+
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
     mIoMmu->SmmuInfo[SmmuIndex].Enabled = TRUE;
-    for (SmmuStatusIndex = 0; SmmuStatusIndex < SmmuConfig->SmmuDisabledCount; SmmuStatusIndex++) {
-      if (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase == SmmuConfig->SmmuDisabledList[SmmuStatusIndex]) {
+    for (SmmuStatusIndex = 0; SmmuStatusIndex < SmmuDisabledCount; SmmuStatusIndex++) {
+      if (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase == SmmuDisabledList[SmmuStatusIndex]) {
         mIoMmu->SmmuInfo[SmmuIndex].Enabled = FALSE;
       }
     }

--- a/ArmPkg/Include/Guid/SmmuConfig.h
+++ b/ArmPkg/Include/Guid/SmmuConfig.h
@@ -28,18 +28,18 @@
 #define CURRENT_SMMU_CONFIG_VERSION_MAJOR  0
 #define CURRENT_SMMU_CONFIG_VERSION_MINOR  9
 
-#define MAX_SMMU_COUNT  512
-
 #pragma pack(push, 1)
 
 // SMMU_CONFIG structure to pass the SMMU configuration data from the platform to the SMMU driver.
+// Platform will configure SmmuDisabledList size and offset to the SMMU disabled list appropriatley
+// for any SMMU that needs be disabled in UEFI and set to bypass.
 typedef struct _SMMU_CONFIG {
   UINT32    VersionMajor;
   UINT32    VersionMinor;
-  UINT64    SmmuDisabledCount;                // Number of SMMU instances to be disabled.
-  UINT64    SmmuDisabledList[MAX_SMMU_COUNT]; // Array of disabled SMMU stream IDs.
+  UINT32    SmmuDisabledListSize;   // Size of SmmuDisabledList in bytes.
+  UINT32    SmmuDisabledListOffset; // Offset in bytes to the SmmuDisabledList from the start of the HOB structure.
   UINT32    IortSize;
-  UINT32    IortOffset;      // Offset in bytes to the IORT table from the start of the HOB structure.
+  UINT32    IortOffset;             // Offset in bytes to the IORT table from the start of the HOB structure.
 } SMMU_CONFIG;
 
 #pragma pack(pop)

--- a/ArmPkg/Include/Guid/SmmuConfig.h
+++ b/ArmPkg/Include/Guid/SmmuConfig.h
@@ -26,25 +26,20 @@
   SmmuDxe driver will check and enforce the version of the SMMU_CONFIG structure to this current version set here.
 */
 #define CURRENT_SMMU_CONFIG_VERSION_MAJOR  0
-#define CURRENT_SMMU_CONFIG_VERSION_MINOR  8
+#define CURRENT_SMMU_CONFIG_VERSION_MINOR  9
+
+#define MAX_SMMU_COUNT  512
 
 #pragma pack(push, 1)
 
-// SMMU_STATUS structure to hold the status of each SMMU instance.
-// Contains the base address of the SMMU and whether it is enabled or not.
-typedef struct _SMMU_STATUS {
-  UINT64     SmmuBase;
-  BOOLEAN    Enabled;
-} SMMU_STATUS;
-
 // SMMU_CONFIG structure to pass the SMMU configuration data from the platform to the SMMU driver.
 typedef struct _SMMU_CONFIG {
-  UINT32         VersionMajor;
-  UINT32         VersionMinor;
-  UINT32         SmmuCount;
-  SMMU_STATUS    *SmmuStatus;
-  UINT32         IortSize;
-  UINT32         IortOffset;
+  UINT32    VersionMajor;
+  UINT32    VersionMinor;
+  UINT64    SmmuDisabledCount;                // Number of SMMU instances to be disabled.
+  UINT64    SmmuDisabledList[MAX_SMMU_COUNT]; // Array of disabled SMMU stream IDs.
+  UINT32    IortSize;
+  UINT32    IortOffset;      // Offset in bytes to the IORT table from the start of the HOB structure.
 } SMMU_CONFIG;
 
 #pragma pack(pop)


### PR DESCRIPTION
## Description

Currently, the platform will have to define explicitly each Smmu base/enabled/disabled status. This could lead to the platform accidentally setting this incorrectly.

As a result, we now set all Smmu's to enabled by default, and if a Smmu base address is found in the SmmuDisabledList within the SMMU_CONFIG HOB, then it will be disabled and set to bypass mode.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on physical arm device and qemu sbsa.

## Integration Instructions

Platform will create and publish this SMMU_CONFIG HOB for SmmuDxe to consume.
