### PR TITLE
ArmPkg: Add bounce buffering to IoMmu SmmuDxe implementation

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -30,8 +30,8 @@
 **/
 typedef struct IOMMU_MAP_INFO {
   UINTN                    NumberOfBytes;
-  UINT64                   VirtualAddress;
-  UINT64                   PhysicalAddress;
+  UINT64                   DeviceAddress;
+  UINT64                   HostAddress;
   EDKII_IOMMU_OPERATION    Operation;
 } IOMMU_MAP_INFO;
 
@@ -273,20 +273,18 @@ IoMmuMap (
     }
   }
 
-  // Assert that CommonBuffer operations do not require remapping
-  ASSERT (!((NeedRemap) && ((Operation == EdkiiIoMmuOperationBusMasterCommonBuffer) || (Operation == EdkiiIoMmuOperationBusMasterCommonBuffer64))));
+  MapInfo->NumberOfBytes = *NumberOfBytes;
+  MapInfo->DeviceAddress = DmaMemoryTop;
+  MapInfo->HostAddress   = PhysicalAddress;
+  MapInfo->Operation     = Operation;
 
-  MapInfo->NumberOfBytes   = *NumberOfBytes;
-  MapInfo->VirtualAddress  = DmaMemoryTop;
-  MapInfo->PhysicalAddress = PhysicalAddress;
-  MapInfo->Operation       = Operation;
-
+  // Bounce buffer case
   if (NeedRemap) {
     Status = gBS->AllocatePages (
                     AllocateMaxAddress,
                     EfiBootServicesData,
                     EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes),
-                    &MapInfo->VirtualAddress
+                    &MapInfo->DeviceAddress
                     );
     if (EFI_ERROR (Status)) {
       FreePool (MapInfo);
@@ -301,13 +299,13 @@ IoMmuMap (
     // so the Bus Master can read the contents of the real buffer.
     //
     if ((Operation == EdkiiIoMmuOperationBusMasterRead) || (Operation == EdkiiIoMmuOperationBusMasterRead64)) {
-      CopyMem ((VOID *)(UINTN)MapInfo->VirtualAddress, (VOID *)(UINTN)MapInfo->PhysicalAddress, MapInfo->NumberOfBytes);
+      CopyMem ((VOID *)(UINTN)MapInfo->DeviceAddress, (VOID *)(UINTN)MapInfo->HostAddress, MapInfo->NumberOfBytes);
     }
   } else {
-    MapInfo->VirtualAddress = MapInfo->PhysicalAddress;
+    MapInfo->DeviceAddress = MapInfo->HostAddress;
   }
 
-  *DeviceAddress = MapInfo->VirtualAddress;
+  *DeviceAddress = MapInfo->DeviceAddress;
   *Mapping       = MapInfo;
 
 End:
@@ -343,7 +341,14 @@ IoMmuUnmap (
 
   MapInfo = (IOMMU_MAP_INFO *)Mapping;
 
-  if (MapInfo->VirtualAddress != MapInfo->PhysicalAddress) {
+  // Bounce buffer case
+  if (MapInfo->DeviceAddress != MapInfo->HostAddress) {
+    if ((MapInfo->DeviceAddress == 0) || (MapInfo->HostAddress == 0) || (MapInfo->NumberOfBytes == 0)) {
+      DEBUG ((DEBUG_ERROR, "%a: Invalid fields in MapInfo struct.\n", __func__));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+
     //
     // If this is a write operation from the Bus Master's point of view,
     // then copy the contents of the mapped buffer into the real buffer
@@ -351,8 +356,8 @@ IoMmuUnmap (
     //
     if ((MapInfo->Operation == EdkiiIoMmuOperationBusMasterWrite) || (MapInfo->Operation == EdkiiIoMmuOperationBusMasterWrite64)) {
       CopyMem (
-        (VOID *)(UINTN)MapInfo->PhysicalAddress,
-        (VOID *)(UINTN)MapInfo->VirtualAddress,
+        (VOID *)(UINTN)MapInfo->HostAddress,
+        (VOID *)(UINTN)MapInfo->DeviceAddress,
         MapInfo->NumberOfBytes
         );
     }
@@ -360,7 +365,7 @@ IoMmuUnmap (
     //
     // Free the mapped buffer and the MAP_INFO structure.
     //
-    gBS->FreePages (MapInfo->VirtualAddress, EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes));
+    gBS->FreePages (MapInfo->DeviceAddress, EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes));
   }
 
   // Free the mapping structure allocated in IoMmuMap
@@ -506,7 +511,7 @@ IoMmuSetAttribute (
 
   Status = UpdatePageTable (
              mIoMmu->SmmuInfo->PageTableRoot,
-             MapInfo->VirtualAddress,
+             MapInfo->DeviceAddress,
              MapInfo->NumberOfBytes,
              PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS ((EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)), // TODO: https://github.com/microsoft/mu_silicon_arm_tiano/issues/375 debug issue on physical platform and revert the permissions
              (IoMmuAccess != 0)

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -273,16 +273,8 @@ IoMmuMap (
     }
   }
 
-  if ((NeedRemap) && ((Operation == EdkiiIoMmuOperationBusMasterCommonBuffer) || (Operation == EdkiiIoMmuOperationBusMasterCommonBuffer64))) {
-    //
-    // Common Buffer operations can not be remapped.  If the common buffer
-    // is above 4GB, then it is not possible to generate a mapping, so return
-    // an error.
-    //
-    DEBUG ((DEBUG_ERROR, "%a: Common buffer operations cannot be remapped.\n", __func__));
-    ASSERT (FALSE);
-    return EFI_UNSUPPORTED;
-  }
+  // Assert that CommonBuffer operations do not require remapping
+  ASSERT (!((NeedRemap) && ((Operation == EdkiiIoMmuOperationBusMasterCommonBuffer) || (Operation == EdkiiIoMmuOperationBusMasterCommonBuffer64))));
 
   MapInfo->NumberOfBytes   = *NumberOfBytes;
   MapInfo->VirtualAddress  = DmaMemoryTop;

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -29,9 +29,10 @@
   Used to pass between IoMmuMap, IoMmuUnmap and IoMmuSetAttribute.
 **/
 typedef struct IOMMU_MAP_INFO {
-  UINTN     NumberOfBytes;
-  UINT64    VirtualAddress;
-  UINT64    PhysicalAddress;
+  UINTN                    NumberOfBytes;
+  UINT64                   VirtualAddress;
+  UINT64                   PhysicalAddress;
+  EDKII_IOMMU_OPERATION    Operation;
 } IOMMU_MAP_INFO;
 
 /**
@@ -221,10 +222,14 @@ IoMmuMap (
   OUT    VOID                   **Mapping
   )
 {
-  EFI_STATUS      Status;
-  IOMMU_MAP_INFO  *MapInfo;
+  EFI_STATUS            Status;
+  IOMMU_MAP_INFO        *MapInfo;
+  EFI_PHYSICAL_ADDRESS  PhysicalAddress;
+  BOOLEAN               NeedRemap;
+  EFI_PHYSICAL_ADDRESS  DmaMemoryTop;
 
-  Status = EFI_SUCCESS;
+  Status    = EFI_SUCCESS;
+  NeedRemap = FALSE;
 
   if ((This == NULL) ||
       (HostAddress == NULL) ||
@@ -246,12 +251,72 @@ IoMmuMap (
     goto End;
   }
 
-  *DeviceAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress; // Identity mapping
+  DmaMemoryTop    = MAX_UINTN;
+  PhysicalAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
+
+  if ((Operation != EdkiiIoMmuOperationBusMasterCommonBuffer) && (Operation != EdkiiIoMmuOperationBusMasterCommonBuffer64)) {
+    if ((*NumberOfBytes != ALIGN_VALUE (*NumberOfBytes, SIZE_4KB)) || (PhysicalAddress != ALIGN_VALUE (PhysicalAddress, SIZE_4KB))) {
+      NeedRemap = TRUE;
+    }
+
+    if ((((Operation != EdkiiIoMmuOperationBusMasterRead64) &&
+          (Operation != EdkiiIoMmuOperationBusMasterWrite64))) &&
+        ((PhysicalAddress + *NumberOfBytes) > SIZE_4GB))
+    {
+      //
+      // If the root bridge or the device cannot handle performing DMA above
+      // 4GB but any part of the DMA transfer being mapped is above 4GB, then
+      // map the DMA transfer to a buffer below 4GB.
+      //
+      NeedRemap    = TRUE;
+      DmaMemoryTop = SIZE_4GB - 1;
+    }
+  }
+
+  if ((NeedRemap) && ((Operation == EdkiiIoMmuOperationBusMasterCommonBuffer) || (Operation == EdkiiIoMmuOperationBusMasterCommonBuffer64))) {
+    //
+    // Common Buffer operations can not be remapped.  If the common buffer
+    // is above 4GB, then it is not possible to generate a mapping, so return
+    // an error.
+    //
+    DEBUG ((DEBUG_ERROR, "%a: Common buffer operations cannot be remapped.\n", __func__));
+    ASSERT (FALSE);
+    return EFI_UNSUPPORTED;
+  }
 
   MapInfo->NumberOfBytes   = *NumberOfBytes;
-  MapInfo->VirtualAddress  = *DeviceAddress;
-  MapInfo->PhysicalAddress = *DeviceAddress;
-  *Mapping                 = MapInfo;
+  MapInfo->VirtualAddress  = DmaMemoryTop;
+  MapInfo->PhysicalAddress = PhysicalAddress;
+  MapInfo->Operation       = Operation;
+
+  if (NeedRemap) {
+    Status = gBS->AllocatePages (
+                    AllocateMaxAddress,
+                    EfiBootServicesData,
+                    EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes),
+                    &MapInfo->VirtualAddress
+                    );
+    if (EFI_ERROR (Status)) {
+      FreePool (MapInfo);
+      *NumberOfBytes = 0;
+      DEBUG ((DEBUG_ERROR, "%a: %r\n", __func__, Status));
+      return Status;
+    }
+
+    //
+    // If this is a read operation from the Bus Master's point of view,
+    // then copy the contents of the real buffer into the mapped buffer
+    // so the Bus Master can read the contents of the real buffer.
+    //
+    if ((Operation == EdkiiIoMmuOperationBusMasterRead) || (Operation == EdkiiIoMmuOperationBusMasterRead64)) {
+      CopyMem ((VOID *)(UINTN)MapInfo->VirtualAddress, (VOID *)(UINTN)MapInfo->PhysicalAddress, MapInfo->NumberOfBytes);
+    }
+  } else {
+    MapInfo->VirtualAddress = MapInfo->PhysicalAddress;
+  }
+
+  *DeviceAddress = MapInfo->VirtualAddress;
+  *Mapping       = MapInfo;
 
 End:
   ASSERT_EFI_ERROR (Status);
@@ -276,10 +341,34 @@ IoMmuUnmap (
   IN  VOID                  *Mapping
   )
 {
+  IOMMU_MAP_INFO  *MapInfo;
+
   if ((This == NULL) || (Mapping == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
     ASSERT (FALSE);
     return EFI_INVALID_PARAMETER;
+  }
+
+  MapInfo = (IOMMU_MAP_INFO *)Mapping;
+
+  if (MapInfo->VirtualAddress != MapInfo->PhysicalAddress) {
+    //
+    // If this is a write operation from the Bus Master's point of view,
+    // then copy the contents of the mapped buffer into the real buffer
+    // so the processor can read the contents of the real buffer.
+    //
+    if ((MapInfo->Operation == EdkiiIoMmuOperationBusMasterWrite) || (MapInfo->Operation == EdkiiIoMmuOperationBusMasterWrite64)) {
+      CopyMem (
+        (VOID *)(UINTN)MapInfo->PhysicalAddress,
+        (VOID *)(UINTN)MapInfo->VirtualAddress,
+        MapInfo->NumberOfBytes
+        );
+    }
+
+    //
+    // Free the mapped buffer and the MAP_INFO structure.
+    //
+    gBS->FreePages (MapInfo->VirtualAddress, EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes));
   }
 
   // Free the mapping structure allocated in IoMmuMap
@@ -425,7 +514,7 @@ IoMmuSetAttribute (
 
   Status = UpdatePageTable (
              mIoMmu->SmmuInfo->PageTableRoot,
-             MapInfo->PhysicalAddress,
+             MapInfo->VirtualAddress,
              MapInfo->NumberOfBytes,
              PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS ((EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)), // TODO: https://github.com/microsoft/mu_silicon_arm_tiano/issues/375 debug issue on physical platform and revert the permissions
              (IoMmuAccess != 0)

--- a/ArmPkg/Drivers/SmmuDxe/README.md
+++ b/ArmPkg/Drivers/SmmuDxe/README.md
@@ -53,7 +53,7 @@ SMMU Hardware
 
    - SmmuDxe will handle Translation Table initialization
 
-### DMA Mapping with IoMmuLib and IoMmu Protocol
+## DMA Mapping with IoMmuLib and IoMmu Protocol
 
 - Maintains up to a 4-level page table, depending on configuration, to map HostAddress and DeviceAddress
 - Identity Mapped
@@ -76,7 +76,48 @@ SMMU Hardware
 - Validates operation type
 - Called by PciIo protocol for mapping
 
-### DMA Unmapping with IoMmuLib and IoMmu Protocol
+### Bounce Buffering
+
+In certain conditions, `IoMmuMap` will allocate a bounce buffer instead of using the original host address directly.
+A bounce buffer is a temporary intermediate buffer allocated that is used when the original DMA buffer
+cannot be used directly by the device.
+
+**Bounce Buffer Conditions:**
+
+A bounce buffer is allocated when the operation is NOT `EdkiiIoMmuOperationBusMasterCommonBuffer` or
+`EdkiiIoMmuOperationBusMasterCommonBuffer64`, AND any of the following conditions are met:
+
+1. **Alignment Requirements Not Met:**
+   - The `NumberOfBytes` is not 4KB aligned, OR
+   - The `HostAddress` (PhysicalAddress) is not 4KB aligned
+
+2. **32-bit DMA Limitation:**
+   - The operation is a 32-bit DMA operation (`EdkiiIoMmuOperationBusMasterRead` or
+     `EdkiiIoMmuOperationBusMasterWrite`), AND
+   - Any part of the DMA transfer range (`PhysicalAddress + NumberOfBytes`) exceeds 4GB
+
+**Bounce Buffer Behavior:**
+
+- When a bounce buffer is needed due to **alignment issues only** (with 64-bit operations), memory can be allocated
+  anywhere in the address space
+- When a bounce buffer is needed due to the **32-bit DMA limitation**, memory is allocated below 4GB using
+  `AllocateMaxAddress` with `DmaMemoryTop` set to `SIZE_4GB - 1`
+- The `DeviceAddress` returned points to the bounce buffer, not the original host address
+- The `Mapping` handle stores information about both the original host address and the bounce buffer address
+
+**CopyMem on Map (Host → Bounce Buffer):**
+
+A `CopyMem` from the host buffer to the bounce buffer is performed during `IoMmuMap` when:
+
+- A bounce buffer was allocated (NeedRemap is TRUE), AND
+- The operation is a **read operation** from the Bus Master's perspective:
+  - `EdkiiIoMmuOperationBusMasterRead`, OR
+  - `EdkiiIoMmuOperationBusMasterRead64`
+
+This copy ensures the Bus Master can read the correct data from the bounce buffer during the DMA operation.
+For write operations, no copy is needed on Map since the Bus Master will write new data into the bounce buffer.
+
+## DMA Unmapping with IoMmuLib and IoMmu Protocol
 
 1. **PCI Driver Completes DMA**:
    - Calls PciIo->Unmap()
@@ -94,6 +135,29 @@ SMMU Hardware
 
    - Invalidates mapping in Page Table
    - Invalidates TLB entries
+
+### Bounce Buffer Handling on Unmap
+
+When unmapping a DMA operation that used a bounce buffer (i.e., `DeviceAddress != HostAddress`):
+
+**CopyMem on Unmap (Bounce Buffer → Host):**
+
+A `CopyMem` from the bounce buffer back to the host buffer is performed during `IoMmuUnmap` when:
+
+- A bounce buffer was used (`DeviceAddress != HostAddress`), AND
+- The operation is a **write operation** from the Bus Master's perspective:
+  - `EdkiiIoMmuOperationBusMasterWrite`, OR
+  - `EdkiiIoMmuOperationBusMasterWrite64`
+
+This copy ensures the processor can access the data that the Bus Master wrote into the bounce buffer.
+For read operations, no copy is needed on Unmap since the Bus Master only read data and did not modify it.
+
+**Cleanup:**
+
+- The bounce buffer pages are freed using `FreePages`
+- The mapping information structure is freed
+
+For direct mappings (no bounce buffer), only the mapping information structure is freed.
 
 ### DMA Access Attributes with IoMmuLib and IoMmu Protocol
 
@@ -240,7 +304,12 @@ Potential improvements:
 1. Multiple translation granule support
 2. Stage 1 & 2 translation
 3. Different page table mapping schemes
-4. Updated IoMmu Protocol to optimize redundencies
+4. Updated IoMmu Protocol to optimize redundancies
+5. Bounce Buffer Optimization
+   - Remove the `NumberOfBytes` end address alignment check in `IoMmuMap`
+   - Update individual drivers to allocate their DMA buffers by page (page-aligned and page-sized)
+   - This eliminates one case for bounce buffering, improving performance by avoiding unnecessary
+     buffer copies and allocations when only the end address is unaligned
 
 ## Configuration Options
 


### PR DESCRIPTION
## Description

ArmPkg: Add bounce buffering to IoMmu SmmuDxe implementation

For the cases where we have:
- Non-aligned DMA buffer when we are not using CommonBuffer operations
- An address above 4G for the DMA buffer when the operation only supports below 4G

We need to bounce buffer the original DMA buffer to a newly allocated one under the above conditions. On a Read operation Map() will copy the contents of the DMA buffer into the newly allocated buffer. On a Write operation Unmap() will copy the contents of the newly allocated buffer back to the original DMA buffer.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Tested on physical platform

## Integration Instructions

N/A