### PR TITLE
ArmPkg: Switch to TLBI All

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -146,7 +146,6 @@ UpdatePageTable (
 {
   EFI_STATUS            Status;
   EFI_PHYSICAL_ADDRESS  PhysicalAddressEnd;
-  EFI_PHYSICAL_ADDRESS  PhysicalAddressStart;
   EFI_PHYSICAL_ADDRESS  CurPhysicalAddress;
   UINT32                SmmuIndex;
 
@@ -180,13 +179,7 @@ UpdatePageTable (
   if (!Valid) {
     for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
       if (mIoMmu->SmmuInfo[SmmuIndex].Enabled) {
-        if (mIoMmu->SmmuInfo[SmmuIndex].RangeInvalidationSupported) {
-          PhysicalAddressStart = ALIGN_DOWN_BY (PhysicalAddress, EFI_PAGE_SIZE);
-          Status               = SmmuV3TLBInvalidateAddressRange (&mIoMmu->SmmuInfo[SmmuIndex], PhysicalAddressStart, EFI_SIZE_TO_PAGES (PhysicalAddressEnd - PhysicalAddressStart));
-        } else {
-          Status = SmmuV3TLBInvalidateAll (&mIoMmu->SmmuInfo[SmmuIndex]);
-        }
-
+        Status = SmmuV3TLBInvalidateAll (&mIoMmu->SmmuInfo[SmmuIndex]);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB\n", __func__));
           goto End;

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -473,21 +473,19 @@ SmmuV3TLBInvalidateAll (
   );
 
 /**
-  Invalidate TLB entries for specified address range for Stage 2 of SmmuV3.
+  Invalidate TLB entries for specified InputAddress for Stage 2 of SmmuV3.
 
   @param [in]  SmmuInfo      Pointer to the SMMU_INFO structure.
   @param [in]  InputAddress  The input address to invalidate.
-  @param [in]  PageNum       Number of pages to invalidate.
 
   @retval EFI_SUCCESS            Success.
   @retval EFI_TIMEOUT            Timeout.
   @retval EFI_INVALID_PARAMETER  Invalid Parameters.
 **/
 EFI_STATUS
-SmmuV3TLBInvalidateAddressRange (
+SmmuV3TLBInvalidateAddress (
   IN SMMU_INFO  *SmmuInfo,
-  IN UINT64     InputAddress,
-  IN UINT32     PageNum
+  IN UINT64     InputAddress
   );
 
 /**

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -882,13 +882,6 @@ SmmuV3TLBInvalidateAll (
     return Status;
   }
 
-  SMMUV3_BUILD_CMD_TLBI_EL2_ALL (&Command);
-  Status = SmmuV3SendCommand (SmmuInfo, &Command);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_EL2_ALL failed.\n", __func__));
-    return Status;
-  }
-
   // Issue a CMD_SYNC command to guarantee that any previously issued TLB
   // invalidations (CMD_TLBI_*) are completed (SMMUv3.2 spec section 4.6.3).
   SMMUV3_BUILD_CMD_SYNC_NO_INTERRUPT (&Command);
@@ -904,43 +897,31 @@ SmmuV3TLBInvalidateAll (
 }
 
 /**
-  Invalidate TLB entries for specified address range for Stage 2 of SmmuV3.
+  Invalidate TLB entries for specified InputAddress for Stage 2 of SmmuV3.
 
   @param [in]  SmmuInfo      Pointer to the SMMU_INFO structure.
   @param [in]  InputAddress  The input address to invalidate.
-  @param [in]  PageNum       Number of pages to invalidate.
 
   @retval EFI_SUCCESS            Success.
   @retval EFI_TIMEOUT            Timeout.
   @retval EFI_INVALID_PARAMETER  Invalid Parameters.
 **/
 EFI_STATUS
-SmmuV3TLBInvalidateAddressRange (
+SmmuV3TLBInvalidateAddress (
   IN SMMU_INFO  *SmmuInfo,
-  IN UINT64     InputAddress,
-  IN UINT32     PageNum
+  IN UINT64     InputAddress
   )
 {
   SMMUV3_CMD_GENERIC  Command;
   EFI_STATUS          Status;
-  UINT32              Tg;
-  UINT32              Ttl;
 
-  if ((SmmuInfo == NULL) || (PageNum == 0)) {
+  if (SmmuInfo == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid Parameters\n", __func__));
     return EFI_INVALID_PARAMETER;
   }
 
-  // Per SmmuV3 spec - 0b01: Entries to be invalidated were inserted using a 4KB Translation Granule.
-  // So we set Tg to 1
-  Tg = 1;
-
-  // Leaf entries at Level 3 for a 4KB Granule table. So we set Ttl to 3.
-  Ttl = PAGE_TABLE_DEPTH - 1;
-
-  // Per SmmuV3 spec - Range = ((NUM+1)*2^SCALE)*Translation_Granule_Size where SCALE = 0, Translation_Granule_Size = 4096
-  // So we pass in (PageNum - 1) to invalidate PageNum pages
-  SMMUV3_BUILD_CMD_TLBI_S2_IPA (&Command, SMMUV3_STREAM_TABLE_ENTRY_S2VMID, InputAddress, (PageNum - 1), Tg, Ttl); // Invalidate with TLBI_S2_IPA Range invalidation Command
+  // Invalidate with TLBI_S2_IPA Commands
+  SMMUV3_BUILD_CMD_TLBI_S2_IPA (&Command, SMMUV3_STREAM_TABLE_ENTRY_S2VMID, InputAddress);
   Status = SmmuV3SendCommand (SmmuInfo, &Command);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: CMD_TLBI_S2_IPA failed.\n", __func__));

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -830,7 +830,7 @@ SmmuV3SendCommand (
 
   SmmuInfo->CachedProducer += 1;
   NewProducer               = SmmuInfo->CachedProducer;
-  SmmuV3WriteRegister32 (SmmuInfo->SmmuBase, SMMU_CMDQ_PROD, (UINT32)NewProducer);
+  SmmuV3WriteRegister32 (SmmuInfo->SmmuBase, SMMU_CMDQ_PROD, (UINT32)(NewProducer & (WrapMask | QueueMask)));
 
   gBS->RestoreTPL (OldTpl);
 

--- a/ArmPkg/Include/Register/SmmuV3Registers.h
+++ b/ArmPkg/Include/Register/SmmuV3Registers.h
@@ -1753,13 +1753,10 @@ typedef union _SMMUV3_FAULT_RECORD {
     (Command)->TlbiS12VmAll.Vmid = InputVmid; \
 }
 
-#define SMMUV3_BUILD_CMD_TLBI_S2_IPA(Command, InputVmid, InputAddress, PageNum, Tg, Ttl) \
+#define SMMUV3_BUILD_CMD_TLBI_S2_IPA(Command, InputVmid, InputAddress) \
 { \
     (Command)->CmdLow = 0; \
     (Command)->CmdHigh = 0; \
-    (Command)->TlbiS2Ipa.Num = PageNum; \
-    (Command)->TlbiS2Ipa.Tg  = Tg; \
-    (Command)->TlbiS2Ipa.Ttl = Ttl; \
     (Command)->TlbiS2Ipa.Opcode = CmdTlbiS2Ipa; \
     (Command)->TlbiS2Ipa.Vmid = InputVmid; \
     (Command)->TlbiS2Ipa.Address = ((InputAddress) >> 12); \


### PR DESCRIPTION
## Description

ArmPkg: Switch to TLBI All

Currently TLBI Range invalidation requires unecessary computation of Num and Scale values to construct the command.
Instead, we will simply issue a TLBI All. Has no impact on performance during high I/O scenarios.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical platform.

## Integration Instructions

N/A
