### PR TITLE
Minor Fix: CLANGPDB: SBSA: UnSafeUint64Mult undefined lld-link failure

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.inf
@@ -38,6 +38,7 @@
   DebugLib
   DxeServicesTableLib
   HobLib
+  SafeIntLib
   UefiDriverEntryPoint
 
 [Protocols]

--- a/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
+++ b/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.inf
@@ -29,6 +29,7 @@
   PeimEntryPoint
   PeiServicesLib
   HobLib
+  SafeIntLib
 
 [Pcd]
   gArmTokenSpaceGuid.PcdMmBufferBase


### PR DESCRIPTION
## Description

Add reference to `SafeIntLib` to fix UnSafeUint64Mult undefined lld-link failure

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted `patina-qemu|sbsa|clangpdb` to uefi shell.

## Integration Instructions

NA