### PR TITLE
Fix MPIDR Check

### DIFF
--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/ArmPsciMpServicesDxe.c
@@ -1334,7 +1334,7 @@ MpServicesInitialize (
   ASSERT (gApStacksBase != NULL);
 
   for (Index = 0; Index < mCpuMpData.NumberOfProcessors; Index++) {
-    if (GET_MPIDR_AFFINITY_BITS (ArmReadMpidr ()) == CoreInfo[Index].Mpidr) {
+    if (GET_MPIDR_AFFINITY_BITS (ArmReadMpidr ()) == GET_MPIDR_AFFINITY_BITS (CoreInfo[Index].Mpidr)) {
       IsBsp = TRUE;
     } else {
       IsBsp = FALSE;
@@ -1862,3 +1862,4 @@ StartupAllAPsNoWaitEvent (
 
   return Status;
 }
+


### PR DESCRIPTION
## Description

The GET_MPIDR_AFFINITY_BITS macro masks MT_BIT in ArmReadMpidr (), but CoreInfo[Index].Mpidr wasn't masked by the same macro which causes a mismatch even if it is the same MPIDR value. Hence, using the same GET_MPIDR_AFFINITY_BITS macro for CoreInfo[Index].Mpidr

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [X] Backport to release branch?

## How This Was Tested

Tested in custom Microsoft hardware

## Integration Instructions

N/A
