### PR TITLE
SmmuDxe: Add check for above or below 4G memory in IoMmuAllocateBuffer

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -448,6 +448,12 @@ IoMmuAllocateBuffer (
     goto End;
   }
 
+  if ((Attributes & EDKII_IOMMU_ATTRIBUTE_DUAL_ADDRESS_CYCLE) == 0) {
+    // Limit allocations to memory below 4GB
+    PhysicalAddress = SIZE_4GB - 1;
+    Type            = AllocateMaxAddress;
+  }
+
   Status = gBS->AllocatePages (
                   Type,
                   MemoryType,


### PR DESCRIPTION
## Description

SmmuDxe: Add check for above or below 4G memory in IoMmuAllocateBuffer

Limit allocations to memory below 4G when dual address cycle is set to 0
Some devices have limitations on what addresses are DMA-able.
To be safe, we check for dual address cycle == 0 and set the allocation address to be below 4G or 32-Bits.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on physical arm platform

## Integration Instructions

N/A
