### PR TITLE
[Rebase & FF] Consolidates memory initialization mechanism for pre-DXE environment

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -629,13 +629,61 @@ MmCommunication2Initialize (
                   EFI_MEMORY_XP |
                   EFI_MEMORY_RUNTIME
                   );
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR (Status) && (Status != EFI_ACCESS_DENIED)) {
     DEBUG ((
       DEBUG_ERROR,
       "MmCommunicateInitialize: "
-      "Failed to add MM-NS Buffer Memory Space\n"
+      "Failed to add MM-NS Buffer Memory Space - %r\n",
+      Status
       ));
     goto ReturnErrorStatus;
+  } else if (Status == EFI_ACCESS_DENIED) {
+    Status = gDS->FreeMemorySpace (
+                    mNsCommBuffMemRegion.PhysicalBase,
+                    mNsCommBuffMemRegion.Length
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "MmCommunicateInitialize: "
+        "Failed to free existing MM-NS Buffer Memory Space - %r\n",
+        Status
+        ));
+      goto ReturnErrorStatus;
+    }
+
+    Status = gDS->RemoveMemorySpace (
+                    mNsCommBuffMemRegion.PhysicalBase,
+                    mNsCommBuffMemRegion.Length
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "MmCommunicateInitialize: "
+        "Failed to remove existing MM-NS Buffer Memory Space - %r\n",
+        Status
+        ));
+      goto ReturnErrorStatus;
+    }
+
+    // Try to add the memory space again
+    Status = gDS->AddMemorySpace (
+                    EfiGcdMemoryTypeReserved,
+                    mNsCommBuffMemRegion.PhysicalBase,
+                    mNsCommBuffMemRegion.Length,
+                    EFI_MEMORY_WB |
+                    EFI_MEMORY_XP |
+                    EFI_MEMORY_RUNTIME
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "MmCommunicateInitialize: "
+        "Failed to add MM-NS Buffer Memory Space (second attempt) - %r\n",
+        Status
+        ));
+      goto ReturnErrorStatus;
+    }
   }
 
   Status = gDS->SetMemorySpaceAttributes (

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -67,6 +67,7 @@ MemoryPeim (
   UINT64                        ResourceLength;
   EFI_PEI_HOB_POINTERS          NextHob;
   EFI_PHYSICAL_ADDRESS          FdTop;
+  EFI_PHYSICAL_ADDRESS          SystemMemoryBase;
   EFI_PHYSICAL_ADDRESS          SystemMemoryTop;
   EFI_PHYSICAL_ADDRESS          ResourceTop;
   BOOLEAN                       Found;
@@ -90,14 +91,20 @@ MemoryPeim (
                         );
 
   //
+  // Use local variable to avoid multiple PcdGet64 calls
+  //
+  SystemMemoryBase = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemoryBase);
+  SystemMemoryTop  = SystemMemoryBase + (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemorySize);
+
+  //
   // Check if the resource for the main system memory has been declared
   //
   Found       = FALSE;
   NextHob.Raw = GetHobList ();
   while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, NextHob.Raw)) != NULL) {
     if ((NextHob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
-        (PcdGet64 (PcdSystemMemoryBase) >= NextHob.ResourceDescriptor->PhysicalStart) &&
-        (NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength <= PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize)))
+        (SystemMemoryBase >= NextHob.ResourceDescriptor->PhysicalStart) &&
+        (NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength <= SystemMemoryTop))
     {
       Found = TRUE;
       break;
@@ -111,7 +118,7 @@ MemoryPeim (
     BuildResourceDescriptorV2 (
       EFI_RESOURCE_SYSTEM_MEMORY,
       ResourceAttributes,
-      PcdGet64 (PcdSystemMemoryBase),
+      SystemMemoryBase,
       PcdGet64 (PcdSystemMemorySize),
       EFI_MEMORY_WB,
       NULL
@@ -122,13 +129,12 @@ MemoryPeim (
   // Reserved the memory space occupied by the firmware volume
   //
 
-  SystemMemoryTop = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemoryBase) + (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemorySize);
-  FdTop           = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdFdBaseAddress) + (EFI_PHYSICAL_ADDRESS)PcdGet32 (PcdFdSize);
+  FdTop = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdFdBaseAddress) + (EFI_PHYSICAL_ADDRESS)PcdGet32 (PcdFdSize);
 
   // EDK2 does not have the concept of boot firmware copied into DRAM. To avoid the DXE
   // core to overwrite this area we must create a memory allocation HOB for the region,
   // but this only works if we split off the underlying resource descriptor as well.
-  if ((PcdGet64 (PcdFdBaseAddress) >= PcdGet64 (PcdSystemMemoryBase)) && (FdTop <= SystemMemoryTop)) {
+  if ((PcdGet64 (PcdFdBaseAddress) >= SystemMemoryBase) && (FdTop <= SystemMemoryTop)) {
     Found = FALSE;
 
     // Search for System Memory Hob that contains the firmware

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -101,10 +101,10 @@ MemoryPeim (
   //
   Found       = FALSE;
   NextHob.Raw = GetHobList ();
-  while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, NextHob.Raw)) != NULL) {
-    if ((NextHob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
-        (SystemMemoryBase >= NextHob.ResourceDescriptor->PhysicalStart) &&
-        (NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength <= SystemMemoryTop))
+  while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2, NextHob.Raw)) != NULL) {
+    if ((NextHob.ResourceDescriptorV2->V1.ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
+        (SystemMemoryBase >= NextHob.ResourceDescriptorV2->V1.PhysicalStart) &&
+        (NextHob.ResourceDescriptorV2->V1.PhysicalStart + NextHob.ResourceDescriptorV2->V1.ResourceLength <= SystemMemoryTop))
     {
       Found = TRUE;
       break;

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -67,11 +67,8 @@ MemoryPeim (
   UINT64                        ResourceLength;
   EFI_PEI_HOB_POINTERS          NextHob;
   EFI_PHYSICAL_ADDRESS          FdTop;
-  EFI_PHYSICAL_ADDRESS          SystemMemoryBase; // MU_CHANGE
   EFI_PHYSICAL_ADDRESS          SystemMemoryTop;
   EFI_PHYSICAL_ADDRESS          ResourceTop;
-  EFI_PHYSICAL_ADDRESS          MmBufferBase; // MU_CHANGE
-  EFI_PHYSICAL_ADDRESS          MmBufferTop;  // MU_CHANGE
   BOOLEAN                       Found;
 
   // Get Virtual Memory Map from the Platform Library
@@ -92,10 +89,6 @@ MemoryPeim (
                         EFI_RESOURCE_ATTRIBUTE_TESTED
                         );
 
-  // MU_CHANGE Use local variable to avoid multiple PcdGet64 calls
-  SystemMemoryBase = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemoryBase);
-  SystemMemoryTop  = SystemMemoryBase + (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemorySize);
-
   //
   // Check if the resource for the main system memory has been declared
   //
@@ -103,8 +96,8 @@ MemoryPeim (
   NextHob.Raw = GetHobList ();
   while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, NextHob.Raw)) != NULL) {
     if ((NextHob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
-        (SystemMemoryBase >= NextHob.ResourceDescriptor->PhysicalStart) &&                                           // MU_CHANGE
-        (NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength <= SystemMemoryTop)) // MU_CHANGE
+        (PcdGet64 (PcdSystemMemoryBase) >= NextHob.ResourceDescriptor->PhysicalStart) &&
+        (NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength <= PcdGet64 (PcdSystemMemoryBase) + PcdGet64 (PcdSystemMemorySize)))
     {
       Found = TRUE;
       break;
@@ -115,75 +108,27 @@ MemoryPeim (
 
   if (!Found) {
     // Reserved the memory space occupied by the firmware volume
-    // MU_CHANGE START: Carve out MM communication buffer from system memory
-    MmBufferBase = PcdGet64 (PcdMmBufferBase);
-    MmBufferTop  = MmBufferBase + PcdGet64 (PcdMmBufferSize);
-
-    // But pay attention to the potential overlap with the mm communication buffer
-    if ((MmBufferBase >= SystemMemoryBase) && (MmBufferBase < SystemMemoryTop)) {
-      // The mm communication buffer is in the system memory range
-      if (MmBufferBase > SystemMemoryBase) {
-        // There is a gap between the start of system memory and the mm communication buffer
-        BuildResourceDescriptorV2 (
-          EFI_RESOURCE_SYSTEM_MEMORY,
-          ResourceAttributes,
-          SystemMemoryBase,
-          MmBufferBase - SystemMemoryBase,
-          EFI_MEMORY_WB,
-          NULL
-          );
-      }
-
-      if (MmBufferTop < SystemMemoryTop) {
-        // There is a gap between the end of mm communication buffer and the end of system memory
-        BuildResourceDescriptorV2 (
-          EFI_RESOURCE_SYSTEM_MEMORY,
-          ResourceAttributes,
-          MmBufferTop,
-          SystemMemoryTop -
-          MmBufferTop,
-          EFI_MEMORY_WB,
-          NULL
-          );
-      }
-    } else if ((MmBufferTop > SystemMemoryBase) && (MmBufferTop <= SystemMemoryTop)) {
-      // The end of mm communication buffer is in the system memory range
-      BuildResourceDescriptorV2 (
-        EFI_RESOURCE_SYSTEM_MEMORY,
-        ResourceAttributes,
-        MmBufferTop,
-        SystemMemoryTop -
-        MmBufferTop,
-        EFI_MEMORY_WB,
-        NULL
-        );
-    } else {
-      // The mm communication buffer is out of the system memory range
-      BuildResourceDescriptorV2 (
-        EFI_RESOURCE_SYSTEM_MEMORY,
-        ResourceAttributes,
-        SystemMemoryBase,
-        PcdGet64 (PcdSystemMemorySize),
-        EFI_MEMORY_WB,
-        NULL
-        );
-    }
-
-    // MU_CHANGE END
+    BuildResourceDescriptorV2 (
+      EFI_RESOURCE_SYSTEM_MEMORY,
+      ResourceAttributes,
+      PcdGet64 (PcdSystemMemoryBase),
+      PcdGet64 (PcdSystemMemorySize),
+      EFI_MEMORY_WB,
+      NULL
+      );
   }
 
   //
   // Reserved the memory space occupied by the firmware volume
   //
 
-  // SystemMemoryTop = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemoryBase) + (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemorySize); // MU_CHANGE
-  FdTop = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdFdBaseAddress) + (EFI_PHYSICAL_ADDRESS)PcdGet32 (PcdFdSize);
+  SystemMemoryTop = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemoryBase) + (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdSystemMemorySize);
+  FdTop           = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdFdBaseAddress) + (EFI_PHYSICAL_ADDRESS)PcdGet32 (PcdFdSize);
 
   // EDK2 does not have the concept of boot firmware copied into DRAM. To avoid the DXE
   // core to overwrite this area we must create a memory allocation HOB for the region,
   // but this only works if we split off the underlying resource descriptor as well.
-  if ((PcdGet64 (PcdFdBaseAddress) >= SystemMemoryBase) && (FdTop <= SystemMemoryTop)) {
-    // MU_CHANGE
+  if ((PcdGet64 (PcdFdBaseAddress) >= PcdGet64 (PcdSystemMemoryBase)) && (FdTop <= SystemMemoryTop)) {
     Found = FALSE;
 
     // Search for System Memory Hob that contains the firmware

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.inf
@@ -52,8 +52,6 @@
 [Pcd]
   gArmTokenSpaceGuid.PcdSystemMemoryBase
   gArmTokenSpaceGuid.PcdSystemMemorySize
-  gArmTokenSpaceGuid.PcdMmBufferBase # MU_CHANGE
-  gArmTokenSpaceGuid.PcdMmBufferSize # MU_CHANGE
 
 [Depex]
   TRUE


### PR DESCRIPTION
## Description

This change is a preparation PR for the platform to switch to PEI less based SEC model.

Specifically, this removes the previous change where the logic will try to poke holes in the main system memory. Instead, we will move to PEI less SEC phase, because the current PEI core is incapable of handling the static carveouts gracefully.

Accordingly, the MM communication driver also needs to handle the case when the system already added the MM communication buffer to GCD.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU SBSA after switching over to PEI less SEC model.

## Integration Instructions

N/A
