### PR TITLE
ArmPlatformPkg: Update TpmStartupLib Status Checking in PeilessSec

### DIFF
--- a/ArmPlatformPkg/PeilessSec/PeilessSec.c
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.c
@@ -186,6 +186,7 @@ SecMain (
   // MU_CHANGE [BEGIN] - Add Tpm2StartupInit call
   // Initialize the TPM before loading the DXE core
   Status = Tpm2StartupInit ();
+
   /* NOTE: EFI_UNSUPPORTED is treated as a success due to the possibility of there
    *       not being a TPM on the system and if so, the NULL instance of the startup
    *       lib should be linked in which returns UNSUPPORTED. Also, even if TPM is
@@ -195,6 +196,7 @@ SecMain (
     DEBUG ((DEBUG_ERROR, "Failed to initialize the TPM\n"));
     ASSERT_EFI_ERROR (Status);
   }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN] - Remove DXE Core FV placement assumption

--- a/ArmPlatformPkg/PeilessSec/PeilessSec.c
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.c
@@ -186,7 +186,15 @@ SecMain (
   // MU_CHANGE [BEGIN] - Add Tpm2StartupInit call
   // Initialize the TPM before loading the DXE core
   Status = Tpm2StartupInit ();
-  ASSERT_EFI_ERROR (Status);
+  /* NOTE: EFI_UNSUPPORTED is treated as a success due to the possibility of there
+   *       not being a TPM on the system and if so, the NULL instance of the startup
+   *       lib should be linked in which returns UNSUPPORTED. Also, even if TPM is
+   *       enabled, Tpm2StartupInit could return UNSUPPORTED depending on the TPM
+   *       instance. */
+  if ((Status != EFI_SUCCESS) && (Status != EFI_UNSUPPORTED)) {
+    DEBUG ((DEBUG_ERROR, "Failed to initialize the TPM\n"));
+    ASSERT_EFI_ERROR (Status);
+  }
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN] - Remove DXE Core FV placement assumption


### PR DESCRIPTION
## Description

Added a check around the return status of TpmStartupInit, we don't want to assert on EFI_UNSUPPORTED. When TPM is disabled, the NULL instance of the TpmStartupLib is included which returns UNSUPPORTED.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built QemuSbsa with TPM disabled. Verified no assert occurs. 

## Integration Instructions

N/A
