### PR TITLE
ArmPkg: Change default EBS behavior for SMMU(s) to be abort

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -1004,16 +1004,26 @@ SmmuV3ExitBootServices (
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-    Status = SmmuV3DisableTranslation (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to disable smmu 0x%llx translation.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
-      ASSERT_EFI_ERROR (Status);
-    }
+    if (mIoMmu->SmmuInfo[SmmuIndex].Enabled) {
+      if (mIoMmu->SmmuInfo[SmmuIndex].EBSBehaviorAbort) {
+        Status = SmmuV3GlobalAbort (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "%a: Failed to global abort smmu 0x%llx.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
+          ASSERT_EFI_ERROR (Status);
+        }
+      } else {
+        Status = SmmuV3DisableTranslation (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "%a: Failed to disable smmu 0x%llx translation.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
+          ASSERT_EFI_ERROR (Status);
+        }
 
-    Status = SmmuV3SetGlobalBypass (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to set smmu 0x%llx global bypass.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
-      ASSERT_EFI_ERROR (Status);
+        Status = SmmuV3SetGlobalBypass (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "%a: Failed to set smmu 0x%llx global bypass.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
+          ASSERT_EFI_ERROR (Status);
+        }
+      }
     }
   }
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -185,6 +185,7 @@ typedef struct _SMMU_INFO {
   UINT8         TranslationStartingLevel;
   BOOLEAN       PageTableRootConcatenated;
   BOOLEAN       RangeInvalidationSupported;
+  BOOLEAN       EBSBehaviorAbort;
   BOOLEAN       Enabled;
 } SMMU_INFO;
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3Util.c
@@ -981,7 +981,8 @@ SmmuV3GetNodeInfo (
       SmmuNode                                     = (EFI_ACPI_6_0_IO_REMAPPING_SMMU3_NODE *)Node;
       SmmuInfoArray[SmmuIndex].SmmuBase            = SmmuNode->Base;
       SmmuInfoArray[SmmuIndex].Flags               = SmmuNode->Flags;
-      SmmuInfoArray[SmmuIndex].StreamTableEntryMax = 0;  // Initialize max stream ID to 0
+      SmmuInfoArray[SmmuIndex].StreamTableEntryMax = 0;    // Initialize max stream ID to 0
+      SmmuInfoArray[SmmuIndex].EBSBehaviorAbort    = TRUE; // Initialize EBS behavior to Abort by default
       SmmuNodePtrs[SmmuIndex]                      = (VOID *)SmmuNode;
       SmmuIndex++;
     }
@@ -1292,6 +1293,7 @@ SmmuV3AddRMRMapping (
       for (NumMemRangeDesc = 0; NumMemRangeDesc < Item->RmrNode->NumMemRangeDesc; NumMemRangeDesc++) {
         IortMemRangeDesc = (EFI_ACPI_6_0_IO_REMAPPING_MEM_RANGE_DESC *)((UINT8 *)Item->RmrNode + Item->RmrNode->MemRangeDescRef);
         if ((IortMemRangeDesc[NumMemRangeDesc].Base > 0) && (IortMemRangeDesc[NumMemRangeDesc].Length > 0)) {
+          SmmuInfo->EBSBehaviorAbort = FALSE; // At least one RMR mapping exists, set EBS behavior to bypass
           DEBUG ((
             DEBUG_INFO,
             "%a: Adding RMR mapping for SMMU[0x%llx]: Base=0x%llx, Length=0x%llx\n",


### PR DESCRIPTION
## Description

ArmPkg: Change default EBS behavior for SMMU(s) to be abort.

The default behavior of the EBS callback for all SMMU's will be global abort.
If there is an associated RMR node with that SMMU, then we will bypass.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical platform.

## Integration Instructions

N/A