### PR TITLE
Carve out the mm buffer region from the bulk system memory hob

### DIFF
--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -103,7 +103,7 @@ MemoryPeim (
   NextHob.Raw = GetHobList ();
   while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, NextHob.Raw)) != NULL) {
     if ((NextHob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
-        (SystemMemoryBase >= NextHob.ResourceDescriptor->PhysicalStart) && // MU_CHANGE
+        (SystemMemoryBase >= NextHob.ResourceDescriptor->PhysicalStart) &&                                           // MU_CHANGE
         (NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength <= SystemMemoryTop)) // MU_CHANGE
     {
       Found = TRUE;
@@ -120,14 +120,10 @@ MemoryPeim (
     MmBufferTop  = MmBufferBase + PcdGet64 (PcdMmBufferSize);
 
     // But pay attention to the potential overlap with the mm communication buffer
-    if (MmBufferBase >= SystemMemoryBase &&
-        MmBufferBase < SystemMemoryTop) {
+    if ((MmBufferBase >= SystemMemoryBase) && (MmBufferBase < SystemMemoryTop)) {
       // The mm communication buffer is in the system memory range
       if (MmBufferBase > SystemMemoryBase) {
         // There is a gap between the start of system memory and the mm communication buffer
-        DEBUG ((DEBUG_INFO, "Build Resource Descriptor Hob for System Memory: 0x%lx - 0x%lx\n",
-          SystemMemoryBase,
-          MmBufferBase - SystemMemoryBase));
         BuildResourceDescriptorV2 (
           EFI_RESOURCE_SYSTEM_MEMORY,
           ResourceAttributes,
@@ -138,13 +134,8 @@ MemoryPeim (
           );
       }
 
-      if (MmBufferTop <
-          SystemMemoryTop) {
+      if (MmBufferTop < SystemMemoryTop) {
         // There is a gap between the end of mm communication buffer and the end of system memory
-        DEBUG ((DEBUG_INFO, "Build Resource Descriptor Hob for System Memory: 0x%lx - 0x%lx\n",
-          MmBufferTop,
-          SystemMemoryTop -
-          MmBufferTop));
         BuildResourceDescriptorV2 (
           EFI_RESOURCE_SYSTEM_MEMORY,
           ResourceAttributes,
@@ -155,10 +146,7 @@ MemoryPeim (
           NULL
           );
       }
-    } else if (MmBufferTop >
-               SystemMemoryBase &&
-               MmBufferTop <=
-               SystemMemoryTop) {
+    } else if ((MmBufferTop > SystemMemoryBase) && (MmBufferTop <= SystemMemoryTop)) {
       // The end of mm communication buffer is in the system memory range
       BuildResourceDescriptorV2 (
         EFI_RESOURCE_SYSTEM_MEMORY,
@@ -180,6 +168,7 @@ MemoryPeim (
         NULL
         );
     }
+
     // MU_CHANGE END
   }
 
@@ -188,12 +177,13 @@ MemoryPeim (
   //
 
   // SystemMemoryTop = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemoryBase) + (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemorySize); // MU_CHANGE
-  FdTop           = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdFdBaseAddress) + (EFI_PHYSICAL_ADDRESS)PcdGet32 (PcdFdSize);
+  FdTop = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdFdBaseAddress) + (EFI_PHYSICAL_ADDRESS)PcdGet32 (PcdFdSize);
 
   // EDK2 does not have the concept of boot firmware copied into DRAM. To avoid the DXE
   // core to overwrite this area we must create a memory allocation HOB for the region,
   // but this only works if we split off the underlying resource descriptor as well.
-  if ((PcdGet64 (PcdFdBaseAddress) >= SystemMemoryBase) && (FdTop <= SystemMemoryTop)) { // MU_CHANGE
+  if ((PcdGet64 (PcdFdBaseAddress) >= SystemMemoryBase) && (FdTop <= SystemMemoryTop)) {
+    // MU_CHANGE
     Found = FALSE;
 
     // Search for System Memory Hob that contains the firmware

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -108,14 +108,69 @@ MemoryPeim (
 
   if (!Found) {
     // Reserved the memory space occupied by the firmware volume
-    BuildResourceDescriptorV2 (
-      EFI_RESOURCE_SYSTEM_MEMORY,
-      ResourceAttributes,
-      PcdGet64 (PcdSystemMemoryBase),
-      PcdGet64 (PcdSystemMemorySize),
-      EFI_MEMORY_WB,
-      NULL
-      );
+    // MU_CHANGE: Carve out MM communication buffer from system memory
+    // But pay attention to the potential overlap with the mm communication buffer
+    if (PcdGet64 (PcdMmBufferBase) >= PcdGet64 (PcdSystemMemoryBase) &&
+        PcdGet64 (PcdMmBufferBase) < (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize))) {
+      // The mm communication buffer is in the system memory range
+      if (PcdGet64 (PcdMmBufferBase) > PcdGet64 (PcdSystemMemoryBase)) {
+        // There is a gap between the start of system memory and the mm communication buffer
+        DEBUG ((DEBUG_INFO, "Build Resource Descriptor Hob for System Memory: 0x%lx - 0x%lx\n",
+          PcdGet64 (PcdSystemMemoryBase),
+          PcdGet64 (PcdMmBufferBase) - PcdGet64 (PcdSystemMemoryBase)));
+        BuildResourceDescriptorV2 (
+          EFI_RESOURCE_SYSTEM_MEMORY,
+          ResourceAttributes,
+          PcdGet64 (PcdSystemMemoryBase),
+          PcdGet64 (PcdMmBufferBase) - PcdGet64 (PcdSystemMemoryBase),
+          EFI_MEMORY_WB,
+          NULL
+          );
+      }
+
+      if ((PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)) <
+          (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize))) {
+        // There is a gap between the end of mm communication buffer and the end of system memory
+        DEBUG ((DEBUG_INFO, "Build Resource Descriptor Hob for System Memory: 0x%lx - 0x%lx\n",
+          PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize),
+          (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize)) -
+          (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize))));
+        BuildResourceDescriptorV2 (
+          EFI_RESOURCE_SYSTEM_MEMORY,
+          ResourceAttributes,
+          PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize),
+          (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize)) -
+          (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)),
+          EFI_MEMORY_WB,
+          NULL
+          );
+      }
+    } else if ((PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)) >
+               PcdGet64 (PcdSystemMemoryBase) &&
+               (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)) <=
+               (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize))) {
+      // The end of mm communication buffer is in the system memory range
+      BuildResourceDescriptorV2 (
+        EFI_RESOURCE_SYSTEM_MEMORY,
+        ResourceAttributes,
+        PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize),
+        (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize)) -
+        (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)),
+        EFI_MEMORY_WB,
+        NULL
+        );
+    } else {
+      // The mm communication buffer is out of the system memory range
+      BuildResourceDescriptorV2 (
+        EFI_RESOURCE_SYSTEM_MEMORY,
+        ResourceAttributes,
+        PcdGet64 (PcdSystemMemoryBase),
+        PcdGet64 (PcdSystemMemorySize),
+        EFI_MEMORY_WB,
+        NULL
+        );
+    }
+    // MU_CHANGE END
   }
 
   //

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -67,8 +67,11 @@ MemoryPeim (
   UINT64                        ResourceLength;
   EFI_PEI_HOB_POINTERS          NextHob;
   EFI_PHYSICAL_ADDRESS          FdTop;
+  EFI_PHYSICAL_ADDRESS          SystemMemoryBase; // MU_CHANGE
   EFI_PHYSICAL_ADDRESS          SystemMemoryTop;
   EFI_PHYSICAL_ADDRESS          ResourceTop;
+  EFI_PHYSICAL_ADDRESS          MmBufferBase; // MU_CHANGE
+  EFI_PHYSICAL_ADDRESS          MmBufferTop;  // MU_CHANGE
   BOOLEAN                       Found;
 
   // Get Virtual Memory Map from the Platform Library
@@ -89,6 +92,10 @@ MemoryPeim (
                         EFI_RESOURCE_ATTRIBUTE_TESTED
                         );
 
+  // MU_CHANGE Use local variable to avoid multiple PcdGet64 calls
+  SystemMemoryBase = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemoryBase);
+  SystemMemoryTop  = SystemMemoryBase + (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemorySize);
+
   //
   // Check if the resource for the main system memory has been declared
   //
@@ -96,8 +103,8 @@ MemoryPeim (
   NextHob.Raw = GetHobList ();
   while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, NextHob.Raw)) != NULL) {
     if ((NextHob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
-        (PcdGet64 (PcdSystemMemoryBase) >= NextHob.ResourceDescriptor->PhysicalStart) &&
-        (NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength <= PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize)))
+        (SystemMemoryBase >= NextHob.ResourceDescriptor->PhysicalStart) && // MU_CHANGE
+        (NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength <= SystemMemoryTop)) // MU_CHANGE
     {
       Found = TRUE;
       break;
@@ -108,54 +115,57 @@ MemoryPeim (
 
   if (!Found) {
     // Reserved the memory space occupied by the firmware volume
-    // MU_CHANGE: Carve out MM communication buffer from system memory
+    // MU_CHANGE START: Carve out MM communication buffer from system memory
+    MmBufferBase = PcdGet64 (PcdMmBufferBase);
+    MmBufferTop  = MmBufferBase + PcdGet64 (PcdMmBufferSize);
+
     // But pay attention to the potential overlap with the mm communication buffer
-    if (PcdGet64 (PcdMmBufferBase) >= PcdGet64 (PcdSystemMemoryBase) &&
-        PcdGet64 (PcdMmBufferBase) < (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize))) {
+    if (MmBufferBase >= SystemMemoryBase &&
+        MmBufferBase < SystemMemoryTop) {
       // The mm communication buffer is in the system memory range
-      if (PcdGet64 (PcdMmBufferBase) > PcdGet64 (PcdSystemMemoryBase)) {
+      if (MmBufferBase > SystemMemoryBase) {
         // There is a gap between the start of system memory and the mm communication buffer
         DEBUG ((DEBUG_INFO, "Build Resource Descriptor Hob for System Memory: 0x%lx - 0x%lx\n",
-          PcdGet64 (PcdSystemMemoryBase),
-          PcdGet64 (PcdMmBufferBase) - PcdGet64 (PcdSystemMemoryBase)));
+          SystemMemoryBase,
+          MmBufferBase - SystemMemoryBase));
         BuildResourceDescriptorV2 (
           EFI_RESOURCE_SYSTEM_MEMORY,
           ResourceAttributes,
-          PcdGet64 (PcdSystemMemoryBase),
-          PcdGet64 (PcdMmBufferBase) - PcdGet64 (PcdSystemMemoryBase),
+          SystemMemoryBase,
+          MmBufferBase - SystemMemoryBase,
           EFI_MEMORY_WB,
           NULL
           );
       }
 
-      if ((PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)) <
-          (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize))) {
+      if (MmBufferTop <
+          SystemMemoryTop) {
         // There is a gap between the end of mm communication buffer and the end of system memory
         DEBUG ((DEBUG_INFO, "Build Resource Descriptor Hob for System Memory: 0x%lx - 0x%lx\n",
-          PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize),
-          (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize)) -
-          (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize))));
+          MmBufferTop,
+          SystemMemoryTop -
+          MmBufferTop));
         BuildResourceDescriptorV2 (
           EFI_RESOURCE_SYSTEM_MEMORY,
           ResourceAttributes,
-          PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize),
-          (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize)) -
-          (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)),
+          MmBufferTop,
+          SystemMemoryTop -
+          MmBufferTop,
           EFI_MEMORY_WB,
           NULL
           );
       }
-    } else if ((PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)) >
-               PcdGet64 (PcdSystemMemoryBase) &&
-               (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)) <=
-               (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize))) {
+    } else if (MmBufferTop >
+               SystemMemoryBase &&
+               MmBufferTop <=
+               SystemMemoryTop) {
       // The end of mm communication buffer is in the system memory range
       BuildResourceDescriptorV2 (
         EFI_RESOURCE_SYSTEM_MEMORY,
         ResourceAttributes,
-        PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize),
-        (PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize)) -
-        (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)),
+        MmBufferTop,
+        SystemMemoryTop -
+        MmBufferTop,
         EFI_MEMORY_WB,
         NULL
         );
@@ -164,7 +174,7 @@ MemoryPeim (
       BuildResourceDescriptorV2 (
         EFI_RESOURCE_SYSTEM_MEMORY,
         ResourceAttributes,
-        PcdGet64 (PcdSystemMemoryBase),
+        SystemMemoryBase,
         PcdGet64 (PcdSystemMemorySize),
         EFI_MEMORY_WB,
         NULL
@@ -177,13 +187,13 @@ MemoryPeim (
   // Reserved the memory space occupied by the firmware volume
   //
 
-  SystemMemoryTop = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemoryBase) + (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemorySize);
+  // SystemMemoryTop = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemoryBase) + (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemorySize); // MU_CHANGE
   FdTop           = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdFdBaseAddress) + (EFI_PHYSICAL_ADDRESS)PcdGet32 (PcdFdSize);
 
   // EDK2 does not have the concept of boot firmware copied into DRAM. To avoid the DXE
   // core to overwrite this area we must create a memory allocation HOB for the region,
   // but this only works if we split off the underlying resource descriptor as well.
-  if ((PcdGet64 (PcdFdBaseAddress) >= PcdGet64 (PcdSystemMemoryBase)) && (FdTop <= SystemMemoryTop)) {
+  if ((PcdGet64 (PcdFdBaseAddress) >= SystemMemoryBase) && (FdTop <= SystemMemoryTop)) { // MU_CHANGE
     Found = FALSE;
 
     // Search for System Memory Hob that contains the firmware

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
@@ -52,6 +52,8 @@
 [Pcd]
   gArmTokenSpaceGuid.PcdSystemMemoryBase
   gArmTokenSpaceGuid.PcdSystemMemorySize
+  gArmTokenSpaceGuid.PcdMmBufferBase # MU_CHANGE
+  gArmTokenSpaceGuid.PcdMmBufferSize # MU_CHANGE
 
 [Depex]
   TRUE


### PR DESCRIPTION
## Description

The MM communication buffer memory is being added in MM communication DXE driver through gDS calls. This means that the region should not be reported as available through resource descriptor hob.

This change will carve out the MM communication buffer from the system memory.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU SBSA and booted to OS desktop.

## Integration Instructions

N/A
