### PR TITLE
ArmPkg: Also disable translation when setting global abort for SmmuDxe EBS behavior

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -1005,6 +1005,12 @@ SmmuV3ExitBootServices (
 
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
     if (mIoMmu->SmmuInfo[SmmuIndex].Enabled) {
+      Status = SmmuV3DisableTranslation (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: Failed to disable smmu 0x%llx translation.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
+        ASSERT_EFI_ERROR (Status);
+      }
+
       if (mIoMmu->SmmuInfo[SmmuIndex].EBSBehaviorAbort) {
         Status = SmmuV3GlobalAbort (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
         if (EFI_ERROR (Status)) {
@@ -1012,12 +1018,6 @@ SmmuV3ExitBootServices (
           ASSERT_EFI_ERROR (Status);
         }
       } else {
-        Status = SmmuV3DisableTranslation (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_ERROR, "%a: Failed to disable smmu 0x%llx translation.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
-          ASSERT_EFI_ERROR (Status);
-        }
-
         Status = SmmuV3SetGlobalBypass (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_ERROR, "%a: Failed to set smmu 0x%llx global bypass.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -1005,12 +1005,6 @@ SmmuV3ExitBootServices (
 
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
     if (mIoMmu->SmmuInfo[SmmuIndex].Enabled) {
-      Status = SmmuV3DisableTranslation (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a: Failed to disable smmu 0x%llx translation.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
-        ASSERT_EFI_ERROR (Status);
-      }
-
       if (mIoMmu->SmmuInfo[SmmuIndex].EBSBehaviorAbort) {
         Status = SmmuV3GlobalAbort (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
         if (EFI_ERROR (Status)) {
@@ -1023,6 +1017,12 @@ SmmuV3ExitBootServices (
           DEBUG ((DEBUG_ERROR, "%a: Failed to set smmu 0x%llx global bypass.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
           ASSERT_EFI_ERROR (Status);
         }
+      }
+
+      Status = SmmuV3DisableTranslation (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: Failed to disable smmu 0x%llx translation.\n", __func__, mIoMmu->SmmuInfo[SmmuIndex].SmmuBase));
+        ASSERT_EFI_ERROR (Status);
       }
     }
   }


### PR DESCRIPTION
## Description

ArmPkg: Also disable translation when setting global abort for SmmuDxe EBS behavior

SMMUv3 honors the Global Abort bit only when CR0.SMMUEN == 0. SmmuV3DisableTranslation() handles this.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical device

## Integration Instructions

N/A