### PR TITLE
Update ArmSetMemoryAttributes to avoid setting invalid states during transitions

### DIFF
--- a/ArmPkg/Include/Library/ArmStandaloneMmMmuLib.h
+++ b/ArmPkg/Include/Library/ArmStandaloneMmMmuLib.h
@@ -12,34 +12,6 @@
 
 #include <Library/ArmLib.h>
 
-/**
-  Convert a region of memory to read-protected, by clearing the access flag.
-  @param  BaseAddress           The start of the region.
-  @param  Length                The size of the region.
-  @retval EFI_SUCCESS           The attributes were set successfully.
-  @retval EFI_OUT_OF_RESOURCES  The operation failed due to insufficient memory.
-**/
-EFI_STATUS
-EFIAPI
-ArmSetMemoryRegionNoAccess (
-  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN  UINT64                Length
-  );
-
-/**
-  Convert a region of memory to read-enabled, by setting the access flag.
-  @param  BaseAddress           The start of the region.
-  @param  Length                The size of the region.
-  @retval EFI_SUCCESS           The attributes were set successfully.
-  @retval EFI_OUT_OF_RESOURCES  The operation failed due to insufficient memory.
-**/
-EFI_STATUS
-EFIAPI
-ArmClearMemoryRegionNoAccess (
-  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN  UINT64                Length
-  );
-
 EFI_STATUS
 EFIAPI
 ArmSetMemoryRegionNoExec (

--- a/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
+++ b/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
@@ -506,7 +506,7 @@ ArmSetMemoryAttributes (
   DEBUG ((
     DEBUG_INFO,
     "%a: BaseAddress == 0x%llx, Length == 0x%llx, Attributes == 0x%llx, Mask == 0x%llx\n",
-    __FUNCTION__,
+    __func__,
     BaseAddress,
     Length,
     Attributes,
@@ -518,6 +518,14 @@ ArmSetMemoryAttributes (
   if ((Length == 0) ||
       ((NeededAttributes & ~(EFI_MEMORY_RO | EFI_MEMORY_RP | EFI_MEMORY_XP)) != 0))
   {
+    DEBUG ((DEBUG_ERROR, "%a: Length is 0 or unsupported attributes are set in Attributes.\n", __func__));
+    Status = EFI_INVALID_PARAMETER;
+    goto Done;
+  }
+
+  if ((BaseAddress % EFI_PAGE_SIZE != 0) || (Length % EFI_PAGE_SIZE != 0)) {
+    // Address and length must be aligned to page size.
+    DEBUG ((DEBUG_ERROR, "%a: Address or length is not aligned to page size.\n", __func__));
     Status = EFI_INVALID_PARAMETER;
     goto Done;
   }
@@ -561,7 +569,8 @@ ArmSetMemoryAttributes (
   while (Length > 0) {
     Status = GetMemoryPermissions (UseFfaAbis, BaseAddress, &MemoryAttributes);
     if (EFI_ERROR (Status)) {
-      break;
+      DEBUG ((DEBUG_ERROR, "%a: GetMemoryPermissions failed with Status == %r\n", __func__, Status));
+      goto Done;
     }
 
     if (Length < Size) {
@@ -576,7 +585,8 @@ ArmSetMemoryAttributes (
                  PermissionRequest
                  );
       if (EFI_ERROR (Status)) {
-        return Status;
+        DEBUG ((DEBUG_ERROR, "%a: RequestMemoryPermissionChange failed with Status == %r\n", __func__, Status));
+        goto Done;
       }
     }
 

--- a/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
+++ b/ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.c
@@ -244,84 +244,6 @@ RequestMemoryPermissionChange (
   return SendMemoryPermissionRequest (UseFfaAbis, &SvcArgs, &Ret);
 }
 
-// MU_CHANGE: Add ArmSetMemoryRegionNoAccess function
-EFI_STATUS
-ArmSetMemoryRegionNoAccess (
-  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN  UINT64                Length
-  )
-{
-  EFI_STATUS  Status;
-  UINT32      MemoryAttributes;
-  UINT32      PermissionRequest;
-  BOOLEAN     UseFfaAbis;
-
-  UseFfaAbis = IsFfaMemoryAbiSupported ();
-
-  Status = GetMemoryPermissions (UseFfaAbis, BaseAddress, &MemoryAttributes);
-  if (!EFI_ERROR (Status)) {
-    if (UseFfaAbis) {
-      PermissionRequest = ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST (
-                            MemoryAttributes,
-                            ARM_FFA_SET_MEM_ATTR_DATA_PERM_NO_ACCESS
-                            );
-    } else {
-      PermissionRequest = ARM_SPM_MM_SET_MEM_ATTR_MAKE_PERM_REQUEST (
-                            MemoryAttributes,
-                            ARM_SPM_MM_SET_MEM_ATTR_DATA_PERM_NO_ACCESS
-                            );
-    }
-
-    return RequestMemoryPermissionChange (
-             UseFfaAbis,
-             BaseAddress,
-             Length,
-             PermissionRequest
-             );
-  }
-
-  return Status;
-}
-
-// MU_CHANGE: Add ArmClearMemoryRegionNoAccess function
-EFI_STATUS
-ArmClearMemoryRegionNoAccess (
-  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN  UINT64                Length
-  )
-{
-  EFI_STATUS  Status;
-  UINT32      MemoryAttributes;
-  UINT32      PermissionRequest;
-  BOOLEAN     UseFfaAbis;
-
-  UseFfaAbis = IsFfaMemoryAbiSupported ();
-
-  Status = GetMemoryPermissions (UseFfaAbis, BaseAddress, &MemoryAttributes);
-  if (!EFI_ERROR (Status)) {
-    if (UseFfaAbis) {
-      PermissionRequest = ARM_FFA_SET_MEM_ATTR_MAKE_PERM_REQUEST (
-                            MemoryAttributes,
-                            ARM_FFA_SET_MEM_ATTR_DATA_PERM_RW
-                            );
-    } else {
-      PermissionRequest = ARM_SPM_MM_SET_MEM_ATTR_MAKE_PERM_REQUEST (
-                            MemoryAttributes,
-                            ARM_SPM_MM_SET_MEM_ATTR_DATA_PERM_RW
-                            );
-    }
-
-    return RequestMemoryPermissionChange (
-             UseFfaAbis,
-             BaseAddress,
-             Length,
-             PermissionRequest
-             );
-  }
-
-  return Status;
-}
-
 EFI_STATUS
 ArmSetMemoryRegionNoExec (
   IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
@@ -576,6 +498,10 @@ ArmSetMemoryAttributes (
   // MU_CHANGE [START] - Add ArmSetMemoryAttributes functionality
   EFI_STATUS  Status;
   UINT64      NeededAttributes;
+  BOOLEAN     UseFfaAbis;
+  UINT32      MemoryAttributes;
+  UINT32      PermissionRequest;
+  UINTN       Size;
 
   DEBUG ((
     DEBUG_INFO,
@@ -596,47 +522,67 @@ ArmSetMemoryAttributes (
     goto Done;
   }
 
-  if (AttributeMask & EFI_MEMORY_RP) {
+  UseFfaAbis = IsFfaMemoryAbiSupported ();
+
+  PermissionRequest = 0;
+
+  if (UseFfaAbis) {
     if ((NeededAttributes & EFI_MEMORY_RP) != 0) {
-      Status = ArmSetMemoryRegionNoAccess (BaseAddress, Length);
-      if (EFI_ERROR (Status)) {
-        goto Done;
-      }
+      PermissionRequest |= ARM_FFA_SET_MEM_ATTR_DATA_PERM_NO_ACCESS << ARM_FFA_SET_MEM_ATTR_DATA_PERM_SHIFT;
+    } else if ((NeededAttributes & EFI_MEMORY_RO) != 0) {
+      PermissionRequest |= ARM_FFA_SET_MEM_ATTR_DATA_PERM_RO << ARM_FFA_SET_MEM_ATTR_DATA_PERM_SHIFT;
     } else {
-      Status = ArmClearMemoryRegionNoAccess (BaseAddress, Length);
-      if (EFI_ERROR (Status)) {
-        goto Done;
-      }
+      PermissionRequest |= ARM_FFA_SET_MEM_ATTR_DATA_PERM_RW << ARM_FFA_SET_MEM_ATTR_DATA_PERM_SHIFT;
     }
-  }
 
-  if (AttributeMask & EFI_MEMORY_RO) {
-    if ((NeededAttributes & EFI_MEMORY_RO) != 0) {
-      Status = ArmSetMemoryRegionReadOnly (BaseAddress, Length);
-      if (EFI_ERROR (Status)) {
-        goto Done;
-      }
-    } else {
-      Status = ArmClearMemoryRegionReadOnly (BaseAddress, Length);
-      if (EFI_ERROR (Status)) {
-        goto Done;
-      }
-    }
-  }
-
-  if (AttributeMask & EFI_MEMORY_XP) {
     if ((NeededAttributes & EFI_MEMORY_XP) != 0) {
-      Status = ArmSetMemoryRegionNoExec (BaseAddress, Length);
-      if (EFI_ERROR (Status)) {
-        goto Done;
-      }
+      PermissionRequest |= ARM_FFA_SET_MEM_ATTR_CODE_PERM_XN << ARM_FFA_SET_MEM_ATTR_CODE_PERM_SHIFT;
     } else {
-      Status = ArmClearMemoryRegionNoExec (BaseAddress, Length);
-      if (EFI_ERROR (Status)) {
-        goto Done;
-      }
+      PermissionRequest |= ARM_FFA_SET_MEM_ATTR_CODE_PERM_X << ARM_FFA_SET_MEM_ATTR_CODE_PERM_SHIFT;
+    }
+  } else {
+    if ((NeededAttributes & EFI_MEMORY_RP) != 0) {
+      PermissionRequest |= ARM_SPM_MM_SET_MEM_ATTR_DATA_PERM_NO_ACCESS << ARM_SPM_MM_SET_MEM_ATTR_DATA_PERM_SHIFT;
+    } else if ((NeededAttributes & EFI_MEMORY_RO) != 0) {
+      PermissionRequest |= ARM_SPM_MM_SET_MEM_ATTR_DATA_PERM_RO << ARM_SPM_MM_SET_MEM_ATTR_DATA_PERM_SHIFT;
+    } else {
+      PermissionRequest |= ARM_SPM_MM_SET_MEM_ATTR_DATA_PERM_RW << ARM_SPM_MM_SET_MEM_ATTR_DATA_PERM_SHIFT;
+    }
+
+    if ((NeededAttributes & EFI_MEMORY_XP) != 0) {
+      PermissionRequest |= ARM_SPM_MM_SET_MEM_ATTR_CODE_PERM_XN << ARM_SPM_MM_SET_MEM_ATTR_CODE_PERM_SHIFT;
+    } else {
+      PermissionRequest |= ARM_SPM_MM_SET_MEM_ATTR_CODE_PERM_X << ARM_SPM_MM_SET_MEM_ATTR_CODE_PERM_SHIFT;
     }
   }
+
+  Size = EFI_PAGE_SIZE;
+
+  while (Length > 0) {
+    Status = GetMemoryPermissions (UseFfaAbis, BaseAddress, &MemoryAttributes);
+    if (EFI_ERROR (Status)) {
+      break;
+    }
+
+    if (Length < Size) {
+      Length = Size;
+    }
+
+    if (MemoryAttributes != PermissionRequest) {
+      Status = RequestMemoryPermissionChange (
+                 UseFfaAbis,
+                 BaseAddress,
+                 Size,
+                 PermissionRequest
+                 );
+      if (EFI_ERROR (Status)) {
+        return Status;
+      }
+    }
+
+    Length      -= Size;
+    BaseAddress += Size;
+  }   // while
 
 Done:
   return Status;


### PR DESCRIPTION
## Description

The current `ArmSetMemoryAttributes` would cycle through the input memory attributes bit by bit and could lead the memory in an invalid transient state during transitions. i.e. setting the memory to be code type (read only and executable), if the RP flag is set, it will make the memory region as data region first and then enable the executable bit, which could cause page fault on the next instruction.

This again resolves https://github.com/microsoft/mu_silicon_arm_tiano/issues/454, more properly.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on both QEMU SBSA platform and physical hardware platform.

## Integration Instructions

N/A
