### PR TITLE
ArmPlatformPkg: Add Tpm2Startup Library to PEI-less SEC Phase

### DIFF
--- a/ArmPlatformPkg/ArmPlatformPkg.ci.yaml
+++ b/ArmPlatformPkg/ArmPlatformPkg.ci.yaml
@@ -52,7 +52,8 @@
             "EmbeddedPkg/EmbeddedPkg.dec",
             "MdeModulePkg/MdeModulePkg.dec",
             "MdePkg/MdePkg.dec",
-            "StandaloneMmPkg/StandaloneMmPkg.dec"       # MU_CHANGE
+            "StandaloneMmPkg/StandaloneMmPkg.dec",       # MU_CHANGE
+            "SecurityPkg/SecurityPkg.dec"       # MU_CHANGE
         ],
         # For host based unit tests
         "AcceptableDependencies-HOST_APPLICATION":[

--- a/ArmPlatformPkg/ArmPlatformPkg.dsc
+++ b/ArmPlatformPkg/ArmPlatformPkg.dsc
@@ -89,7 +89,7 @@
   HobLib|EmbeddedPkg/Library/PrePiHobLib/PrePiHobLib.inf
   MemoryAllocationLib|EmbeddedPkg/Library/PrePiMemoryAllocationLib/PrePiMemoryAllocationLib.inf
   PrePiHobListPointerLib|ArmPlatformPkg/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
-  Tpm2StartupLib|SecurityPkg/Library/Tpm2StartupLibNull/Tpm2StartupLibNull.inf
+  Tpm2StartupLib|SecurityPkg/Library/Tpm2StartupLibNull/Tpm2StartupLibNull.inf  # MU_CHANGE
 
 #[LibraryClasses.AARCH64.MM_STANDALONE]   # MU_CHANGE
 [LibraryClasses.common.MM_STANDALONE]     # MU_CHANGE

--- a/ArmPlatformPkg/ArmPlatformPkg.dsc
+++ b/ArmPlatformPkg/ArmPlatformPkg.dsc
@@ -89,6 +89,7 @@
   HobLib|EmbeddedPkg/Library/PrePiHobLib/PrePiHobLib.inf
   MemoryAllocationLib|EmbeddedPkg/Library/PrePiMemoryAllocationLib/PrePiMemoryAllocationLib.inf
   PrePiHobListPointerLib|ArmPlatformPkg/Library/PrePiHobListPointerLib/PrePiHobListPointerLib.inf
+  Tpm2StartupLib|SecurityPkg/Library/Tpm2StartupLibNull/Tpm2StartupLibNull.inf
 
 #[LibraryClasses.AARCH64.MM_STANDALONE]   # MU_CHANGE
 [LibraryClasses.common.MM_STANDALONE]     # MU_CHANGE

--- a/ArmPlatformPkg/PeilessSec/PeilessSec.c
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.c
@@ -7,6 +7,7 @@
 **/
 
 #include "PeilessSec.h"
+#include <Library/Tpm2StartupLib.h>
 
 #define IS_XIP()  (((UINT64)FixedPcdGet64 (PcdFdBaseAddress) > mSystemMemoryEnd) ||\
                   ((FixedPcdGet64 (PcdFdBaseAddress) + FixedPcdGet32 (PcdFdSize)) <= FixedPcdGet64 (PcdSystemMemoryBase)))
@@ -186,6 +187,10 @@ SecMain (
 
   // Decompress firmware volumes and load the DXE Core
   DecompressFvs ();
+
+  // Initialize the TPM before loading the DXE core
+  Status = Tpm2StartupInit ();
+  ASSERT_EFI_ERROR (Status);
 
   // Load the DXE Core and transfer control to it
   Status = LoadDxeCoreFromFv (NULL, 0);

--- a/ArmPlatformPkg/PeilessSec/PeilessSec.c
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.c
@@ -7,7 +7,7 @@
 **/
 
 #include "PeilessSec.h"
-#include <Library/Tpm2StartupLib.h>
+#include <Library/Tpm2StartupLib.h> // MU_CHANGE
 
 #define IS_XIP()  (((UINT64)FixedPcdGet64 (PcdFdBaseAddress) > mSystemMemoryEnd) ||\
                   ((FixedPcdGet64 (PcdFdBaseAddress) + FixedPcdGet32 (PcdFdSize)) <= FixedPcdGet64 (PcdSystemMemoryBase)))
@@ -183,14 +183,16 @@ SecMain (
   // SEC phase needs to run library constructors by hand.
   ProcessLibraryConstructorList ();
 
+  // MU_CHANGE [BEGIN] - Add Tpm2StartupInit call
+  // Initialize the TPM before loading the DXE core
+  Status = Tpm2StartupInit ();
+  ASSERT_EFI_ERROR (Status);
+  // MU_CHANGE [END]
+
   // MU_CHANGE [BEGIN] - Remove DXE Core FV placement assumption
 
   // Decompress firmware volumes and load the DXE Core
   DecompressFvs ();
-
-  // Initialize the TPM before loading the DXE core
-  Status = Tpm2StartupInit ();
-  ASSERT_EFI_ERROR (Status);
 
   // Load the DXE Core and transfer control to it
   Status = LoadDxeCoreFromFv (NULL, 0);

--- a/ArmPlatformPkg/PeilessSec/PeilessSec.inf
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.inf
@@ -35,7 +35,7 @@
   EmbeddedPkg/EmbeddedPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
-  SecurityPkg/SecurityPkg.dec
+  SecurityPkg/SecurityPkg.dec # MU_CHANGE
 
 [LibraryClasses]
   ArmLib
@@ -54,7 +54,7 @@
   SerialPortLib
   TimerLib
   StackCheckLib
-  Tpm2StartupLib
+  Tpm2StartupLib # MU_CHANGE
 
 [Ppis]
   gArmMpCoreInfoPpiGuid

--- a/ArmPlatformPkg/PeilessSec/PeilessSec.inf
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.inf
@@ -35,6 +35,7 @@
   EmbeddedPkg/EmbeddedPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
 
 [LibraryClasses]
   ArmLib
@@ -53,6 +54,7 @@
   SerialPortLib
   TimerLib
   StackCheckLib
+  Tpm2StartupLib
 
 [Ppis]
   gArmMpCoreInfoPpiGuid


### PR DESCRIPTION
## Description

Add use of Tpm2StartupLib to PeilessSec which will init the TPM on our PEI-less platform, QEMU SBSA.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built QEMU SBSA with TPM enabled, verified TPM communication and boot to UEFI shell.

## Integration Instructions

N/A
