### PR TITLE
[CHERRY-PICK] Fix PSCI-based warm reset

### DIFF
--- a/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
+++ b/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
@@ -71,13 +71,16 @@ ResetWarm (
 {
   ARM_MONITOR_ARGS  Args;
 
-  Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
+  Args.Arg0 = ARM_SMC_ID_PSCI_FEATURES;
+  Args.Arg1 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
 
   // Is SYSTEM_RESET2 supported?
   ArmMonitorCall (&Args);
   if (Args.Arg0 == ARM_SMC_PSCI_RET_SUCCESS) {
     // Send PSCI SYSTEM_RESET2 command
     Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
+    Args.Arg1 = 0; // Reset type
+    // cookie does not matter with reset type 0
 
     ArmMonitorCall (&Args);
   } else {

--- a/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
+++ b/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.c
@@ -16,7 +16,6 @@
 #include <IndustryStandard/ArmStdSmc.h>
 
 #include <Library/ArmMonitorLib.h>
-#include <Library/BaseMemoryLib.h> // MU_CHANGE
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/ResetSystemLib.h>
@@ -52,7 +51,6 @@ ResetCold (
 {
   ARM_MONITOR_ARGS  Args;
 
-  ZeroMem (&Args, sizeof (ARM_MONITOR_ARGS)); // MU_CHANGE
   // Send a PSCI 0.2 SYSTEM_RESET command
   Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET;
 
@@ -73,15 +71,12 @@ ResetWarm (
 {
   ARM_MONITOR_ARGS  Args;
 
-  ZeroMem (&Args, sizeof (ARM_MONITOR_ARGS)); // MU_CHANGE
+  Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
 
-  Args.Arg0 = ARM_SMC_ID_PSCI_FEATURES;              // MU_CHANGE
-  Args.Arg1 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64; // MU_CHANGE
   // Is SYSTEM_RESET2 supported?
   ArmMonitorCall (&Args);
   if (Args.Arg0 == ARM_SMC_PSCI_RET_SUCCESS) {
     // Send PSCI SYSTEM_RESET2 command
-    ZeroMem (&Args, sizeof (ARM_MONITOR_ARGS)); // MU_CHANGE
     Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
 
     ArmMonitorCall (&Args);
@@ -109,7 +104,6 @@ ResetShutdown (
 {
   ARM_MONITOR_ARGS  Args;
 
-  ZeroMem (&Args, sizeof (ARM_MONITOR_ARGS)); // MU_CHANGE
   // Send a PSCI 0.2 SYSTEM_RESET command
   Args.Arg0 = ARM_SMC_ID_PSCI_SYSTEM_OFF;
 

--- a/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.inf
+++ b/ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.inf
@@ -28,6 +28,5 @@
 
 [LibraryClasses]
   ArmMonitorLib
-  BaseMemoryLib # MU_CHANGE
   BaseLib
   DebugLib


### PR DESCRIPTION
## Description

This change replaces the warm reset fix with the finalized version of EDK2 commit:
https://github.com/tianocore/edk2/pull/11093

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This was tested on QEMU SBSA and booted to UEFI shell.

## Integration Instructions

N/A