### PR TITLE
ArmPkg: Switch to Invalidate by range TLBI commands to improve SmmuDxe performance

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -67,7 +67,6 @@ UpdateMapping (
   UINT32      Index;
   PAGE_TABLE  *Current;
   UINT64      Entry;
-  UINT32      SmmuIndex;
 
   // Flags must be 12 bits or less
   if ((Root == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (PhysicalAddress == 0)) {
@@ -118,28 +117,6 @@ UpdateMapping (
     }
   }
 
-  // Invalidate TLBI Command.
-  // Current implementation of IoMmu protocol doesnt distinguish between stream id's or Smmu's.
-  // As a result we have to invalidate TLB for all SMMU's for the given virtual address to make
-  // sure that the correct smmu's streamid's page table's TLB is invalidated.
-  // To workaround the limitations of the IoMmu protocol, we globally set the page table root
-  // for all SMMU's and stream id's to be the same.
-  // Todo: Update the IoMmu protocol to support multiple SMMU's and stream id's so we don't have to
-  // invalidate all SMMU's TLB for a given virtual address, just the one that was updated.
-  if (!Valid) {
-    for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-      if (mIoMmu->SmmuInfo[SmmuIndex].Enabled) {
-        Status = SmmuV3TLBInvalidateAddress (&mIoMmu->SmmuInfo[SmmuIndex], VirtualAddress);
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB\n", __func__));
-          goto End;
-        }
-      }
-    }
-  }
-
-  SpeculationBarrier ();
-
 End:
   ASSERT_EFI_ERROR (Status);
   return Status;
@@ -169,7 +146,9 @@ UpdatePageTable (
 {
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  PhysicalAddressEnd;
+  EFI_PHYSICAL_ADDRESS  PhysicalAddressStart;
   EFI_PHYSICAL_ADDRESS  CurPhysicalAddress;
+  UINT32                SmmuIndex;
 
   if ((Root == NULL) || ((Flags & ~PAGE_TABLE_BLOCK_OFFSET) != 0) || (PhysicalAddress == 0) || (Bytes == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
@@ -189,6 +168,34 @@ UpdatePageTable (
 
     CurPhysicalAddress += EFI_PAGE_SIZE;
   }
+
+  // Invalidate TLBI Command.
+  // Current implementation of IoMmu protocol doesnt distinguish between stream id's or Smmu's.
+  // As a result we have to invalidate TLB for all SMMU's for the given virtual address to make
+  // sure that the correct smmu's streamid's page table's TLB is invalidated.
+  // To workaround the limitations of the IoMmu protocol, we globally set the page table root
+  // for all SMMU's and stream id's to be the same.
+  // Todo: Update the IoMmu protocol to support multiple SMMU's and stream id's so we don't have to
+  // invalidate all SMMU's TLB for a given virtual address, just the one that was updated.
+  if (!Valid) {
+    for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+      if (mIoMmu->SmmuInfo[SmmuIndex].Enabled) {
+        if (mIoMmu->SmmuInfo[SmmuIndex].RangeInvalidationSupported) {
+          PhysicalAddressStart = ALIGN_DOWN_BY (PhysicalAddress, EFI_PAGE_SIZE);
+          Status               = SmmuV3TLBInvalidateAddressRange (&mIoMmu->SmmuInfo[SmmuIndex], PhysicalAddressStart, EFI_SIZE_TO_PAGES (PhysicalAddressEnd - PhysicalAddressStart));
+        } else {
+          Status = SmmuV3TLBInvalidateAll (&mIoMmu->SmmuInfo[SmmuIndex]);
+        }
+
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB\n", __func__));
+          goto End;
+        }
+      }
+    }
+  }
+
+  SpeculationBarrier ();
 
 End:
   ASSERT_EFI_ERROR (Status);

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -565,6 +565,7 @@ SmmuV3Configure (
   SMMUV3_CR1                         Cr1;
   SMMUV3_CR2                         Cr2;
   SMMUV3_IDR0                        Idr0;
+  SMMUV3_IDR3                        Idr3;
   SMMUV3_CMD_GENERIC                 Command;
   SMMUV3_GERROR                      GError;
   VOID                               *CommandQueue;
@@ -711,6 +712,10 @@ SmmuV3Configure (
   SmmuV3WriteRegister64 (SmmuInfo->SmmuBase, SMMU_EVENTQ_BASE, EventQueueBase.AsUINT64);
   SmmuV3WriteRegister32 (SmmuInfo->SmmuBase + SMMUV3_PAGE_1_OFFSET, SMMU_EVENTQ_PROD, 0);
   SmmuV3WriteRegister32 (SmmuInfo->SmmuBase + SMMUV3_PAGE_1_OFFSET, SMMU_EVENTQ_CONS, 0);
+
+  // Check if Range-based invalidation and level hint are supported.
+  Idr3.AsUINT32                        = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_IDR3);
+  SmmuInfo->RangeInvalidationSupported = (Idr3.Ril != 0);
 
   // Enable GError and event interrupts
   Status = SmmuV3EnableInterrupts (SmmuInfo->SmmuBase);

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -184,6 +184,7 @@ typedef struct _SMMU_INFO {
   UINT32        OutputAddressWidth;
   UINT8         TranslationStartingLevel;
   BOOLEAN       PageTableRootConcatenated;
+  BOOLEAN       RangeInvalidationSupported;
   BOOLEAN       Enabled;
 } SMMU_INFO;
 
@@ -431,8 +432,12 @@ SmmuV3DumpPageTableEntries (
   Does nothing if no errors found.
 
   @param [in]  SmmuInfo  Pointer to the SMMU_INFO structure.
+
+  @retval EFI_SUCCESS            No SMMU errors found.
+  @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+  @retval EFI_DEVICE_ERROR       SMMU error found.
 **/
-VOID
+EFI_STATUS
 SmmuV3LogErrors (
   IN SMMU_INFO  *SmmuInfo
   );
@@ -468,19 +473,21 @@ SmmuV3TLBInvalidateAll (
   );
 
 /**
-  Invalidate TLB entries for specified InputAddress for Stage 2 of SmmuV3.
+  Invalidate TLB entries for specified address range for Stage 2 of SmmuV3.
 
   @param [in]  SmmuInfo      Pointer to the SMMU_INFO structure.
   @param [in]  InputAddress  The input address to invalidate.
+  @param [in]  PageNum       Number of pages to invalidate.
 
   @retval EFI_SUCCESS            Success.
   @retval EFI_TIMEOUT            Timeout.
   @retval EFI_INVALID_PARAMETER  Invalid Parameters.
 **/
 EFI_STATUS
-SmmuV3TLBInvalidateAddress (
+SmmuV3TLBInvalidateAddressRange (
   IN SMMU_INFO  *SmmuInfo,
-  IN UINT64     InputAddress
+  IN UINT64     InputAddress,
+  IN UINT32     PageNum
   );
 
 /**

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -625,8 +625,12 @@ SmmuV3DumpPageTableEntries (
   Does nothing if no errors found.
 
   @param [in]  SmmuInfo  Pointer to the SMMU_INFO structure.
+
+  @retval EFI_SUCCESS            No SMMU errors found.
+  @retval EFI_INVALID_PARAMETER  Invalid Parameters.
+  @retval EFI_DEVICE_ERROR       SMMU error found.
 **/
-VOID
+EFI_STATUS
 SmmuV3LogErrors (
   IN SMMU_INFO  *SmmuInfo
   )
@@ -639,7 +643,7 @@ SmmuV3LogErrors (
 
   if (SmmuInfo == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
-    return;
+    return EFI_INVALID_PARAMETER;
   }
 
   do {
@@ -647,10 +651,11 @@ SmmuV3LogErrors (
     Status = SmmuV3ConsumeEventQueueForErrors (SmmuInfo, &FaultRecord, &IsEmpty);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Error consuming event queue\n", __func__));
-      break;
+      return Status;
     }
 
     if (IsEmpty == FALSE) {
+      Status = EFI_DEVICE_ERROR;
       DEBUG ((DEBUG_ERROR, "%a: %llx FaultRecord:\n", __func__, SmmuInfo->SmmuBase));
       for (Index = 0; Index < sizeof (FaultRecord.Fault) / sizeof (FaultRecord.Fault[0]); Index++) {
         DEBUG ((DEBUG_ERROR, "0x%llx\n", FaultRecord.Fault[Index]));
@@ -667,8 +672,11 @@ SmmuV3LogErrors (
 
   GError.AsUINT32 = SmmuV3ReadRegister32 (SmmuInfo->SmmuBase, SMMU_GERROR);
   if (GError.AsUINT32 != 0) {
+    Status = EFI_DEVICE_ERROR;
     DEBUG ((DEBUG_ERROR, "%a: %llx GError: 0x%lx\n", __func__, SmmuInfo->SmmuBase, GError.AsUINT32));
   }
+
+  return Status;
 }
 
 /**
@@ -832,7 +840,13 @@ SmmuV3SendCommand (
     // the synchronized view of the consumer index when checking against the current local producer index.
     OldTpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
     SmmuV3CmdQueueUpdateCachedConsumer (SmmuInfo, QueueMask, WrapMask, TotalQueueEntries, &ConsumerIndex, &ConsumerWrap);
+    // Only prints errors if Event Queue is not empty and GError != 0. Returns EFI_SUCCESS if no errors found.
+    Status = SmmuV3LogErrors (SmmuInfo);
     gBS->RestoreTPL (OldTpl);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Error logged from SMMUv3 during command queue operation.\n", __func__));
+      break;
+    }
   } while (SmmuInfo->CachedConsumer < NewProducer);
 
   return Status;
@@ -890,34 +904,46 @@ SmmuV3TLBInvalidateAll (
 }
 
 /**
-  Invalidate TLB entries for specified InputAddress for Stage 2 of SmmuV3.
+  Invalidate TLB entries for specified address range for Stage 2 of SmmuV3.
 
   @param [in]  SmmuInfo      Pointer to the SMMU_INFO structure.
   @param [in]  InputAddress  The input address to invalidate.
+  @param [in]  PageNum       Number of pages to invalidate.
 
   @retval EFI_SUCCESS            Success.
   @retval EFI_TIMEOUT            Timeout.
   @retval EFI_INVALID_PARAMETER  Invalid Parameters.
 **/
 EFI_STATUS
-SmmuV3TLBInvalidateAddress (
+SmmuV3TLBInvalidateAddressRange (
   IN SMMU_INFO  *SmmuInfo,
-  IN UINT64     InputAddress
+  IN UINT64     InputAddress,
+  IN UINT32     PageNum
   )
 {
   SMMUV3_CMD_GENERIC  Command;
   EFI_STATUS          Status;
+  UINT32              Tg;
+  UINT32              Ttl;
 
-  if (SmmuInfo == NULL) {
+  if ((SmmuInfo == NULL) || (PageNum == 0)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
-  // Invalidate with TLBI_S2_IPA Commands
-  SMMUV3_BUILD_CMD_TLBI_S2_IPA (&Command, SMMUV3_STREAM_TABLE_ENTRY_S2VMID, InputAddress);
+  // Per SmmuV3 spec - 0b01: Entries to be invalidated were inserted using a 4KB Translation Granule.
+  // So we set Tg to 1
+  Tg = 1;
+
+  // Leaf entries at Level 3 for a 4KB Granule table. So we set Ttl to 3.
+  Ttl = PAGE_TABLE_DEPTH - 1;
+
+  // Per SmmuV3 spec - Range = ((NUM+1)*2^SCALE)*Translation_Granule_Size where SCALE = 0, Translation_Granule_Size = 4096
+  // So we pass in (PageNum - 1) to invalidate PageNum pages
+  SMMUV3_BUILD_CMD_TLBI_S2_IPA (&Command, SMMUV3_STREAM_TABLE_ENTRY_S2VMID, InputAddress, (PageNum - 1), Tg, Ttl); // Invalidate with TLBI_S2_IPA Range invalidation Command
   Status = SmmuV3SendCommand (SmmuInfo, &Command);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_EL2_ALL failed.\n", __func__));
+    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_S2_IPA failed.\n", __func__));
     return Status;
   }
 

--- a/ArmPkg/Include/Register/SmmuV3Registers.h
+++ b/ArmPkg/Include/Register/SmmuV3Registers.h
@@ -1753,10 +1753,13 @@ typedef union _SMMUV3_FAULT_RECORD {
     (Command)->TlbiS12VmAll.Vmid = InputVmid; \
 }
 
-#define SMMUV3_BUILD_CMD_TLBI_S2_IPA(Command, InputVmid, InputAddress) \
+#define SMMUV3_BUILD_CMD_TLBI_S2_IPA(Command, InputVmid, InputAddress, PageNum, Tg, Ttl) \
 { \
     (Command)->CmdLow = 0; \
     (Command)->CmdHigh = 0; \
+    (Command)->TlbiS2Ipa.Num = PageNum; \
+    (Command)->TlbiS2Ipa.Tg  = Tg; \
+    (Command)->TlbiS2Ipa.Ttl = Ttl; \
     (Command)->TlbiS2Ipa.Opcode = CmdTlbiS2Ipa; \
     (Command)->TlbiS2Ipa.Vmid = InputVmid; \
     (Command)->TlbiS2Ipa.Address = ((InputAddress) >> 12); \


### PR DESCRIPTION
## Description

ArmPkg: Switch to Invalidate by range TLBI commands to improve SmmuDxe performance

Improves performance of high I/O scenarios like hibernate/resume.
Improves hibernate/resume speeds by ~5 seconds.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical platform with hibernate/resume. Improves hibernate/resume speeds by ~5 seconds.

## Integration Instructions

N/A
