### PR TITLE
Fix MP service might lose a core if the timer expires

### DIFF
--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
@@ -887,7 +887,8 @@ EnableDisableAP (
     return EFI_INVALID_PARAMETER;
   }
 
-  if (GetApState (CpuData) != CpuStateIdle) {
+  if ((GetApState (CpuData) != CpuStateIdle) &&
+      (GetApState (CpuData) != CpuStateFinished)) {
     return EFI_UNSUPPORTED;
   }
 

--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
@@ -887,8 +887,10 @@ EnableDisableAP (
     return EFI_INVALID_PARAMETER;
   }
 
+  // MU_CHANGE Starts: Fix for invocation on timer expired APs.
   if ((GetApState (CpuData) != CpuStateIdle) &&
       (GetApState (CpuData) != CpuStateFinished)) {
+  // MU_CHANGE Ends
     return EFI_UNSUPPORTED;
   }
 


### PR DESCRIPTION
## Description

When an AP is waken up to perform some operation with a time out period specified, the expired timer will put the core into `CpuStateFinished` state. This will make the subsequent enable/disable AP core fail to proceed, which is unexpected and inconsistent with the rest of the handling in this module (`CpuStateIdle` and `CpuStateFinished` are generally treated the same).

This change extends the accepted state of CPU to `CpuStateFinished` for AP enable/disable interface to fix calls on timer expired APs.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This was tested on QEMU SBSA and passed MP tests.

## Integration Instructions

N/A