### PR TITLE
[Squash on Rebase] CISettings.py: Clean up submodules.

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -163,8 +163,6 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         If no RequiredSubmodules return an empty iterable
         '''
         rs = []
-        rs.append(RequiredSubmodule(
-            "ArmPkg/Library/ArmSoftFloatLib/berkeley-softfloat-3", False))
         return rs
 
     def GetName(self):


### PR DESCRIPTION
## Description

After the last integration, where berkeley-softfloat was removed by EDK2, the CISettings file was missed when removing the dependency. This was causing a benign warning message when populating submodules through cisetup. This removal will prevent the warning message.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
mu_tiano_platforms was showing a warning message about not finding the softfloat (because there was no associated .gitmodules). After the change, the warning message no longer is displayed.

## Integration Instructions
No integration necessary.