### PR TITLE
[2502] [REBASE & FF] Port CLANGPDB AARCH64 to 2502

### DIFF
--- a/ArmPkg/Drivers/ArmPsciMpServicesDxe/MpFuncs.S
+++ b/ArmPkg/Drivers/ArmPsciMpServicesDxe/MpFuncs.S
@@ -30,11 +30,11 @@ GCC_ASM_EXPORT (ApEntryPoint)
 //   );
 ASM_PFX(ApEntryPoint):
   // Configure the MMU and caches
-  ldr x0, gTcr
+  LDR_LIT(x0, gTcr)
   bl ArmSetTCR
-  ldr x0, gTtbr0
+  LDR_LIT(x0, gTtbr0)
   bl ArmSetTTBR0
-  ldr x0, gMair
+  LDR_LIT(x0, gMair)
   bl ArmSetMAIR
   bl ArmDisableAlignmentCheck
   bl ArmEnableStackAlignmentCheck
@@ -46,7 +46,7 @@ ASM_PFX(ApEntryPoint):
   // Mask the non-affinity bits
   bic x0, x0, 0x00ff000000
   and x0, x0, 0xffffffffff
-  ldr x1, gProcessorIDs
+  LDR_LIT(x1, gProcessorIDs)
   mov x2, 0                   // x2 = processor index
 
 // Find index in gProcessorIDs for current processor
@@ -60,8 +60,8 @@ ASM_PFX(ApEntryPoint):
 
 // Calculate stack address
   // x2 contains the index for the current processor plus 1
-  ldr x0, gApStacksBase
-  ldr x1, gApStackSize
+  LDR_LIT(x0, gApStacksBase)
+  LDR_LIT(x1, gApStackSize)
   mul x3, x2, x1              // x3 = (ProcessorIndex + 1) * gApStackSize
   add sp, x0, x3              // sp = gApStacksBase + x3
   mov x29, xzr

--- a/ArmPkg/Library/ArmExceptionLib/AArch64/ExceptionSupport.S
+++ b/ArmPkg/Library/ArmExceptionLib/AArch64/ExceptionSupport.S
@@ -108,8 +108,6 @@ GCC_ASM_EXPORT(CommonCExceptionHandler)
 // exception vector initialization method is used.
 //
 
-VECTOR_BASE(ExceptionHandlersStart)
-
   .macro  ExceptionEntry, val, sp=SPx
   //
   // Our backtrace and register dump code is written in C and so it requires
@@ -165,83 +163,76 @@ VECTOR_BASE(ExceptionHandlersStart)
   b         ASM_PFX(CommonExceptionEntry)
   .endm
 
-//
-// Current EL with SP0 : 0x0 - 0x180
-//
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SP0_SYNC)
-ASM_PFX(SynchronousExceptionSP0):
-  ExceptionEntry  EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
+#define EXCEPTION_VECTOR                                                  \
+/* Current EL with SP0 : 0x0 - 0x180 */                                   \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SP0_SYNC)             \
+ASM_PFX(SynchronousExceptionSP0):                                         \
+  ExceptionEntry  EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS                  ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SP0_IRQ)              \
+ASM_PFX(IrqSP0):                                                          \
+  ExceptionEntry  EXCEPT_AARCH64_IRQ                                     ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SP0_FIQ)              \
+ASM_PFX(FiqSP0):                                                          \
+  ExceptionEntry  EXCEPT_AARCH64_FIQ                                     ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SP0_SERR)             \
+ASM_PFX(SErrorSP0):                                                       \
+  ExceptionEntry  EXCEPT_AARCH64_SERROR                                  ;\
+                                                                          \
+/* Current EL with SPx: 0x200 - 0x380 */                                  \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SPX_SYNC)             \
+ASM_PFX(SynchronousExceptionSPx):                                         \
+  ExceptionEntry  EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS, SP0             ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SPX_IRQ)              \
+ASM_PFX(IrqSPx):                                                          \
+  ExceptionEntry  EXCEPT_AARCH64_IRQ                                     ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SPX_FIQ)              \
+ASM_PFX(FiqSPx):                                                          \
+  ExceptionEntry  EXCEPT_AARCH64_FIQ                                     ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SPX_SERR)             \
+ASM_PFX(SErrorSPx):                                                       \
+  ExceptionEntry  EXCEPT_AARCH64_SERROR                                  ;\
+                                                                          \
+/* Lower EL using AArch64 : 0x400 - 0x580 */                              \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A64_SYNC)             \
+ASM_PFX(SynchronousExceptionA64):                                         \
+  ExceptionEntry  EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS                  ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A64_IRQ)              \
+ASM_PFX(IrqA64):                                                          \
+  ExceptionEntry  EXCEPT_AARCH64_IRQ                                     ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A64_FIQ)              \
+ASM_PFX(FiqA64):                                                          \
+  ExceptionEntry  EXCEPT_AARCH64_FIQ                                     ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A64_SERR)             \
+ASM_PFX(SErrorA64):                                                       \
+  ExceptionEntry  EXCEPT_AARCH64_SERROR                                  ;\
+                                                                          \
+/* Lower EL using AArch32 : 0x600 - 0x780 */                              \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A32_SYNC)             \
+ASM_PFX(SynchronousExceptionA32):                                         \
+  ExceptionEntry  EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS                  ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A32_IRQ)              \
+ASM_PFX(IrqA32):                                                          \
+  ExceptionEntry  EXCEPT_AARCH64_IRQ                                     ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A32_FIQ)              \
+ASM_PFX(FiqA32):                                                          \
+  ExceptionEntry  EXCEPT_AARCH64_FIQ                                     ;\
+                                                                          \
+VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A32_SERR)             \
+ASM_PFX(SErrorA32):                                                       \
+  ExceptionEntry  EXCEPT_AARCH64_SERROR                                  ;\
 
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SP0_IRQ)
-ASM_PFX(IrqSP0):
-  ExceptionEntry  EXCEPT_AARCH64_IRQ
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SP0_FIQ)
-ASM_PFX(FiqSP0):
-  ExceptionEntry  EXCEPT_AARCH64_FIQ
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SP0_SERR)
-ASM_PFX(SErrorSP0):
-  ExceptionEntry  EXCEPT_AARCH64_SERROR
-
-//
-// Current EL with SPx: 0x200 - 0x380
-//
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SPX_SYNC)
-ASM_PFX(SynchronousExceptionSPx):
-  ExceptionEntry  EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS, SP0
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SPX_IRQ)
-ASM_PFX(IrqSPx):
-  ExceptionEntry  EXCEPT_AARCH64_IRQ
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SPX_FIQ)
-ASM_PFX(FiqSPx):
-  ExceptionEntry  EXCEPT_AARCH64_FIQ
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_CUR_SPX_SERR)
-ASM_PFX(SErrorSPx):
-  ExceptionEntry  EXCEPT_AARCH64_SERROR
-
-//
-// Lower EL using AArch64 : 0x400 - 0x580
-//
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A64_SYNC)
-ASM_PFX(SynchronousExceptionA64):
-  ExceptionEntry  EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A64_IRQ)
-ASM_PFX(IrqA64):
-  ExceptionEntry  EXCEPT_AARCH64_IRQ
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A64_FIQ)
-ASM_PFX(FiqA64):
-  ExceptionEntry  EXCEPT_AARCH64_FIQ
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A64_SERR)
-ASM_PFX(SErrorA64):
-  ExceptionEntry  EXCEPT_AARCH64_SERROR
-
-//
-// Lower EL using AArch32 : 0x600 - 0x780
-//
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A32_SYNC)
-ASM_PFX(SynchronousExceptionA32):
-  ExceptionEntry  EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A32_IRQ)
-ASM_PFX(IrqA32):
-  ExceptionEntry  EXCEPT_AARCH64_IRQ
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A32_FIQ)
-ASM_PFX(FiqA32):
-  ExceptionEntry  EXCEPT_AARCH64_FIQ
-
-VECTOR_ENTRY(ExceptionHandlersStart, ARM_VECTOR_LOW_A32_SERR)
-ASM_PFX(SErrorA32):
-  ExceptionEntry  EXCEPT_AARCH64_SERROR
-
-VECTOR_END(ExceptionHandlersStart)
+VECTOR_TABLE(ExceptionHandlersStart, EXCEPTION_VECTOR)
 
 ASM_PFX(CommonExceptionEntry):
 

--- a/ArmPkg/Library/ArmExceptionLib/AArch64/ExceptionSupport.S
+++ b/ArmPkg/Library/ArmExceptionLib/AArch64/ExceptionSupport.S
@@ -92,7 +92,6 @@
   UINT64  Padding;0x328   // Required for stack alignment
 */
 
-GCC_ASM_EXPORT(ExceptionHandlersEnd)
 GCC_ASM_EXPORT(CommonCExceptionHandler)
 
 .text
@@ -243,9 +242,6 @@ ASM_PFX(SErrorA32):
   ExceptionEntry  EXCEPT_AARCH64_SERROR
 
 VECTOR_END(ExceptionHandlersStart)
-
-ASM_PFX(ExceptionHandlersEnd):
-
 
 ASM_PFX(CommonExceptionEntry):
 

--- a/ArmPkg/Library/ArmExceptionLib/ArmExceptionLib.c
+++ b/ArmPkg/Library/ArmExceptionLib/ArmExceptionLib.c
@@ -26,11 +26,6 @@ ExceptionHandlersStart (
   VOID
   );
 
-VOID
-ExceptionHandlersEnd (
-  VOID
-  );
-
 RETURN_STATUS
 ArchVectorConfig (
   IN  UINTN  VectorBaseAddress

--- a/ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
+++ b/ArmPkg/Library/ArmMmuLib/ArmMmuBaseLib.inf
@@ -48,5 +48,8 @@
 [Guids]
   gArmMmuReplaceLiveTranslationEntryFuncGuid
 
+[Protocols]
+  gArmPageTableMemoryAllocationProtocolGuid
+
 [Pcd.ARM]
   gArmTokenSpaceGuid.PcdNormalMemoryNonshareableOverride

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
@@ -66,12 +66,10 @@
 [Pcd]
   gArmTokenSpaceGuid.PcdStMmStackSize
 
-#
-# This configuration fails for CLANGPDB, which does not support PIE in the GCC
-# sense. Such however is required for ARM family StandaloneMmCore
-# self-relocation, and thus the CLANGPDB toolchain is unsupported for ARM and
-# AARCH64 for this module.
-#
+# Standalone MM Core can be used as an OP-TEE trusted application and needs to do runtime
+# relocation in that scenario. It needs to be built as a position independent executable (PIE)
+# for this use case. However, PE targets do not support PIE, so only ELF targets
+# are built with these flags and support this scenario.
 [BuildOptions]
-  GCC:*_*_ARM_CC_FLAGS = -fpie
-  GCC:*_*_AARCH64_CC_FLAGS = -fpie
+  GCC:*_GCC_AARCH64_CC_FLAGS = -fpie
+  CLANGDWARF:*_CLANGDWARF_AARCH64_CC_FLAGS = -fpie

--- a/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
+++ b/ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
@@ -25,3 +25,5 @@
 
 [LibraryClasses]
   BaseLib
+  DebugLib
+  HobLib

--- a/ArmPlatformPkg/PeilessSec/AArch64/ModuleEntryPoint.S
+++ b/ArmPlatformPkg/PeilessSec/AArch64/ModuleEntryPoint.S
@@ -16,7 +16,7 @@ _SetSVCMode:
 // to install the stacks at the bottom of the Firmware Device (case the FD is located
 // at the top of the DRAM)
 _SystemMemoryEndInit:
-  ldr   x1, mSystemMemoryEnd
+  LDR_LIT(x1, mSystemMemoryEnd)
 
 _SetupStackPosition:
   // r1 = SystemMemoryTop

--- a/ArmPlatformPkg/Sec/AArch64/Exception.S
+++ b/ArmPlatformPkg/Sec/AArch64/Exception.S
@@ -24,93 +24,92 @@
 3: bl   ASM_PFX(PeiCommonExceptionEntry)                       ;
 
 
+#define EXCEPTION_VECTOR                                        \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SP0_SYNC)           \
+_DefaultSyncExceptHandler_t:                                    \
+  mov  x0, #EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS              ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SP0_IRQ)            \
+_DefaultIrq_t:                                                  \
+  mov  x0, #EXCEPT_AARCH64_IRQ                                 ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SP0_FIQ)            \
+_DefaultFiq_t:                                                  \
+  mov  x0, #EXCEPT_AARCH64_FIQ                                 ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SP0_SERR)           \
+_DefaultSError_t:                                               \
+  mov  x0, #EXCEPT_AARCH64_SERROR                              ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SPX_SYNC)           \
+_DefaultSyncExceptHandler_h:                                    \
+  mov  x0, #EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS              ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SPX_IRQ)            \
+_DefaultIrq_h:                                                  \
+  mov  x0, #EXCEPT_AARCH64_IRQ                                 ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SPX_FIQ)            \
+_DefaultFiq_h:                                                  \
+  mov  x0, #EXCEPT_AARCH64_FIQ                                 ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SPX_SERR)           \
+_DefaultSError_h:                                               \
+  mov  x0, #EXCEPT_AARCH64_SERROR                              ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A64_SYNC)           \
+_DefaultSyncExceptHandler_LowerA64:                             \
+  mov  x0, #EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS              ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A64_IRQ)            \
+_DefaultIrq_LowerA64:                                           \
+  mov  x0, #EXCEPT_AARCH64_IRQ                                 ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A64_FIQ)            \
+_DefaultFiq_LowerA64:                                           \
+  mov  x0, #EXCEPT_AARCH64_FIQ                                 ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A64_SERR)           \
+_DefaultSError_LowerA64:                                        \
+  mov  x0, #EXCEPT_AARCH64_SERROR                              ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A32_SYNC)           \
+_DefaultSyncExceptHandler_LowerA32:                             \
+  mov  x0, #EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS              ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A32_IRQ)            \
+_DefaultIrq_LowerA32:                                           \
+  mov  x0, #EXCEPT_AARCH64_IRQ                                 ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A32_FIQ)            \
+_DefaultFiq_LowerA32:                                           \
+  mov  x0, #EXCEPT_AARCH64_FIQ                                 ;\
+  TO_HANDLER                                                   ;\
+                                                                \
+VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A32_SERR)           \
+_DefaultSError_LowerA32:                                        \
+  mov  x0, #EXCEPT_AARCH64_SERROR                              ;\
+  TO_HANDLER                                                   ;
+
 //
 // Default Exception handlers: There is no plan to return from any of these exceptions.
 // No context saving at all.
 //
 
-VECTOR_BASE(PeiVectorTable)
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SP0_SYNC)
-_DefaultSyncExceptHandler_t:
-  mov  x0, #EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SP0_IRQ)
-_DefaultIrq_t:
-  mov  x0, #EXCEPT_AARCH64_IRQ
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SP0_FIQ)
-_DefaultFiq_t:
-  mov  x0, #EXCEPT_AARCH64_FIQ
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SP0_SERR)
-_DefaultSError_t:
-  mov  x0, #EXCEPT_AARCH64_SERROR
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SPX_SYNC)
-_DefaultSyncExceptHandler_h:
-  mov  x0, #EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SPX_IRQ)
-_DefaultIrq_h:
-  mov  x0, #EXCEPT_AARCH64_IRQ
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SPX_FIQ)
-_DefaultFiq_h:
-  mov  x0, #EXCEPT_AARCH64_FIQ
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_CUR_SPX_SERR)
-_DefaultSError_h:
-  mov  x0, #EXCEPT_AARCH64_SERROR
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A64_SYNC)
-_DefaultSyncExceptHandler_LowerA64:
-  mov  x0, #EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A64_IRQ)
-_DefaultIrq_LowerA64:
-  mov  x0, #EXCEPT_AARCH64_IRQ
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A64_FIQ)
-_DefaultFiq_LowerA64:
-  mov  x0, #EXCEPT_AARCH64_FIQ
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A64_SERR)
-_DefaultSError_LowerA64:
-  mov  x0, #EXCEPT_AARCH64_SERROR
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A32_SYNC)
-_DefaultSyncExceptHandler_LowerA32:
-  mov  x0, #EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A32_IRQ)
-_DefaultIrq_LowerA32:
-  mov  x0, #EXCEPT_AARCH64_IRQ
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A32_FIQ)
-_DefaultFiq_LowerA32:
-  mov  x0, #EXCEPT_AARCH64_FIQ
-  TO_HANDLER
-
-VECTOR_ENTRY(PeiVectorTable, ARM_VECTOR_LOW_A32_SERR)
-_DefaultSError_LowerA32:
-  mov  x0, #EXCEPT_AARCH64_SERROR
-  TO_HANDLER
-
-VECTOR_END(PeiVectorTable)
+VECTOR_TABLE(PeiVectorTable, EXCEPTION_VECTOR)
 
 AARCH64_BTI_NOTE()


### PR DESCRIPTION
## Description

In order to facilitate platforms migrating from MSVC AARCH64 to CLANGPDB AARCH64, add the requisite support to 2502.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.