### PR TITLE
[CHERRY-PICK] ArmPlatformPkg : Move RealTimeClockLib header

### DIFF
--- a/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.inf
+++ b/ArmPlatformPkg/Library/PL031RealTimeClockLib/PL031RealTimeClockLib.inf
@@ -22,6 +22,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   ArmPlatformPkg/ArmPlatformPkg.dec
 


### PR DESCRIPTION
## Description

RealTimeClockLib is an architectural implementation that is not restricted to the embedded segment or any platform in particular.

So the header has been moved to MdeModulePkg.
And the package has been added to the relevant INF files.

### Additional Notes:

This is backporting from EDK2 a change to move RealTimeClockLib from EmbeddedPkg to MdeModulePkg.

Upstream commit: https://github.com/tianocore/edk2/commit/57230fff6b39a665485be1bd43ec608d412ba6fb

Split up commits:
Dependency: https://github.com/microsoft/mu_basecore/pull/1612
https://github.com/microsoft/mu_tiano_plus/pull/490

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built Locally 

## Integration Instructions

Needs cross submodule updates - depends on https://github.com/microsoft/mu_basecore/pull/1612
And for ARM may depend on https://github.com/microsoft/mu_tiano_plus/pull/490

