### PR TITLE
ArmPkg: SmmuDxe Switch to 2-Level Stream Table Implementation

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/README.md
+++ b/ArmPkg/Drivers/SmmuDxe/README.md
@@ -157,7 +157,8 @@ Translation Table Base.
 
 2. **SMMU Translation**:
    - Looks up Stream Table Entry (STE)
-   - Walks 4-level page tables
+      - 2 level or Linear Stream Table. Depending on configurable maximum StreamId via IORT.
+   - Walks up to 4-level page tables
    - Converts IOVA to PA (Physical Address)
 
 ## Memory Protection
@@ -229,9 +230,8 @@ Current implementation constraints:
 1. Fixed 4KB granule size
 2. 48-bit address space limit
 3. Stage 2 translation only
-   - Stage 2 is used on its own to simplify the translation process and use a linear stream table.
-4. Linear Stream Table
-5. Identity mapped page tables
+   - Stage 2 is used on its own to simplify the translation process.
+4. Identity mapped page tables
 
 ## Future Enhancements
 
@@ -239,9 +239,8 @@ Potential improvements:
 
 1. Multiple translation granule support
 2. Stage 1 & 2 translation
-3. 2-level Stream Tables
-4. Different page table mapping schemes
-5. Updated IoMmu Protocol to optimize redundencies
+3. Different page table mapping schemes
+4. Updated IoMmu Protocol to optimize redundencies
 
 ## Configuration Options
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -24,7 +24,6 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiDriverEntryPoint.h>
 #include <Protocol/AcpiTable.h>
-#include <Protocol/IoMmu.h>
 #include <Guid/SmmuConfig.h>
 #include "IoMmu.h"
 #include "SmmuV3.h"
@@ -295,10 +294,9 @@ SmmuV3FreeQueue (
 }
 
 /**
-  Build the stream table for SMMUv3.
+  Build the default stream table entry for SMMUv3.
 
   @param [in]  SmmuInfo       Pointer to the SMMU_INFO structure.
-  @param [in]  StreamId       Stream ID.
   @param [out] StreamEntry    Pointer to the stream table entry.
 
   @retval EFI_SUCCESS         Success.
@@ -308,58 +306,29 @@ STATIC
 EFI_STATUS
 SmmuV3BuildStreamTableEntry (
   IN SMMU_INFO                   *SmmuInfo,
-  IN UINT32                      StreamId,
   OUT SMMUV3_STREAM_TABLE_ENTRY  *StreamEntry
   )
 {
-  EFI_STATUS                                Status;
-  UINT32                                    InputSize;
-  SMMUV3_IDR0                               Idr0;
-  SMMUV3_IDR1                               Idr1;
-  SMMUV3_IDR5                               Idr5;
-  UINT8                                     IortCohac;
-  UINT32                                    CCA;
-  UINT8                                     CPM;
-  UINT8                                     DACS;
-  UINT64                                    S2Sl0;
-  EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE        *RmrNode;
-  EFI_ACPI_6_0_IO_REMAPPING_MEM_RANGE_DESC  *IortMemRangeDesc;
-  UINT32                                    NumMemRangeDesc;
+  EFI_STATUS   Status;
+  UINT32       InputSize;
+  SMMUV3_IDR0  Idr0;
+  SMMUV3_IDR1  Idr1;
+  SMMUV3_IDR5  Idr5;
+  UINT8        IortCohac;
+  UINT32       CCA;
+  UINT8        CPM;
+  UINT8        DACS;
+  UINT64       S2Sl0;
 
-  if ((SmmuInfo == NULL) || (SmmuInfo->StreamEntryConfig == NULL) || (StreamEntry == NULL) || (StreamId > SmmuInfo->StreamTableEntryMax)) {
+  if ((SmmuInfo == NULL) || (StreamEntry == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
-  IortCohac = SmmuInfo->Flags & EFI_ACPI_IORT_SMMUv3_FLAG_COHAC_OVERRIDE;                              // Cohac override flag
-  CCA       = SmmuInfo->StreamEntryConfig[StreamId].CacheCoherentAttribute;                            // Cache Coherent Attribute
-  CPM       = SmmuInfo->StreamEntryConfig[StreamId].MemoryAccessFlags & SMMUV3_STREAM_TABLE_ENTRY_CPM; // Coherent Path to Memory
-
-  // Device attributes are Cacheable and Inner-Shareable
-  DACS = (SmmuInfo->StreamEntryConfig[StreamId].MemoryAccessFlags & SMMUV3_STREAM_TABLE_ENTRY_DACS) >> 1;      // Shift by 1 to isolate DACS bit.
-
-  RmrNode = SmmuInfo->RmrNode;
-
-  // Process memory range descriptors
-  if (RmrNode != NULL) {
-    for (NumMemRangeDesc = 0; NumMemRangeDesc < RmrNode->NumMemRangeDesc; NumMemRangeDesc++) {
-      IortMemRangeDesc = (EFI_ACPI_6_0_IO_REMAPPING_MEM_RANGE_DESC *)((UINT8 *)RmrNode + RmrNode->MemRangeDescRef);
-      if ((IortMemRangeDesc[NumMemRangeDesc].Base > 0) && (IortMemRangeDesc[NumMemRangeDesc].Length > 0)) {
-        Status = UpdatePageTable (
-                   SmmuInfo->PageTableRoot,
-                   IortMemRangeDesc[NumMemRangeDesc].Base,
-                   IortMemRangeDesc[NumMemRangeDesc].Length,
-                   PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS ((EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)),
-                   TRUE,
-                   FALSE
-                   );
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_ERROR, "%a: Failed to update RMR mapping.\n", __func__));
-          return Status;
-        }
-      }
-    }
-  }
+  IortCohac = SmmuInfo->Flags & EFI_ACPI_IORT_SMMUv3_FLAG_COHAC_OVERRIDE; // Cohac override flag
+  CCA       = SMMUV3_STREAM_TABLE_ENTRY_CCA;
+  CPM       = SMMUV3_STREAM_TABLE_ENTRY_CPM;
+  DACS      = SMMUV3_STREAM_TABLE_ENTRY_DACS;
 
   ZeroMem ((VOID *)StreamEntry, sizeof (SMMUV3_STREAM_TABLE_ENTRY));
 
@@ -647,17 +616,20 @@ SmmuV3Configure (
     goto End;
   }
 
+  Status = SmmuV3AddRMRMapping (SmmuInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Error adding RMR mapping\n", __func__));
+    goto End;
+  }
+
   // Load default STE values
-  if (!TwoLevelStreamTable) {
-    StreamTableEntryPtr = (SMMUV3_STREAM_TABLE_ENTRY *)StreamTablePtr;
-    for (Index = 0; Index <= SmmuInfo->StreamTableEntryMax; Index++) {
-      Status = SmmuV3BuildStreamTableEntry (SmmuInfo, Index, &StreamTableEntryPtr[Index]);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a: Error building stream table entry\n", __func__));
-        goto End;
-      }
-    }
-  } else {
+  Status = SmmuV3BuildStreamTableEntry (SmmuInfo, &TemplateEntry);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Error building stream table entry\n", __func__));
+    goto End;
+  }
+
+  if (TwoLevelStreamTable) {
     L2StreamTablePtr = (SMMUV3_STREAM_TABLE_ENTRY *)AllocatePages (1);
     if (L2StreamTablePtr == NULL) {
       DEBUG ((DEBUG_ERROR, "%a: Error allocating L2 stream table\n", __func__));
@@ -666,11 +638,6 @@ SmmuV3Configure (
     }
 
     ZeroMem (L2StreamTablePtr, EFI_PAGE_SIZE);
-    Status = SmmuV3BuildStreamTableEntry (SmmuInfo, SmmuInfo->StreamTableEntryMax, &TemplateEntry);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Error building stream table entry\n", __func__));
-      goto End;
-    }
 
     for (Index = 0; Index < (EFI_PAGE_SIZE / sizeof (SMMUV3_STREAM_TABLE_ENTRY)); Index++) {
       CopyMem (&L2StreamTablePtr[Index], &TemplateEntry, sizeof (SMMUV3_STREAM_TABLE_ENTRY));
@@ -683,6 +650,11 @@ SmmuV3Configure (
       // That is it must stay within the bounds of the Stream table split point.
       // Cannot have Span of 0, means invalid L2 table ptr in the L1 table entry.
       L1Table[Index].Span = SMMUV3_STR_TAB_BASE_CFG_SPLIT + 1;
+    }
+  } else {
+    StreamTableEntryPtr = (SMMUV3_STREAM_TABLE_ENTRY *)StreamTablePtr;
+    for (Index = 0; Index <= SmmuInfo->StreamTableEntryMax; Index++) {
+      CopyMem (&StreamTableEntryPtr[Index], &TemplateEntry, sizeof (SMMUV3_STREAM_TABLE_ENTRY));
     }
   }
 
@@ -972,11 +944,6 @@ IoMmuDeInit (
       IoMmu->SmmuInfo->PageTableRoot = NULL;
     }
 
-    if (IoMmu->SmmuInfo[SmmuIndex].StreamEntryConfig != NULL) {
-      FreePool (IoMmu->SmmuInfo[SmmuIndex].StreamEntryConfig);
-      IoMmu->SmmuInfo[SmmuIndex].StreamEntryConfig = NULL;
-    }
-
     if (IoMmu->SmmuInfo[SmmuIndex].StreamTable != NULL) {
       SmmuV3FreeStreamTable (IoMmu->SmmuInfo[SmmuIndex].StreamTable, IoMmu->SmmuInfo[SmmuIndex].StreamTableSize);
       IoMmu->SmmuInfo[SmmuIndex].StreamTable = NULL;
@@ -1204,13 +1171,6 @@ InitializeSmmuDxe (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to intall IoMmuProtocol\n", __func__));
     goto Error;
-  }
-
-  // Free StreamEntryConfig temp buffer
-  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-    if (mIoMmu->SmmuInfo[SmmuIndex].StreamEntryConfig != NULL) {
-      FreePool (mIoMmu->SmmuInfo[SmmuIndex].StreamEntryConfig);
-    }
   }
 
   DEBUG ((DEBUG_INFO, "%a: Status = %llx\n", __func__, Status));

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -84,30 +84,15 @@ AddIortTable (
   IN UINT32                   IortSize
   )
 {
-  EFI_STATUS            Status;
-  UINTN                 TableHandle;
-  EFI_PHYSICAL_ADDRESS  PageAddress;
+  EFI_STATUS  Status;
+  UINTN       TableHandle;
 
   if ((AcpiTable == NULL) || (IortData == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = gBS->AllocatePages (
-                  AllocateAnyPages,
-                  EfiACPIReclaimMemory,
-                  EFI_SIZE_TO_PAGES (IortSize),
-                  &PageAddress
-                  );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate pages for IORT table\n", __func__));
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  ZeroMem ((VOID *)(UINTN)PageAddress, EFI_SIZE_TO_PAGES (IortSize) * EFI_PAGE_SIZE);
-  CopyMem ((VOID *)(UINTN)PageAddress, IortData, IortSize);
-
-  Status = AcpiPlatformChecksum ((UINT8 *)(UINTN)PageAddress, IortSize);
+  Status = AcpiPlatformChecksum ((UINT8 *)(UINTN)IortData, IortSize);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to calculate checksum for IORT table\n", __func__));
     return Status;
@@ -115,7 +100,7 @@ AddIortTable (
 
   Status = AcpiTable->InstallAcpiTable (
                         AcpiTable,
-                        (EFI_ACPI_COMMON_HEADER *)(UINTN)PageAddress,
+                        (EFI_ACPI_COMMON_HEADER *)(UINTN)IortData,
                         IortSize,
                         &TableHandle
                         );
@@ -353,7 +338,7 @@ SmmuV3BuildStreamTableEntry (
   // Device attributes are Cacheable and Inner-Shareable
   DACS = (SmmuInfo->StreamEntryConfig[StreamId].MemoryAccessFlags & SMMUV3_STREAM_TABLE_ENTRY_DACS) >> 1;      // Shift by 1 to isolate DACS bit.
 
-  RmrNode = SmmuInfo->StreamEntryConfig[StreamId].RmrNode;
+  RmrNode = SmmuInfo->RmrNode;
 
   // Process memory range descriptors
   if (RmrNode != NULL) {
@@ -478,7 +463,7 @@ SmmuV3BuildStreamTableEntry (
 }
 
 /**
-  Allocate a linear stream table for SMMUv3.
+  Allocate a linear or 2-Level stream table for SMMUv3.
 
   For allocating a 2-level or linear stream table, the stream table alignment
   requirements per SMMUv3 spec:
@@ -486,24 +471,25 @@ SmmuV3BuildStreamTableEntry (
     table size or 64 bytes.
   - For linear table, the table needs to be aligned to its size.
 
-  This function uses the linear stream table.
-
-  @param [in]  SmmuInfo       Pointer to the SMMU_INFO structure.
-  @param [out] Log2Size       Pointer to store the log2 size of the stream table.
-  @param [out] Size           Pointer to store the size of the stream table.
+  @param [in]  SmmuInfo             Pointer to the SMMU_INFO structure.
+  @param [in]  TwoLevelStreamTable  Flag to indicate if a two-level stream table is used.
+  @param [out] Log2Size             Pointer to store the log2 size of the stream table.
+  @param [out] Size                 Pointer to store the size of the stream table.
 
   @retval Pointer to the allocated stream table, or NULL on failure.
 **/
 STATIC
-SMMUV3_STREAM_TABLE_ENTRY *
+VOID *
 SmmuV3AllocateStreamTable (
   IN SMMU_INFO  *SmmuInfo,
+  IN BOOLEAN    TwoLevelStreamTable,
   OUT UINT32    *Log2Size,
   OUT UINT32    *Size
   )
 {
   UINT32  MaxStreamId;
   UINT32  SidMsb;
+  UINT32  L1Bits;
   UINT32  Alignment;
   UINTN   Pages;
   VOID    *AllocatedAddress;
@@ -514,17 +500,31 @@ SmmuV3AllocateStreamTable (
   }
 
   // The max stream id is calculated as the output base + the number of stream ids
-  MaxStreamId      = SmmuInfo->StreamTableEntryMax;
-  SidMsb           = HighBitSet32 (MaxStreamId);
-  *Log2Size        = SidMsb + 1;
-  *Size            = SMMUV3_LINEAR_STREAM_TABLE_SIZE_FROM_LOG2 (*Log2Size);
+  MaxStreamId = SmmuInfo->StreamTableEntryMax;
+  if (TwoLevelStreamTable && (MaxStreamId < (EFI_PAGE_SIZE / sizeof (SMMUV3_STREAM_TABLE_ENTRY)))) {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid MaxStreamId for 2-Level table%u\n", __func__, MaxStreamId));
+    return NULL;
+  }
+
+  SidMsb    = HighBitSet32 (MaxStreamId);
+  *Log2Size = SidMsb + 1;
+  *Size     = SMMUV3_LINEAR_STREAM_TABLE_SIZE_FROM_LOG2 (*Log2Size);
+  if (TwoLevelStreamTable) {
+    L1Bits = *Log2Size - SMMUV3_STR_TAB_BASE_CFG_SPLIT; // L1 table log2 size
+    *Size  = SMMUV3_L1_STREAM_TABLE_SIZE_FROM_LOG2 (L1Bits);
+  }
+
   *Size            = ALIGN_VALUE (*Size, EFI_PAGE_SIZE);
   Alignment        = *Size; // Aligned to the size of the table, linear stream table
   Pages            = EFI_SIZE_TO_PAGES (*Size);
   AllocatedAddress = AllocateAlignedPages (Pages, Alignment);
+  if (AllocatedAddress == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Allocation failed for stream table\n", __func__));
+    return NULL;
+  }
 
   ZeroMem (AllocatedAddress, *Size);
-  return (SMMUV3_STREAM_TABLE_ENTRY *)AllocatedAddress;
+  return AllocatedAddress;
 }
 
 /**
@@ -576,26 +576,31 @@ SmmuV3Configure (
   IN PAGE_TABLE  *PageTableRoot
   )
 {
-  EFI_STATUS                 Status;
-  UINT32                     Index;
-  UINT32                     StreamTableLog2Size;
-  UINT32                     StreamTableSize;
-  UINT32                     CommandQueueLog2Size;
-  UINT32                     EventQueueLog2Size;
-  UINT8                      ReadWriteAllocationHint;
-  SMMUV3_STRTAB_BASE         StrTabBase;
-  SMMUV3_STRTAB_BASE_CFG     StrTabBaseCfg;
-  SMMUV3_STREAM_TABLE_ENTRY  *StreamTablePtr;
-  SMMUV3_CMDQ_BASE           CommandQueueBase;
-  SMMUV3_EVENTQ_BASE         EventQueueBase;
-  SMMUV3_CR0                 Cr0;
-  SMMUV3_CR1                 Cr1;
-  SMMUV3_CR2                 Cr2;
-  SMMUV3_IDR0                Idr0;
-  SMMUV3_CMD_GENERIC         Command;
-  SMMUV3_GERROR              GError;
-  VOID                       *CommandQueue;
-  VOID                       *EventQueue;
+  EFI_STATUS                         Status;
+  UINT32                             Index;
+  UINT32                             StreamTableLog2Size;
+  UINT32                             StreamTableSize;
+  UINT32                             CommandQueueLog2Size;
+  UINT32                             EventQueueLog2Size;
+  UINT8                              ReadWriteAllocationHint;
+  SMMUV3_STRTAB_BASE                 StrTabBase;
+  SMMUV3_STRTAB_BASE_CFG             StrTabBaseCfg;
+  VOID                               *StreamTablePtr;
+  SMMUV3_STREAM_TABLE_ENTRY          *StreamTableEntryPtr;
+  SMMUV3_STREAM_TABLE_ENTRY          *L2StreamTablePtr;
+  SMMUV3_L1_STREAM_TABLE_DESCRIPTOR  *L1Table;
+  SMMUV3_STREAM_TABLE_ENTRY          TemplateEntry;
+  SMMUV3_CMDQ_BASE                   CommandQueueBase;
+  SMMUV3_EVENTQ_BASE                 EventQueueBase;
+  SMMUV3_CR0                         Cr0;
+  SMMUV3_CR1                         Cr1;
+  SMMUV3_CR2                         Cr2;
+  SMMUV3_IDR0                        Idr0;
+  SMMUV3_CMD_GENERIC                 Command;
+  SMMUV3_GERROR                      GError;
+  VOID                               *CommandQueue;
+  VOID                               *EventQueue;
+  BOOLEAN                            TwoLevelStreamTable;
 
   if ((SmmuInfo == NULL) || (PageTableRoot == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
@@ -623,8 +628,8 @@ SmmuV3Configure (
     goto End;
   }
 
-  // Allocate Linear Stream Table
-  StreamTablePtr = SmmuV3AllocateStreamTable (SmmuInfo, &StreamTableLog2Size, &StreamTableSize);
+  TwoLevelStreamTable = (SmmuInfo->StreamTableEntryMax >= (EFI_PAGE_SIZE / sizeof (SMMUV3_STREAM_TABLE_ENTRY)));
+  StreamTablePtr      = SmmuV3AllocateStreamTable (SmmuInfo, TwoLevelStreamTable, &StreamTableLog2Size, &StreamTableSize);
   if (StreamTablePtr == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Error allocating stream table\n", __func__));
     Status = EFI_OUT_OF_RESOURCES;
@@ -643,11 +648,41 @@ SmmuV3Configure (
   }
 
   // Load default STE values
-  for (Index = 0; Index <= SmmuInfo->StreamTableEntryMax; Index++) {
-    Status = SmmuV3BuildStreamTableEntry (SmmuInfo, Index, &StreamTablePtr[Index]);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Error building stream table\n", __func__));
+  if (!TwoLevelStreamTable) {
+    StreamTableEntryPtr = (SMMUV3_STREAM_TABLE_ENTRY *)StreamTablePtr;
+    for (Index = 0; Index <= SmmuInfo->StreamTableEntryMax; Index++) {
+      Status = SmmuV3BuildStreamTableEntry (SmmuInfo, Index, &StreamTableEntryPtr[Index]);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: Error building stream table entry\n", __func__));
+        goto End;
+      }
+    }
+  } else {
+    L2StreamTablePtr = (SMMUV3_STREAM_TABLE_ENTRY *)AllocatePages (1);
+    if (L2StreamTablePtr == NULL) {
+      DEBUG ((DEBUG_ERROR, "%a: Error allocating L2 stream table\n", __func__));
+      Status = EFI_OUT_OF_RESOURCES;
       goto End;
+    }
+
+    ZeroMem (L2StreamTablePtr, EFI_PAGE_SIZE);
+    Status = SmmuV3BuildStreamTableEntry (SmmuInfo, SmmuInfo->StreamTableEntryMax, &TemplateEntry);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Error building stream table entry\n", __func__));
+      goto End;
+    }
+
+    for (Index = 0; Index < (EFI_PAGE_SIZE / sizeof (SMMUV3_STREAM_TABLE_ENTRY)); Index++) {
+      CopyMem (&L2StreamTablePtr[Index], &TemplateEntry, sizeof (SMMUV3_STREAM_TABLE_ENTRY));
+    }
+
+    L1Table = (SMMUV3_L1_STREAM_TABLE_DESCRIPTOR *)StreamTablePtr;
+    for (Index = 0; Index < (SMMUV3_L1_STREAM_TABLE_SIZE_FROM_LOG2 (StreamTableLog2Size - SMMUV3_STR_TAB_BASE_CFG_SPLIT) / sizeof (UINT64)); Index++) {
+      L1Table[Index].L2Ptr = (UINT64)(UINTN)L2StreamTablePtr >> SMMUV3_STR_TAB_BASE_L2_PTR_OFFSET;
+      // Per SmmuV3 spec: Span must be within the range of 0 to (SMMU_STRTAB_BASE_CFG.SPLIT + 1)
+      // That is it must stay within the bounds of the Stream table split point.
+      // Cannot have Span of 0, means invalid L2 table ptr in the L1 table entry.
+      L1Table[Index].Span = SMMUV3_STR_TAB_BASE_CFG_SPLIT + 1;
     }
   }
 
@@ -671,6 +706,11 @@ SmmuV3Configure (
   // Configure Stream Table Base
   StrTabBaseCfg.AsUINT32 = 0;
   StrTabBaseCfg.Fmt      = SMMUV3_STR_TAB_BASE_CFG_FMT_LINEAR; // Linear format
+  if (TwoLevelStreamTable) {
+    StrTabBaseCfg.Fmt   = SMMUV3_STR_TAB_BASE_CFG_FMT_2LEVEL; // 2-Level format
+    StrTabBaseCfg.Split = SMMUV3_STR_TAB_BASE_CFG_SPLIT;
+  }
+
   StrTabBaseCfg.Log2Size = StreamTableLog2Size;
 
   SmmuV3WriteRegister32 (SmmuInfo->SmmuBase, SMMU_STRTAB_BASE_CFG, StrTabBaseCfg.AsUINT32);
@@ -1166,11 +1206,19 @@ InitializeSmmuDxe (
     goto Error;
   }
 
+  // Free StreamEntryConfig temp buffer
+  for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+    if (mIoMmu->SmmuInfo[SmmuIndex].StreamEntryConfig != NULL) {
+      FreePool (mIoMmu->SmmuInfo[SmmuIndex].StreamEntryConfig);
+    }
+  }
+
   DEBUG ((DEBUG_INFO, "%a: Status = %llx\n", __func__, Status));
 
   return Status;
 
 Error:
+  DEBUG ((DEBUG_ERROR, "%a: SMMU DMA protection failed to initialize. Status = %llx\n", __func__, Status));
   IoMmuDeInit (mIoMmu);
   mIoMmu = NULL;
   return Status;

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -128,6 +128,9 @@
 // SMMUV3 Configuration bit definitions
 //
 #define SMMUV3_STR_TAB_BASE_CFG_FMT_LINEAR  0                // Linear Stream Table format
+#define SMMUV3_STR_TAB_BASE_CFG_FMT_2LEVEL  1                // 2-Level Stream Table format
+#define SMMUV3_STR_TAB_BASE_CFG_SPLIT       6                // Split bit for 2-Level Stream Table
+#define SMMUV3_STR_TAB_BASE_L2_PTR_OFFSET   6                // Offset of L2 pointer in the L1 stream table entry
 #define SMMUV3_STR_TAB_BASE_ADDR_OFFSET     6                // Stream Table base address offset
 #define SMMUV3_STR_TAB_BASE_CMDQ_OFFSET     5                // Command queue base address offset
 #define SMMUV3_STR_TAB_BASE_EVENTQ_OFFSET   5                // Event queue base address offset
@@ -154,31 +157,31 @@ typedef enum _SMMU_ADDRESS_SIZE_TYPE {
 } SMMU_ADDRESS_SIZE_TYPE;
 
 typedef struct _SMMU_STREAM_ENTRY_CONFIG {
-  UINT32                                CacheCoherentAttribute;
-  UINT32                                MemoryAccessFlags;
-  EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE    *RmrNode;
+  UINT32    CacheCoherentAttribute;
+  UINT32    MemoryAccessFlags;
 } SMMU_STREAM_ENTRY_CONFIG;
 
 // General SMMU Information for a SMMU instance
 typedef struct _SMMU_INFO {
-  PAGE_TABLE                  *PageTableRoot;
-  VOID                        *StreamTable;
-  VOID                        *CommandQueue;
-  VOID                        *EventQueue;
-  SMMU_STREAM_ENTRY_CONFIG    *StreamEntryConfig;
-  UINT64                      SmmuBase;
-  UINT32                      StreamTableSize;
-  UINT32                      StreamTableEntryMax;
-  UINT32                      Flags;
-  UINT32                      CommandQueueSize;
-  UINT32                      EventQueueSize;
-  UINT32                      StreamTableLog2Size;
-  UINT32                      CommandQueueLog2Size;
-  UINT32                      EventQueueLog2Size;
-  UINT32                      OutputAddressWidth;
-  UINT8                       TranslationStartingLevel;
-  BOOLEAN                     PageTableRootConcatenated;
-  BOOLEAN                     Enabled;
+  PAGE_TABLE                            *PageTableRoot;
+  VOID                                  *StreamTable;
+  VOID                                  *CommandQueue;
+  VOID                                  *EventQueue;
+  SMMU_STREAM_ENTRY_CONFIG              *StreamEntryConfig;
+  EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE    *RmrNode;
+  UINT64                                SmmuBase;
+  UINT32                                StreamTableSize;
+  UINT32                                StreamTableEntryMax;
+  UINT32                                Flags;
+  UINT32                                CommandQueueSize;
+  UINT32                                EventQueueSize;
+  UINT32                                StreamTableLog2Size;
+  UINT32                                CommandQueueLog2Size;
+  UINT32                                EventQueueLog2Size;
+  UINT32                                OutputAddressWidth;
+  UINT8                                 TranslationStartingLevel;
+  BOOLEAN                               PageTableRootConcatenated;
+  BOOLEAN                               Enabled;
 } SMMU_INFO;
 
 // IoMmu configuration structure

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -15,6 +15,7 @@
 #include <Register/SmmuV3Registers.h>
 #include <Uefi/UefiBaseType.h>
 #include <IndustryStandard/IoRemappingTable.h>
+#include <Protocol/IoMmu.h>
 #include "IoMmu.h"
 
 // Number of levels in the page table
@@ -105,8 +106,9 @@
 //
 // SMMUV3 Stream Table Entry bit definitions
 //
+#define SMMUV3_STREAM_TABLE_ENTRY_CCA                                      1     // Cache Coherent Attribute
 #define SMMUV3_STREAM_TABLE_ENTRY_CPM                                      1     // Coherent Path to Memory
-#define SMMUV3_STREAM_TABLE_ENTRY_DACS                                     2     // Device attributes are Cacheable and Inner-Shareable
+#define SMMUV3_STREAM_TABLE_ENTRY_DACS                                     1     // Device attributes are Cacheable and Inner-Shareable
 #define SMMUV3_STREAM_TABLE_ENTRY_CONFIG_STAGE_2_TRANSLATE_STAGE_1_BYPASS  0x6   // Stage 2 Translate, Stage 1 Bypass
 #define SMMUV3_STREAM_TABLE_ENTRY_CONFIG_STAGE_2_BYPASS_STAGE_1_BYPASS     0x4   // Stage 2 Bypass, Stage 1 Bypass
 #define SMMUV3_STREAM_TABLE_ENTRY_EATS_NOT_SUPPORTED                       0     // ATS not supported
@@ -156,32 +158,31 @@ typedef enum _SMMU_ADDRESS_SIZE_TYPE {
   SmmuAddressSize52Bit = 6,
 } SMMU_ADDRESS_SIZE_TYPE;
 
-typedef struct _SMMU_STREAM_ENTRY_CONFIG {
-  UINT32    CacheCoherentAttribute;
-  UINT32    MemoryAccessFlags;
-} SMMU_STREAM_ENTRY_CONFIG;
+typedef struct _RMR_NODE_INFO {
+  EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE    *RmrNode; // Pointer to the RMR node
+  LIST_ENTRY                            Link;     // Link to the RMR node in the list
+} RMR_NODE_INFO;
 
 // General SMMU Information for a SMMU instance
 typedef struct _SMMU_INFO {
-  PAGE_TABLE                            *PageTableRoot;
-  VOID                                  *StreamTable;
-  VOID                                  *CommandQueue;
-  VOID                                  *EventQueue;
-  SMMU_STREAM_ENTRY_CONFIG              *StreamEntryConfig;
-  EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE    *RmrNode;
-  UINT64                                SmmuBase;
-  UINT32                                StreamTableSize;
-  UINT32                                StreamTableEntryMax;
-  UINT32                                Flags;
-  UINT32                                CommandQueueSize;
-  UINT32                                EventQueueSize;
-  UINT32                                StreamTableLog2Size;
-  UINT32                                CommandQueueLog2Size;
-  UINT32                                EventQueueLog2Size;
-  UINT32                                OutputAddressWidth;
-  UINT8                                 TranslationStartingLevel;
-  BOOLEAN                               PageTableRootConcatenated;
-  BOOLEAN                               Enabled;
+  PAGE_TABLE    *PageTableRoot;
+  VOID          *StreamTable;
+  VOID          *CommandQueue;
+  VOID          *EventQueue;
+  LIST_ENTRY    RmrNodeList;
+  UINT64        SmmuBase;
+  UINT32        StreamTableSize;
+  UINT32        StreamTableEntryMax;
+  UINT32        Flags;
+  UINT32        CommandQueueSize;
+  UINT32        EventQueueSize;
+  UINT32        StreamTableLog2Size;
+  UINT32        CommandQueueLog2Size;
+  UINT32        EventQueueLog2Size;
+  UINT32        OutputAddressWidth;
+  UINT8         TranslationStartingLevel;
+  BOOLEAN       PageTableRootConcatenated;
+  BOOLEAN       Enabled;
 } SMMU_INFO;
 
 // IoMmu configuration structure
@@ -478,6 +479,22 @@ EFI_STATUS
 SmmuV3TLBInvalidateAddress (
   IN SMMU_INFO  *SmmuInfo,
   IN UINT64     InputAddress
+  );
+
+/**
+ * Add RMR mappings for each SMMU node in the SmmuInfo structure.
+ * This function iterates through the RMR nodes and updates the page table
+ * for each memory range described in the RMR node.
+ *
+ * @param [in] SmmuInfo  Pointer to the SMMU_INFO structure.
+ *
+ * @retval EFI_SUCCESS            Success.
+ * @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+ * @retval Other                  RMR mapping update failure.
+ */
+EFI_STATUS
+SmmuV3AddRMRMapping (
+  IN SMMU_INFO  *SmmuInfo
   );
 
 /**

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -953,11 +953,11 @@ SmmuV3GetNodeInfo (
 
   for (Count = 0; Count < Iort->NumNodes; Count++) {
     if (Node->Type == EFI_ACPI_IORT_TYPE_SMMUv3) {
+      InitializeListHead (&SmmuInfoArray[SmmuIndex].RmrNodeList);
       SmmuNode                                     = (EFI_ACPI_6_0_IO_REMAPPING_SMMU3_NODE *)Node;
       SmmuInfoArray[SmmuIndex].SmmuBase            = SmmuNode->Base;
       SmmuInfoArray[SmmuIndex].Flags               = SmmuNode->Flags;
       SmmuInfoArray[SmmuIndex].StreamTableEntryMax = 0;  // Initialize max stream ID to 0
-      SmmuInfoArray[SmmuIndex].StreamEntryConfig   = NULL;
       SmmuNodePtrs[SmmuIndex]                      = (VOID *)SmmuNode;
       SmmuIndex++;
     }
@@ -1119,7 +1119,34 @@ SmmuV3GetMaxStreamIds (
 }
 
 /**
- * Collect Stream ID specific information for each SMMU.
+ * Add a new RMR node to the SMMU_INFO structure's RMR node list.
+ *
+ * @param [in] SmmuInfo  Pointer to the SMMU_INFO structure.
+ * @param [in] RmrNode   Pointer to the RMR node to add.
+ *
+ * @return EFI_SUCCESS on success, or EFI_OUT_OF_RESOURCES on failure.
+ */
+EFI_STATUS
+SmmuV3AddRmrNodeToList (
+  IN SMMU_INFO                           *SmmuInfo,
+  IN EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE  *RmrNode
+  )
+{
+  RMR_NODE_INFO  *Item;
+
+  Item = AllocateZeroPool (sizeof (RMR_NODE_INFO));
+  if (Item == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to allocate memory for RMR_NODE_INFO\n", __func__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Item->RmrNode = RmrNode;
+  InsertTailList (&SmmuInfo->RmrNodeList, &Item->Link);
+  return EFI_SUCCESS;
+}
+
+/**
+ * Collect RMR Node information for each SMMU and add it to the RmrNodeList
  *
  * @param [in]  IortTable      Pointer to the IORT table.
  * @param [in]  SmmuNodePtrs   Pointer to the array of SMMU node pointers.
@@ -1131,52 +1158,34 @@ SmmuV3GetMaxStreamIds (
  * @retval EFI_NOT_FOUND          SMMU node not found.
  */
 EFI_STATUS
-SmmuV3GetStreamIdInfo (
+SmmuV3GetRMRNodeInfo (
   IN  VOID       *IortTable,
   IN  VOID       **SmmuNodePtrs,
   IN  UINT32     SmmuNodeCount,
   OUT SMMU_INFO  *SmmuInfoArray
   )
 {
-  EFI_ACPI_6_0_IO_REMAPPING_TABLE            *Iort;
-  EFI_ACPI_6_0_IO_REMAPPING_NODE             *Node;
-  EFI_ACPI_6_0_IO_REMAPPING_RC_NODE          *RcNode;
-  EFI_ACPI_6_0_IO_REMAPPING_NAMED_COMP_NODE  *NamedCompNode;
-  EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE         *IdMapping;
-  VOID                                       *OutputNode;
-  SMMU_STREAM_ENTRY_CONFIG                   StreamEntryConfig;
-  UINT32                                     ByteOffset;
-  UINT32                                     SmmuIndex;
-  UINT32                                     IdMappingIndex;
-  UINT32                                     Count;
-  BOOLEAN                                    Found;
-  UINT32                                     StartId;
-  UINT32                                     EndId;
-  UINT32                                     CurID;
+  EFI_ACPI_6_0_IO_REMAPPING_TABLE     *Iort;
+  EFI_ACPI_6_0_IO_REMAPPING_NODE      *Node;
+  EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE  *IdMapping;
+  VOID                                *OutputNode;
+  UINT32                              ByteOffset;
+  UINT32                              SmmuIndex;
+  UINT32                              IdMappingIndex;
+  UINT32                              Count;
+  BOOLEAN                             Found;
+  EFI_STATUS                          Status;
 
   if ((IortTable == NULL) || (SmmuNodePtrs == NULL) || (SmmuInfoArray == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameters\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
-  ZeroMem (&StreamEntryConfig, sizeof (SMMU_STREAM_ENTRY_CONFIG));
-
   Iort = (EFI_ACPI_6_0_IO_REMAPPING_TABLE *)IortTable;
   Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Iort + Iort->NodeOffset);
 
   for (Count = 0; Count < Iort->NumNodes; Count++) {
-    if ((Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) || (Node->Type == EFI_ACPI_IORT_TYPE_NAMED_COMP) || (Node->Type == EFI_ACPI_IORT_TYPE_RMR)) {
-      // Extract Cache Coherent and Memory Access Flags based on node type
-      if (Node->Type == EFI_ACPI_IORT_TYPE_ROOT_COMPLEX) {
-        RcNode                                   = (EFI_ACPI_6_0_IO_REMAPPING_RC_NODE *)Node;
-        StreamEntryConfig.CacheCoherentAttribute = RcNode->CacheCoherent;
-        StreamEntryConfig.MemoryAccessFlags      = RcNode->MemoryAccessFlags;
-      } else if (Node->Type == EFI_ACPI_IORT_TYPE_NAMED_COMP) {
-        NamedCompNode                            = (EFI_ACPI_6_0_IO_REMAPPING_NAMED_COMP_NODE *)Node;
-        StreamEntryConfig.CacheCoherentAttribute = NamedCompNode->CacheCoherent;
-        StreamEntryConfig.MemoryAccessFlags      = NamedCompNode->MemoryAccessFlags;
-      }
-
+    if (Node->Type == EFI_ACPI_IORT_TYPE_RMR) {
       if (Node->NumIdMappings > 0) {
         // Get the ID mapping array
         IdMapping = (EFI_ACPI_6_0_IO_REMAPPING_ID_TABLE *)((UINT8 *)Node + Node->IdReference);
@@ -1192,29 +1201,11 @@ SmmuV3GetStreamIdInfo (
             if (OutputNode == SmmuNodePtrs[SmmuIndex]) {
               // This ID mapping references an SMMU node
               // If RMR Node store the RMR node pointer for this SMMU
-              if (Node->Type == EFI_ACPI_IORT_TYPE_RMR) {
-                SmmuInfoArray[SmmuIndex].RmrNode = (EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE *)Node;
-              } else {
-                // RC or Named Comp Node
-                // Calculate the Stream ID range
-                StartId = IdMapping[IdMappingIndex].OutputBase;
-                EndId   = StartId + IdMapping[IdMappingIndex].NumIds;
-
-                // Store the Stream ID range information
-                for (CurID = StartId; CurID <= EndId; CurID++) {
-                  SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID].CacheCoherentAttribute = StreamEntryConfig.CacheCoherentAttribute;
-                  SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID].MemoryAccessFlags      = StreamEntryConfig.MemoryAccessFlags;
-                }
+              Status = SmmuV3AddRmrNodeToList (&SmmuInfoArray[SmmuIndex], (EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE *)Node);
+              if (EFI_ERROR (Status)) {
+                DEBUG ((DEBUG_ERROR, "%a: Failed to add RMR node to list for SMMU[0x%llx]\n", __func__, SmmuInfoArray[SmmuIndex].SmmuBase));
+                return Status;
               }
-
-              DEBUG ((
-                DEBUG_VERBOSE,
-                "%a: Added Stream ID range for SMMU[0x%llx]: StartId=0x%x, EndId=0x%x\n",
-                __func__,
-                SmmuInfoArray[SmmuIndex].SmmuBase,
-                StartId,
-                EndId
-                ));
 
               Found = TRUE;
               break;
@@ -1236,6 +1227,73 @@ SmmuV3GetStreamIdInfo (
 
     // Move to the next node
     Node = (EFI_ACPI_6_0_IO_REMAPPING_NODE *)((UINT8 *)Node + Node->Length);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+ * Add RMR mappings for each SMMU node in the SmmuInfo structure.
+ * This function iterates through the RMR nodes and updates the page table
+ * for each memory range described in the RMR node.
+ *
+ * @param [in] SmmuInfo  Pointer to the SMMU_INFO structure.
+ *
+ * @retval EFI_SUCCESS            Success.
+ * @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+ * @retval Other                  RMR mapping update failure.
+ */
+EFI_STATUS
+SmmuV3AddRMRMapping (
+  IN SMMU_INFO  *SmmuInfo
+  )
+{
+  EFI_ACPI_6_0_IO_REMAPPING_MEM_RANGE_DESC  *IortMemRangeDesc;
+  UINT32                                    NumMemRangeDesc;
+  LIST_ENTRY                                *Entry;
+  RMR_NODE_INFO                             *Item;
+  EFI_STATUS                                Status;
+
+  if (SmmuInfo == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Entry = GetFirstNode (&SmmuInfo->RmrNodeList);
+  while (!IsNull (&SmmuInfo->RmrNodeList, Entry)) {
+    Item  = BASE_CR (Entry, RMR_NODE_INFO, Link);
+    Entry = GetNextNode (&SmmuInfo->RmrNodeList, Entry);
+
+    if ((Item != NULL) && (Item->RmrNode != NULL)) {
+      for (NumMemRangeDesc = 0; NumMemRangeDesc < Item->RmrNode->NumMemRangeDesc; NumMemRangeDesc++) {
+        IortMemRangeDesc = (EFI_ACPI_6_0_IO_REMAPPING_MEM_RANGE_DESC *)((UINT8 *)Item->RmrNode + Item->RmrNode->MemRangeDescRef);
+        if ((IortMemRangeDesc[NumMemRangeDesc].Base > 0) && (IortMemRangeDesc[NumMemRangeDesc].Length > 0)) {
+          DEBUG ((
+            DEBUG_INFO,
+            "%a: Adding RMR mapping for SMMU[0x%llx]: Base=0x%llx, Length=0x%llx\n",
+            __func__,
+            SmmuInfo->SmmuBase,
+            IortMemRangeDesc[NumMemRangeDesc].Base,
+            IortMemRangeDesc[NumMemRangeDesc].Length
+            ));
+          Status = UpdatePageTable (
+                     SmmuInfo->PageTableRoot,
+                     IortMemRangeDesc[NumMemRangeDesc].Base,
+                     IortMemRangeDesc[NumMemRangeDesc].Length,
+                     PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS ((EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)),
+                     TRUE,
+                     FALSE
+                     );
+          if (EFI_ERROR (Status)) {
+            DEBUG ((DEBUG_ERROR, "%a: Failed to update RMR mapping.\n", __func__));
+            return Status;
+          }
+        }
+      }
+
+      RemoveEntryList (&Item->Link);
+      FreePool (Item);
+    }
   }
 
   return EFI_SUCCESS;
@@ -1266,7 +1324,6 @@ SmmuV3ParseIort (
   SMMU_INFO                        *SmmuInfoArray;
   VOID                             **SmmuNodePtrs;
   UINT32                           SmmuNodeCount;
-  UINT32                           SmmuIndex;
 
   if ((IortTable == NULL) || (SmmuInfo == NULL) || (SmmuCount == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameters\n", __func__));
@@ -1346,22 +1403,8 @@ SmmuV3ParseIort (
     goto Error;
   }
 
-  // Allocate memory for Stream ID ranges after knowing the maximum Stream ID
-  for (SmmuIndex = 0; SmmuIndex < SmmuNodeCount; SmmuIndex++) {
-    if (SmmuInfoArray[SmmuIndex].StreamTableEntryMax > 0) {
-      // Allocate space for StreamIdRanges based on MaxStreamId
-      // One entry for each possible StreamId (0 to MaxStreamId inclusive)
-      SmmuInfoArray[SmmuIndex].StreamEntryConfig = AllocateZeroPool ((SmmuInfoArray[SmmuIndex].StreamTableEntryMax + 1) * sizeof (SMMU_STREAM_ENTRY_CONFIG));
-      if (SmmuInfoArray[SmmuIndex].StreamEntryConfig == NULL) {
-        DEBUG ((DEBUG_ERROR, "%a: Failed to allocate Stream ID ranges for SMMU[%d]\n", __func__, SmmuInfoArray[SmmuIndex].SmmuBase));
-        Status = EFI_OUT_OF_RESOURCES;
-        goto Error;
-      }
-    }
-  }
-
   // Fourth pass: collect per Stream ID range info like CCA, CPM, DACS for each RC/NamedComp node
-  Status = SmmuV3GetStreamIdInfo (IortTable, SmmuNodePtrs, SmmuNodeCount, SmmuInfoArray);
+  Status = SmmuV3GetRMRNodeInfo (IortTable, SmmuNodePtrs, SmmuNodeCount, SmmuInfoArray);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to get Stream ID info for SMMU nodes\n", __func__));
     goto Error;
@@ -1374,12 +1417,6 @@ SmmuV3ParseIort (
 
 Error:
   if (SmmuInfoArray != NULL) {
-    for (SmmuIndex = 0; SmmuIndex < SmmuNodeCount; SmmuIndex++) {
-      if (SmmuInfoArray[SmmuIndex].StreamEntryConfig != NULL) {
-        FreePool (SmmuInfoArray[SmmuIndex].StreamEntryConfig);
-      }
-    }
-
     FreePool (SmmuInfoArray);
   }
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -1191,15 +1191,17 @@ SmmuV3GetStreamIdInfo (
           for (SmmuIndex = 0; SmmuIndex < SmmuNodeCount; SmmuIndex++) {
             if (OutputNode == SmmuNodePtrs[SmmuIndex]) {
               // This ID mapping references an SMMU node
-              // Calculate the Stream ID range
-              StartId = IdMapping[IdMappingIndex].OutputBase;
-              EndId   = StartId + IdMapping[IdMappingIndex].NumIds;
+              // If RMR Node store the RMR node pointer for this SMMU
+              if (Node->Type == EFI_ACPI_IORT_TYPE_RMR) {
+                SmmuInfoArray[SmmuIndex].RmrNode = (EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE *)Node;
+              } else {
+                // RC or Named Comp Node
+                // Calculate the Stream ID range
+                StartId = IdMapping[IdMappingIndex].OutputBase;
+                EndId   = StartId + IdMapping[IdMappingIndex].NumIds;
 
-              // Store the Stream ID range information
-              for (CurID = StartId; CurID <= EndId; CurID++) {
-                if (Node->Type == EFI_ACPI_IORT_TYPE_RMR) {
-                  SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID].RmrNode = (EFI_ACPI_6_0_IO_REMAPPING_RMR_NODE *)Node;
-                } else {
+                // Store the Stream ID range information
+                for (CurID = StartId; CurID <= EndId; CurID++) {
                   SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID].CacheCoherentAttribute = StreamEntryConfig.CacheCoherentAttribute;
                   SmmuInfoArray[SmmuIndex].StreamEntryConfig[CurID].MemoryAccessFlags      = StreamEntryConfig.MemoryAccessFlags;
                 }

--- a/ArmPkg/Include/Register/SmmuV3Registers.h
+++ b/ArmPkg/Include/Register/SmmuV3Registers.h
@@ -1766,6 +1766,10 @@ typedef union _SMMUV3_FAULT_RECORD {
     (UINT32)((UINT32)(1UL << (Log2Size)) * \
                 (UINT16)sizeof(SMMUV3_STREAM_TABLE_ENTRY))
 
+#define SMMUV3_L1_STREAM_TABLE_SIZE_FROM_LOG2(Log2Size) \
+    (UINT32)((UINT32)(1UL << (Log2Size)) * \
+                (UINT32)sizeof(UINT64))
+
 //
 // Register offsets for Page0.
 //


### PR DESCRIPTION
## Description

Switches to 2-Level Stream Table implementation.
- If the number of StreamId's < 64: linear stream table is used. 64 is the number of STE's that can fit in EFI_PAGE_SIZE.
- Else: 2-Level implementation to consumes less memory and has less strict alignment requirements.
- Eliminates need for large contiguous allocation chunks.

Also cleans up and reduces memory usage throughout SmmuDxe.

Memory savings example:
Memory usage of StreamID space of 0xFFFFF would allocate a 64MB size and aligned linear stream table.
With 2-Level this reduces down to: 
StreamID bits Split = 6 always so leaf level table is 1 page. 2^14 entries, 16,384 entries * 8 bytes = 131,072 bytes + 4096 bytes for leaf level table = 135,168 bytes, or ~135K 

Docs:
- https://developer.arm.com/documentation/109242/0100/Programming-the-SMMU/Stream-table/2-level-Stream-table

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on physical arm platform.

## Integration Instructions

N/A
