### PR TITLE
[CHERRY-PICK] Extending FF-A definitions

### DIFF
--- a/ArmPkg/Include/IndustryStandard/ArmFfaSvc.h
+++ b/ArmPkg/Include/IndustryStandard/ArmFfaSvc.h
@@ -196,6 +196,8 @@
 #define ARM_FFA_SET_MEM_ATTR_CODE_PERM_X      0
 #define ARM_FFA_SET_MEM_ATTR_CODE_PERM_XN     1
 
+#define ARM_FFA_MEM_PERM_RESERVED_MASK  0xFFFFFFF8
+
 #define ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST(dataperm, codeperm)  \
     ((((codeperm) & ARM_FFA_SET_MEM_ATTR_CODE_PERM_MASK) <<         \
       ARM_FFA_SET_MEM_ATTR_CODE_PERM_SHIFT) |                       \
@@ -223,5 +225,40 @@
 
 #define IS_FID_FFA_ERROR(fid) \
   (fid == ARM_FID_FFA_ERROR)
+
+/*
+ * macro used in FFA_NOTIFICATION_GET/SET
+ * See FF-A spec sections for FFA_NOTIFICATION_GET and
+ * FFA_NOTIFICATION_SET
+ */
+#define ARM_FFA_NOTIFICATION_FLAG_PER_VCPU  (0x1 << 0)
+
+/** Flag to delay Schedule Receiver Interrupt. */
+#define ARM_FFA_NOTIFICATION_FLAG_DELAY_SRI  (0x1 << 1)
+
+#define ARM_FFA_NOTIFICATION_FLAGS_VCPU_ID(id)  ((id & 0xFFFF) << 16)
+
+#define ARM_FFA_NOTIFICATION_FLAG_BITMAP_SP   (0x1 << 0)
+#define ARM_FFA_NOTIFICATION_FLAG_BITMAP_VM   (0x1 << 1)
+#define ARM_FFA_NOTIFICATION_FLAG_BITMAP_SPM  (0x1 << 2)
+#define ARM_FFA_NOTIFICATION_FLAG_BITMAP_HYP  (0x1 << 3)
+
+/*
+ * macro used in FFA_FEATURES function.
+ * See FF-A spec sections for FFA_FEATURES, Table of
+ * Feature IDs and properties table.
+ */
+
+/** Query interrupt ID of Notification Pending Interrupt. */
+#define ARM_FFA_FEATURE_NPI  0x1U
+
+/** Query interrupt ID of Schedule Receiver Interrupt. */
+#define ARM_FFA_FEATURE_SRI  0x2U
+
+/** Query interrupt ID of the Managed Exit Interrupt. */
+#define ARM_FFA_FEATURE_MEI  0x3U
+
+/** Query notifications features. */
+#define ARM_FFA_FEATURE_NOTIFICATIONS  0x4U
 
 #endif // ARM_FFA_SVC_H_

--- a/ArmPkg/Include/IndustryStandard/ArmFfaSvc.h
+++ b/ArmPkg/Include/IndustryStandard/ArmFfaSvc.h
@@ -196,8 +196,6 @@
 #define ARM_FFA_SET_MEM_ATTR_CODE_PERM_X      0
 #define ARM_FFA_SET_MEM_ATTR_CODE_PERM_XN     1
 
-#define ARM_FFA_MEM_PERM_RESERVED_MASK  0xFFFFFFF8
-
 #define ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST(dataperm, codeperm)  \
     ((((codeperm) & ARM_FFA_SET_MEM_ATTR_CODE_PERM_MASK) <<         \
       ARM_FFA_SET_MEM_ATTR_CODE_PERM_SHIFT) |                       \
@@ -225,26 +223,5 @@
 
 #define IS_FID_FFA_ERROR(fid) \
   (fid == ARM_FID_FFA_ERROR)
-
-#define FFA_NOTIFICATIONS_FLAG_PER_VCPU  (0x1 << 0)
-
-/** Flag to delay Schedule Receiver Interrupt. */
-#define FFA_NOTIFICATIONS_FLAG_DELAY_SRI  (0x1 << 1)
-
-#define FFA_NOTIFICATIONS_FLAGS_VCPU_ID(id)  ((id & 0xFFFF) << 16)
-
-#define FFA_NOTIFICATIONS_FLAG_BITMAP_SP   (0x1 << 0)
-#define FFA_NOTIFICATIONS_FLAG_BITMAP_VM   (0x1 << 1)
-#define FFA_NOTIFICATIONS_FLAG_BITMAP_SPM  (0x1 << 2)
-#define FFA_NOTIFICATIONS_FLAG_BITMAP_HYP  (0x1 << 3)
-
-/** Query interrupt ID of Notification Pending Interrupt. */
-#define FFA_FEATURE_NPI  0x1U
-
-/** Query interrupt ID of Schedule Receiver Interrupt. */
-#define FFA_FEATURE_SRI  0x2U
-
-/** Query interrupt ID of the Managed Exit Interrupt. */
-#define FFA_FEATURE_MEI  0x3U
 
 #endif // ARM_FFA_SVC_H_


### PR DESCRIPTION
## Description

These definitions used be brought in to Project MU.

Now that this PR is merged to EDK2 https://github.com/tianocore/edk2/pull/10686, we can move to the EDK2 version and revert our original changes.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This was tested on QEMU SBSA and booted to UEFI Shell.

## Integration Instructions

The names of macro definitions has changed during upstreaming process. Thus the consumers need to update the code accordingly.

| Original Name | New Name |
|-|-|
| FFA_NOTIFICATIONS_FLAG_PER_VCPU | ARM_FFA_NOTIFICATION_FLAG_PER_VCPU |
| FFA_NOTIFICATIONS_FLAG_DELAY_SRI | ARM_FFA_NOTIFICATION_FLAG_DELAY_SRI |
| FFA_NOTIFICATIONS_FLAGS_VCPU_ID | ARM_FFA_NOTIFICATION_FLAGS_VCPU_ID |
| FFA_NOTIFICATIONS_FLAG_BITMAP_SP | ARM_FFA_NOTIFICATION_FLAG_BITMAP_SP |
| FFA_NOTIFICATIONS_FLAG_BITMAP_VM | ARM_FFA_NOTIFICATION_FLAG_BITMAP_VM |
| FFA_NOTIFICATIONS_FLAG_BITMAP_SPM | ARM_FFA_NOTIFICATION_FLAG_BITMAP_SPM |
| FFA_NOTIFICATIONS_FLAG_BITMAP_HYP | ARM_FFA_NOTIFICATION_FLAG_BITMAP_HYP |
| FFA_FEATURE_NPI | ARM_FFA_FEATURE_NPI |
| FFA_FEATURE_SRI | ARM_FFA_FEATURE_SRI |
| FFA_FEATURE_MEI | ARM_FFA_FEATURE_MEI |