### PR TITLE
ArmPkg: Update to fix Command and Event Queues

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -110,16 +110,20 @@ UpdateMapping (
   PAGE_TABLE  *Current;
   UINT64      Entry;
   UINT32      SmmuIndex;
+  EFI_TPL     OldTpl;
 
   // Flags must be 12 bits or less
   if ((Root == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (PhysicalAddress == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter.\n", __func__));
     Status = EFI_INVALID_PARAMETER;
-    goto End;
+    ASSERT_EFI_ERROR (Status);
+    return Status;
   }
 
   Status  = EFI_SUCCESS;
   Current = Root;
+
+  OldTpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
 
   // Traverse the page table to the leaf level
   for (Level = mIoMmu->SmmuInfo->TranslationStartingLevel; Level < PAGE_TABLE_DEPTH - 1; Level++) {
@@ -187,9 +191,9 @@ UpdateMapping (
     }
   }
 
-  SpeculationBarrier ();
-
 End:
+  SpeculationBarrier ();
+  gBS->RestoreTPL (OldTpl);
   ASSERT_EFI_ERROR (Status);
   return Status;
 }

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -110,20 +110,16 @@ UpdateMapping (
   PAGE_TABLE  *Current;
   UINT64      Entry;
   UINT32      SmmuIndex;
-  EFI_TPL     OldTpl;
 
   // Flags must be 12 bits or less
   if ((Root == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (PhysicalAddress == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter.\n", __func__));
     Status = EFI_INVALID_PARAMETER;
-    ASSERT_EFI_ERROR (Status);
-    return Status;
+    goto End;
   }
 
   Status  = EFI_SUCCESS;
   Current = Root;
-
-  OldTpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
 
   // Traverse the page table to the leaf level
   for (Level = mIoMmu->SmmuInfo->TranslationStartingLevel; Level < PAGE_TABLE_DEPTH - 1; Level++) {
@@ -191,9 +187,9 @@ UpdateMapping (
     }
   }
 
-End:
   SpeculationBarrier ();
-  gBS->RestoreTPL (OldTpl);
+
+End:
   ASSERT_EFI_ERROR (Status);
   return Status;
 }

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -8,6 +8,7 @@
 
 **/
 
+#include <Uefi.h>
 #include <Library/ArmLib.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
@@ -740,6 +741,7 @@ SmmuV3SendCommand (
   SMMUV3_CMDQ_CONS  Consumer;
   UINT8             Count;
   EFI_STATUS        Status;
+  EFI_TPL           OldTpl;
 
   if ((SmmuInfo == NULL) || (Command == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
@@ -747,6 +749,8 @@ SmmuV3SendCommand (
   }
 
   Count = 10; // Set 0.1ms timeout value.
+  // Synchronize access to the command queue.
+  OldTpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
 
   Producer.AsUINT32 = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_CMDQ_PROD);
   Consumer.AsUINT32 = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_CMDQ_CONS);
@@ -789,13 +793,14 @@ SmmuV3SendCommand (
                          ) != FALSE))
   {
     DEBUG ((DEBUG_ERROR, "%a: Command Queue Full, Timeout\n", __func__));
-    return EFI_TIMEOUT;
+    Status = EFI_TIMEOUT;
+    goto End;
   }
 
   Status = SmmuV3WriteCommands (SmmuInfo, ProducerIndex, 1, Command);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Error writing command to queue\n", __func__));
-    return Status;
+    goto End;
   }
 
   ArmDataSynchronizationBarrier ();
@@ -822,9 +827,11 @@ SmmuV3SendCommand (
 
   if ((Count == 0) || (ConsumerIndex != ProducerIndex)) {
     DEBUG ((DEBUG_ERROR, "%a: Timeout waiting for command queue to be consumed\n", __func__));
-    return EFI_TIMEOUT;
+    Status = EFI_TIMEOUT;
   }
 
+End:
+  gBS->RestoreTPL (OldTpl);
   return Status;
 }
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -641,10 +641,14 @@ SmmuV3LogErrors (
     return;
   }
 
-  Status = SmmuV3ConsumeEventQueueForErrors (SmmuInfo, &FaultRecord, &IsEmpty);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Error consuming event queue\n", __func__));
-  } else {
+  do {
+    // Only consumes one entry at a time, so we loop until empty
+    Status = SmmuV3ConsumeEventQueueForErrors (SmmuInfo, &FaultRecord, &IsEmpty);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Error consuming event queue\n", __func__));
+      break;
+    }
+
     if (IsEmpty == FALSE) {
       DEBUG ((DEBUG_ERROR, "%a: %llx FaultRecord:\n", __func__, SmmuInfo->SmmuBase));
       for (Index = 0; Index < sizeof (FaultRecord.Fault) / sizeof (FaultRecord.Fault[0]); Index++) {
@@ -658,7 +662,7 @@ SmmuV3LogErrors (
         SmmuV3DumpPageTableEntries (SmmuInfo, FaultRecord.Fault[2], SmmuInfo->PageTableRoot);
       }
     }
-  }
+  } while (IsEmpty == FALSE);
 
   GError.AsUINT32 = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_GERROR);
   if (GError.AsUINT32 != 0) {
@@ -796,24 +800,27 @@ SmmuV3SendCommand (
 
   ArmDataSynchronizationBarrier ();
 
-  NewProducerIndex = ProducerIndex + 1;
+  NewProducerIndex = Producer.WriteIndex + 1;
 
   Producer.AsUINT32   = 0;
   Producer.WriteIndex = NewProducerIndex & (QueueMask | WrapMask);
+  ProducerIndex       = NewProducerIndex & (QueueMask | WrapMask);
 
   SmmuV3WriteRegister32 (SmmuInfo->SmmuBase, SMMU_CMDQ_PROD, Producer.AsUINT32);
 
   Consumer.AsUINT32 = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_CMDQ_CONS);
+  ConsumerIndex     = Consumer.ReadIndex & (QueueMask | WrapMask);
   Count             = 10; // Set 0.1ms timeout value
 
   // Wait for the command to be consumed
-  while (Count > 0 && Consumer.ReadIndex < Producer.WriteIndex) {
+  while ((Count > 0) && (ConsumerIndex != ProducerIndex)) {
     MicroSecondDelay (10);
     Consumer.AsUINT32 = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_CMDQ_CONS);
+    ConsumerIndex     = Consumer.ReadIndex & (QueueMask | WrapMask);
     Count--;
   }
 
-  if ((Count == 0) && (Consumer.ReadIndex < Producer.WriteIndex)) {
+  if ((Count == 0) || (ConsumerIndex != ProducerIndex)) {
     DEBUG ((DEBUG_ERROR, "%a: Timeout waiting for command queue to be consumed\n", __func__));
     return EFI_TIMEOUT;
   }


### PR DESCRIPTION
## Description

SmmuDxe: Update to fix Command and Event Queues

Updates SmmuV3LogErrors to dump all available entries until Event Queue IsEmpty.
Updates SmmuV3SendCommand to properly handle the wrap case in the circular buffer.
Adds raise/restore TPL to SmmuV3SendCommand to synchronize command queue access.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on physical arm platform

## Integration Instructions

N/A
