### PR TITLE
Minor CISettings cleanup: Remove stale submodule references

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -162,10 +162,7 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         ''' return iterable containing RequiredSubmodule objects.
         If no RequiredSubmodules return an empty iterable
         '''
-        rs = []
-        rs.append(RequiredSubmodule(
-            "ArmPkg/Library/ArmSoftFloatLib/berkeley-softfloat-3", False))
-        return rs
+        return []
 
     def GetName(self):
         return "SiliconArmTiano"


### PR DESCRIPTION
## Description

This fixes, below stuart_setup error
```
PROGRESS - ## Resolving Git Submodule: Silicon/Arm/MU_TIANO
ERROR - Failed to find /__w/..../Silicon/Arm/MU_TIANO/.pytool/CISettings.py
```
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

NA

## Integration Instructions

NA