### PR TITLE
Do not set attributes if the incoming attributes is outside of the mask

### DIFF
--- a/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
+++ b/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
@@ -451,6 +451,8 @@ ArmSetMemoryRegionReadOnly (
       break;
     }
 
+    DEBUG ((DEBUG_ERROR, "%a: Current MemAttr: 0x%x\n", __FUNCTION__, MemoryAttributes));
+
     if (UseFfaAbis) {
       PermissionRequest = ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST (
                             ARM_FFA_SET_MEM_ATTR_DATA_PERM_RO,
@@ -596,39 +598,45 @@ ArmSetMemoryAttributes (
     goto Done;
   }
 
-  if ((NeededAttributes & EFI_MEMORY_RP) != 0) {
-    Status = ArmSetMemoryRegionNoAccess (BaseAddress, Length);
-    if (EFI_ERROR (Status)) {
-      goto Done;
-    }
-  } else {
-    Status = ArmClearMemoryRegionNoAccess (BaseAddress, Length);
-    if (EFI_ERROR (Status)) {
-      goto Done;
-    }
-  }
-
-  if ((NeededAttributes & EFI_MEMORY_RO) != 0) {
-    Status = ArmSetMemoryRegionReadOnly (BaseAddress, Length);
-    if (EFI_ERROR (Status)) {
-      goto Done;
-    }
-  } else {
-    Status = ArmClearMemoryRegionReadOnly (BaseAddress, Length);
-    if (EFI_ERROR (Status)) {
-      goto Done;
+  if (AttributeMask & EFI_MEMORY_RP) {
+    if ((NeededAttributes & EFI_MEMORY_RP) != 0) {
+      Status = ArmSetMemoryRegionNoAccess (BaseAddress, Length);
+      if (EFI_ERROR (Status)) {
+        goto Done;
+      }
+    } else {
+      Status = ArmClearMemoryRegionNoAccess (BaseAddress, Length);
+      if (EFI_ERROR (Status)) {
+        goto Done;
+      }
     }
   }
 
-  if ((NeededAttributes & EFI_MEMORY_XP) != 0) {
-    Status = ArmSetMemoryRegionNoExec (BaseAddress, Length);
-    if (EFI_ERROR (Status)) {
-      goto Done;
+  if (AttributeMask & EFI_MEMORY_RO) {
+    if ((NeededAttributes & EFI_MEMORY_RO) != 0) {
+      Status = ArmSetMemoryRegionReadOnly (BaseAddress, Length);
+      if (EFI_ERROR (Status)) {
+        goto Done;
+      }
+    } else {
+      Status = ArmClearMemoryRegionReadOnly (BaseAddress, Length);
+      if (EFI_ERROR (Status)) {
+        goto Done;
+      }
     }
-  } else {
-    Status = ArmClearMemoryRegionNoExec (BaseAddress, Length);
-    if (EFI_ERROR (Status)) {
-      goto Done;
+  }
+
+  if (AttributeMask & EFI_MEMORY_XP) {
+    if ((NeededAttributes & EFI_MEMORY_XP) != 0) {
+      Status = ArmSetMemoryRegionNoExec (BaseAddress, Length);
+      if (EFI_ERROR (Status)) {
+        goto Done;
+      }
+    } else {
+      Status = ArmClearMemoryRegionNoExec (BaseAddress, Length);
+      if (EFI_ERROR (Status)) {
+        goto Done;
+      }
     }
   }
 

--- a/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
+++ b/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
@@ -451,8 +451,6 @@ ArmSetMemoryRegionReadOnly (
       break;
     }
 
-    DEBUG ((DEBUG_ERROR, "%a: Current MemAttr: 0x%x\n", __FUNCTION__, MemoryAttributes));
-
     if (UseFfaAbis) {
       PermissionRequest = ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST (
                             ARM_FFA_SET_MEM_ATTR_DATA_PERM_RO,


### PR DESCRIPTION
## Description

The current code will set all RO, RP and XP attributes after using the attribute mask. This could cause the system to trip on unwanted attributes getting set even when the mask does not set on certain bits.

The change will check on the attribute masks before apply the bits.

resolves #454.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU SBSA and successfully relocated the image.

## Integration Instructions

N/A
