### PR TITLE
[CHERRY-PICK] ArmPkg/Driver: use ArmFfaGetPartitionInfo() in Mmcommunication

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -441,13 +441,7 @@ InitializeFfaCommunication (
   )
 {
   EFI_STATUS              Status;
-  VOID                    *TxBuffer;
-  UINT64                  TxBufferSize;
-  VOID                    *RxBuffer;
-  UINT64                  RxBufferSize;
-  EFI_FFA_PART_INFO_DESC  *StmmPartInfo;
-  UINT32                  Count;
-  UINT32                  Size;
+  EFI_FFA_PART_INFO_DESC  StmmPartInfo;
 
   Status = ArmFfaLibPartitionIdGet (&mPartId);
   if (EFI_ERROR (Status)) {
@@ -459,62 +453,26 @@ InitializeFfaCommunication (
     return Status;
   }
 
-  Status = ArmFfaLibGetRxTxBuffers (
-             &TxBuffer,
-             &TxBufferSize,
-             &RxBuffer,
-             &RxBufferSize
-             );
+  Status = ArmFfaLibGetPartitionInfo (&gEfiMmCommunication2ProtocolGuid, &StmmPartInfo);
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "Failed to get Rx/Tx Buffer. Status: %r\n",
-      Status
-      ));
-    return Status;
-  }
-
-  Status = ArmFfaLibPartitionInfoGet (
-             &gEfiMmCommunication2ProtocolGuid,
-             FFA_PART_INFO_FLAG_TYPE_DESC,
-             &Count,
-             &Size
-             );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "Failed to get Stmm(%g) partition Info. Status: %r\n",
+      "Failed to get partition Info(%g). Status: %r\n",
       &gEfiMmCommunication2ProtocolGuid,
       Status
       ));
     return Status;
   }
 
-  if ((Count != 1) || (Size < sizeof (EFI_FFA_PART_INFO_DESC))) {
-    Status = EFI_INVALID_PARAMETER;
-    DEBUG ((
-      DEBUG_ERROR,
-      "Invalid partition Info(%g). Count: %d, Size: %d\n",
-      &gEfiMmCommunication2ProtocolGuid,
-      Count,
-      Size
-      ));
-    goto ErrorHandler;
-  }
-
-  StmmPartInfo = (EFI_FFA_PART_INFO_DESC *)RxBuffer;
-
-  if ((StmmPartInfo->PartitionProps & FFA_PART_PROP_RECV_DIRECT_REQ) == 0x00) {
+  if ((StmmPartInfo.PartitionProps & FFA_PART_PROP_RECV_DIRECT_REQ) == 0x00) {
     Status = EFI_UNSUPPORTED;
     DEBUG ((DEBUG_ERROR, "StandaloneMm doesn't receive DIRECT_MSG_REQ...\n"));
-    goto ErrorHandler;
+    return Status;
   }
 
-  mStMmPartId = StmmPartInfo->PartitionId;
+  mStMmPartId = StmmPartInfo.PartitionId;
 
-ErrorHandler:
-  ArmFfaLibRxRelease (mPartId);
-  return Status;
+  return EFI_SUCCESS;
 }
 
 /**

--- a/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
+++ b/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
@@ -141,13 +141,7 @@ InitializeFfaCommunication (
   )
 {
   EFI_STATUS              Status;
-  VOID                    *TxBuffer;
-  UINT64                  TxBufferSize;
-  VOID                    *RxBuffer;
-  UINT64                  RxBufferSize;
-  EFI_FFA_PART_INFO_DESC  *StmmPartInfo;
-  UINT32                  Count;
-  UINT32                  Size;
+  EFI_FFA_PART_INFO_DESC  StmmPartInfo;
 
   Status = ArmFfaLibPartitionIdGet (&mPartId);
   if (EFI_ERROR (Status)) {
@@ -159,58 +153,24 @@ InitializeFfaCommunication (
     return Status;
   }
 
-  Status = ArmFfaLibGetRxTxBuffers (
-             &TxBuffer,
-             &TxBufferSize,
-             &RxBuffer,
-             &RxBufferSize
-             );
+  Status = ArmFfaLibGetPartitionInfo (&gEfiMmCommunication2ProtocolGuid, &StmmPartInfo);
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "Failed to get Rx/Tx Buffer. Status: %r\n",
-      Status
-      ));
-    return Status;
-  }
-
-  Status = ArmFfaLibPartitionInfoGet (
-             &gEfiMmCommunication2ProtocolGuid,
-             FFA_PART_INFO_FLAG_TYPE_DESC,
-             &Count,
-             &Size
-             );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "Failed to get Stmm(%g) partition Info. Status: %r\n",
+      "Failed to get partition Info(%g). Status: %r\n",
       &gEfiMmCommunication2ProtocolGuid,
       Status
       ));
     return Status;
   }
 
-  if ((Count != 1) || (Size < sizeof (EFI_FFA_PART_INFO_DESC))) {
-    Status = EFI_INVALID_PARAMETER;
-    DEBUG ((
-      DEBUG_ERROR,
-      "Invalid partition Info(%g). Count: %d, Size: %d\n",
-      &gEfiMmCommunication2ProtocolGuid,
-      Count,
-      Size
-      ));
-    goto ErrorHandler;
-  }
-
-  StmmPartInfo = (EFI_FFA_PART_INFO_DESC *)RxBuffer;
-
-  if ((StmmPartInfo->PartitionProps & FFA_PART_PROP_RECV_DIRECT_REQ) == 0x00) {
+  if ((StmmPartInfo.PartitionProps & FFA_PART_PROP_RECV_DIRECT_REQ) == 0x00) {
     Status = EFI_UNSUPPORTED;
     DEBUG ((DEBUG_ERROR, "StandaloneMm doesn't receive DIRECT_MSG_REQ...\n"));
     goto ErrorHandler;
   }
 
-  mStMmPartId = StmmPartInfo->PartitionId;
+  mStMmPartId = StmmPartInfo.PartitionId;
 
 ErrorHandler:
   ArmFfaLibRxRelease (mPartId);


### PR DESCRIPTION
## Description

This patch adds ArmFfaLibPartitionInfoGetRegs() in ArmFfaLib
As ArmFfaLibPartitionInfoGetRegs() is added, Normal world ArmFfLib Rx/Tx buffer is not a madatory.
That's why return EFI_UNSUPPORTED while Rx/Tx buffer mapping in ArmFfaLib constructor
can be consider as valid return If ARM_FFA_PARTITION_INFO_GET_REGS is supported by SPMC.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is tested on physical ARM64 platform.

## Integration Instructions

Need to rely on the `MdeModulePkg` to have the corresponding interface change.
